### PR TITLE
Guild User Approval System

### DIFF
--- a/XeniaBot.Shared/Helpers/ExceptionHelper.cs
+++ b/XeniaBot.Shared/Helpers/ExceptionHelper.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+
+namespace XeniaBot.Shared.Helpers;
+
+public static class ExceptionHelper
+{
+    public static async Task RetryOnTimedOut(Func<Task> callback, int count = 3)
+    {
+        for (int i = 0; i <= count; i++)
+        {
+            try
+            {
+                await callback();
+                return;
+            }
+            catch (Exception ex)
+            {
+                var exStr = ex.ToString();
+                if (!exStr.Contains("timed out", StringComparison.OrdinalIgnoreCase) || i >= 3)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/XeniaBot.Shared/Services/ErrorReportBuilder.cs
+++ b/XeniaBot.Shared/Services/ErrorReportBuilder.cs
@@ -21,6 +21,7 @@ public class ErrorReportBuilder
     private IChannel? _channel = null;
     private IUser? _user = null;
     private IMessage? _message = null;
+    private IRole? _role = null;
 
     private ICommandContext? _commandContext = null;
     private IInteractionContext? _interactionContext = null;
@@ -148,6 +149,14 @@ public class ErrorReportBuilder
             extra["message.channel.id"] = _message.Channel.Id.ToString();
             extra["message.channel.name"] = string.IsNullOrEmpty(_message.Channel.Name) ? string.Empty : _message.Channel.Name;
         }
+        if (_role != null)
+        {
+            extra["role.id"] = _role.Id.ToString();
+            extra["role.name"] = _role.Name;
+            extra["role.is_managed"] = _role.IsManaged.ToString();
+            extra["role.guild.id"] = _role.Guild.Id.ToString();
+            extra["role.guild.name"] = _role.Guild.Name;
+        }
         if (_commandContext != null)
         {
             extra["commandContext"] = ErrorReportService.SerializeJsonSafe(_commandContext) ?? "";
@@ -220,12 +229,17 @@ public class ErrorReportBuilder
         _message = message;
         return this;
     }
-    public ErrorReportBuilder WithContext(ICommandContext commandContext)
+    public ErrorReportBuilder WithRole(IRole? role)
+    {
+        _role = role;
+        return this;
+    }
+    public ErrorReportBuilder WithContext(ICommandContext? commandContext)
     {
         _commandContext = commandContext;
         return this;
     }
-    public ErrorReportBuilder WithContext(IInteractionContext interactionContext)
+    public ErrorReportBuilder WithContext(IInteractionContext? interactionContext)
     {
         _interactionContext = interactionContext;
         return this;

--- a/XeniaBot.Shared/_Reflection/InteractionHandler.cs
+++ b/XeniaBot.Shared/_Reflection/InteractionHandler.cs
@@ -6,6 +6,7 @@ using NLog;
 using Sentry;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
@@ -114,6 +115,29 @@ public class InteractionHandler
         }
         Log.Debug($"Loaded [{_interactionService.Modules.Count}] modules\n" + string.Join("\n", lines));
         _client.InteractionCreated += InteractionCreateAsync;
+        _client.ModalSubmitted += ModalSubmittedAsync;
+    }
+
+    private async Task ModalSubmittedAsync(SocketModal interaction)
+    {
+        try
+        {
+            var context = new SocketInteractionContext(
+                _client,
+                interaction);
+            var result = await _interactionService.ExecuteCommandAsync(
+                context,
+                _services);
+            // Debugger.Break();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed to handle interation {interaction.Id} invoked by user \"{interaction.User.GlobalName}\" ({interaction.User.Username}, {interaction.User.Id})");
+            SentrySdk.CaptureException(ex, scope =>
+            {
+                SentryHelper.SetInteractionInfo(scope, interaction);
+            });
+        }
     }
 
     private async Task InteractionCreateAsync(SocketInteraction interaction)

--- a/XeniaDiscord.Common/Services/GuildApprovalService.Approve.cs
+++ b/XeniaDiscord.Common/Services/GuildApprovalService.Approve.cs
@@ -1,0 +1,158 @@
+using Discord;
+using Microsoft.EntityFrameworkCore;
+using XeniaBot.Shared.Helpers;
+using XeniaDiscord.Data.Models.GuildApproval;
+
+namespace XeniaDiscord.Common.Services;
+
+partial class GuildApprovalService
+{
+    public async Task<ApproveUserResult> ApproveUser(
+        IGuildUser user,
+        IUser doneByUser)
+    {
+        var guildIdStr = user.Guild.Id.ToString();
+        var config = await _db.GuildApprovals.AsNoTracking().FirstOrDefaultAsync(e => e.GuildId == guildIdStr);
+
+        if (config == null)
+        {
+            return new ApproveUserResult(ApproveUserResultKind.NotConfigured, user, doneByUser, null, null);
+        }
+        if (!config.Enabled)
+        {
+            return new ApproveUserResult(ApproveUserResultKind.NotEnabled, user, doneByUser, null, null);
+        }
+
+        var roleId = config.GetApprovedRoleId();
+        if (!roleId.HasValue)
+        {
+            return new ApproveUserResult(ApproveUserResultKind.ApprovedRoleNotConfigured, user, doneByUser, null, null);
+        }
+        var role = await user.Guild.GetRoleAsync(roleId.Value);
+        if (role == null)
+        {
+            return new ApproveUserResult(ApproveUserResultKind.ApprovedRoleMissing, user, doneByUser, roleId.Value, null);
+        }
+
+        var targetFormatted = user.Username + (string.IsNullOrEmpty(user.Discriminator.Trim('0')?.Trim()) ? "" : $"#{user.Discriminator}");
+        var invokerFormatted = doneByUser.Username + (string.IsNullOrEmpty(doneByUser.Discriminator.Trim('0')?.Trim()) ? "" : $"#{doneByUser.Discriminator}");
+        if (user.RoleIds.Contains(role.Id))
+        {
+            return new ApproveUserResult(ApproveUserResultKind.UserAlreadyApproved, user, doneByUser, roleId.Value, role);
+        }
+        else
+        {
+            await ExceptionHelper.RetryOnTimedOut(async () =>
+            {
+                await user.AddRoleAsync(role);
+            });
+            await using var db = _db.CreateSession();
+            await using var trans = await db.Database.BeginTransactionAsync();
+            try
+            {
+                await db.GuildApprovalLogEvents.AddAsync(new GuildApprovalLogEventModel
+                {
+                    GuildId = guildIdStr,
+                    UserId = user.Id.ToString(),
+                    ApprovedByUserId = doneByUser.Id.ToString()
+                });
+                await db.SaveChangesAsync();
+                await trans.CommitAsync();
+            }
+            catch
+            {
+                await trans.RollbackAsync();
+                throw;
+            }
+        }
+        try
+        {
+            await SendGreeterMessage(user.Guild, user);
+        }
+        catch (Exception ex)
+        {
+            _log.Warn(ex, $"Failed to send greeter message for user \"{targetFormatted}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})");
+        }
+        try
+        {
+            await SendLogEvent(user.Guild, new EmbedBuilder()
+                .WithTitle("Approval - Approved User")
+                .WithDescription($"{user.Mention} ({targetFormatted}, {user.Id})")
+                .AddField("Approved By", $"{doneByUser.Mention} ({invokerFormatted}, {doneByUser.Id})")
+                .WithColor(Color.Blue)
+                .WithCurrentTimestamp());
+        }
+        catch (Exception ex)
+        {
+            _log.Warn(ex, $"Failed to send log message for guild \"{user.Guild.Name}\" ({user.Guild.Id}) about {invokerFormatted} ({doneByUser.Id}) approving user {targetFormatted} ({user.Id})");
+        }
+        return new ApproveUserResult(ApproveUserResultKind.Success, user, doneByUser, roleId.Value, role);
+    }
+
+    public class ApproveUserResult
+    {
+        public ApproveUserResult(
+            ApproveUserResultKind kind,
+            IGuildUser user,
+            IUser invokedByUser,
+            ulong? approvedRoleId,
+            IRole? approvedRole)
+        {
+            Kind = kind;
+            User = user;
+            InvokedByUser = invokedByUser;
+            ApprovedRoleId = approvedRoleId;
+            ApprovedRole = approvedRole;
+        }
+
+        public ApproveUserResultKind Kind { get; }
+        public IGuildUser User { get; }
+        public IUser InvokedByUser { get; }
+        public ulong? ApprovedRoleId { get; }
+        public IRole? ApprovedRole { get; }
+
+        public bool IsSuccess
+            => Kind == ApproveUserResultKind.Success
+            || Kind == ApproveUserResultKind.UserAlreadyApproved;
+
+        public string FormatForEmbed()
+        {
+            var targetFormatted = User.Username + (string.IsNullOrEmpty(User.Discriminator.Trim('0')?.Trim()) ? "" : $"#{User.Discriminator}");
+            var invokerFormatted = InvokedByUser.Username + (string.IsNullOrEmpty(InvokedByUser.Discriminator.Trim('0')?.Trim()) ? "" : $"#{InvokedByUser.Discriminator}");
+            switch (Kind)
+            {
+                case ApproveUserResultKind.Success:
+                    return "Successfully approved user.";
+                case ApproveUserResultKind.UserAlreadyApproved:
+                    return "User has already been approved!\n"
+                        + $"-# user: `{targetFormatted}` ({User.Id})"
+                        + (ApprovedRole != null ? $"\n-# role: {ApprovedRole.Mention}" : string.Empty);
+                case ApproveUserResultKind.NotConfigured:
+                    return "Approval system has not been configured.";
+                case ApproveUserResultKind.NotEnabled:
+                    return "Approval system is not enabled.";
+                case ApproveUserResultKind.ApprovedRoleMissing:
+                    return "Could not find \"Approved Role\". It might need re-configuring with `/approval-admin set-approved-role`";
+                case ApproveUserResultKind.ApprovedRoleNotConfigured:
+                    return "\"Approved Role\" has not been configured.\nThis can be done with `/approval-admin set-approved-role`";
+                case ApproveUserResultKind.FailedToGiveRole:
+                    if (ApprovedRole != null)
+                        return $"Failed to give role {ApprovedRole.Mention} to user {User.Mention} ({User.Username})";
+                    return $"Failed to give \"Approved\" role to user {User.Mention} ({User.Username})";
+                default:
+                    return Kind.ToString();
+            }
+        }
+    }
+
+    public enum ApproveUserResultKind
+    {
+        Success,
+        UserAlreadyApproved,
+        NotConfigured,
+        NotEnabled,
+        ApprovedRoleMissing,
+        ApprovedRoleNotConfigured,
+        FailedToGiveRole,
+    }
+}

--- a/XeniaDiscord.Common/Services/GuildApprovalService.Embed.cs
+++ b/XeniaDiscord.Common/Services/GuildApprovalService.Embed.cs
@@ -1,0 +1,94 @@
+using Discord;
+using XeniaBot.Shared.Services;
+
+namespace XeniaDiscord.Common.Services;
+
+partial class GuildApprovalService
+{
+    public async Task<EmbedBuilder> SetApprovedRoleEmbed(
+        IGuild guild,
+        IRole role,
+        IInteractionContext? context = null)
+    {
+        var embed = new EmbedBuilder()
+            .WithTitle("Approval - Set Role")
+            .WithColor(Color.Blue);
+        try
+        {
+            var result = await SetApprovedRole(guild, role, context?.User);
+            
+            embed.Color = result.IsSuccess ? Color.Green : Color.Red;
+            embed.WithDescription(result.FormatForEmbed());
+            return embed;
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithContext(context)
+                .WithGuild(guild));
+            return embed
+                .WithDescription(string.Join("\n", $"Failed to set \"approved\" role to: {role.Mention}", $"`{errorType}`"))
+                .WithColor(Color.Red);
+        }
+    }
+
+    public async Task<EmbedBuilder> SetGreeterChannelEmbed(
+        IGuild guild,
+        ITextChannel channel,
+        IInteractionContext? context = null)
+    {
+        var embed = new EmbedBuilder()
+            .WithTitle("Approval - Set Greeter channel")
+            .WithColor(Color.Blue);
+        try
+        {
+            var result = await SetGreeterChannel(guild, channel, context?.User);
+            
+            embed.Color = result.IsSuccess ? Color.Green : Color.Red;
+            embed.WithDescription(result.FormatForEmbed());
+            return embed;
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithContext(context)
+                .WithGuild(guild));
+            return embed
+                .WithDescription(string.Join("\n", $"Failed to set \"greeter channel\" to: {channel.Mention}", $"`{errorType}`"))
+                .WithColor(Color.Red);
+        }
+    }
+
+    public async Task<EmbedBuilder> SetLogChannelEmbed(
+        IGuild guild,
+        ITextChannel channel,
+        IInteractionContext? context = null)
+    {
+        var embed = new EmbedBuilder()
+            .WithTitle("Approval - Set Log channel")
+            .WithColor(Color.Blue);
+        try
+        {
+            var result = await SetLogChannel(guild, channel, context?.User);
+            
+            embed.Color = result.IsSuccess ? Color.Green : Color.Red;
+            embed.WithDescription(result.FormatForEmbed());
+            return embed;
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithContext(context)
+                .WithGuild(guild));
+            return embed
+                .WithDescription(string.Join("\n", $"Failed to set \"log channel\" to: {channel.Mention}", $"`{errorType}`"))
+                .WithColor(Color.Red);
+        }
+    }
+}

--- a/XeniaDiscord.Common/Services/GuildApprovalService.Embed.cs
+++ b/XeniaDiscord.Common/Services/GuildApprovalService.Embed.cs
@@ -5,6 +5,35 @@ namespace XeniaDiscord.Common.Services;
 
 partial class GuildApprovalService
 {
+    public async Task<EmbedBuilder> ApproveUserEmbed(
+        IGuildUser user,
+        IUser doneByUser,
+        IInteractionContext? context = null)
+    {
+        var embed = new EmbedBuilder()
+            .WithTitle("Approve User")
+            .WithColor(Color.Blue);
+        try
+        {
+            var result = await ApproveUser(user, doneByUser);
+            
+            embed.Color = result.IsSuccess ? Color.Green : Color.Red;
+            embed.WithDescription(result.FormatForEmbed());
+            return embed;
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithContext(context)
+                .WithUser(user));
+            return embed
+                .WithDescription(string.Join("\n", $"Failed to approve user: {user.Mention}", $"`{errorType}`"))
+                .WithColor(Color.Red);
+        }
+    }
+
     public async Task<EmbedBuilder> SetApprovedRoleEmbed(
         IGuild guild,
         IRole role,

--- a/XeniaDiscord.Common/Services/GuildApprovalService.Greeter.cs
+++ b/XeniaDiscord.Common/Services/GuildApprovalService.Greeter.cs
@@ -1,0 +1,313 @@
+using System.Text;
+using Discord;
+using Microsoft.EntityFrameworkCore;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Data.Models.GuildApproval;
+
+namespace XeniaDiscord.Common.Services;
+
+partial class GuildApprovalService
+{
+    #region Action - Set Greeter Channel
+    public async Task<SetGreeterChannelResult> SetGreeterChannel(
+        IGuild guild,
+        ITextChannel channel,
+        IUser? doneByUser = null)
+    {
+        var ourMember = await guild.GetCurrentUserAsync();
+        var ourChannelPermissions = ourMember.GetPermissions(channel);
+        var ourChannelPermissionsList = ourChannelPermissions.ToList();
+        var missingPermissions = RequiredChannelPermissions.Where(e => !ourChannelPermissionsList.Contains(e)).ToArray();
+        if (missingPermissions.Length > 0)
+        {
+            return new SetGreeterChannelResult(
+                SetGreeterChannelResultKind.MissingPermissions,
+                missingPermissions,
+                channel,
+                guild);
+        }
+
+        await using var db = _db.CreateSession();
+        await using var trans = await db.Database.BeginTransactionAsync();
+        try
+        {
+            var guildIdStr = guild.Id.ToString();
+            if (await db.GuildApprovals.AnyAsync(e => e.GuildId == guildIdStr))
+            {
+                await db.GuildApprovals.Where(e => e.GuildId == guildIdStr)
+                    .ExecuteUpdateAsync(e => e.SetProperty(p => p.GreeterChannelId, channel.Id.ToString()));
+            }
+            else
+            {
+                await db.GuildApprovals.AddAsync(new GuildApprovalModel
+                {
+                    GuildId = guildIdStr,
+                    GreeterChannelId = channel.Id.ToString()
+                });
+            }
+
+            await db.SaveChangesAsync();
+            await trans.CommitAsync();
+        }
+        catch
+        {
+            await trans.RollbackAsync();
+            throw;
+        }
+
+        try
+        {
+            var logEmbed = new EmbedBuilder()
+                .WithTitle("Approval - Update \"Greeter Channel\"")
+                .WithDescription($"Updated `Greeter Channel` to {channel.Mention}")
+                .WithColor(Color.Blue)
+                .WithCurrentTimestamp();
+            if (doneByUser != null)
+            {
+                var fmt = doneByUser.Username + (string.IsNullOrEmpty(doneByUser.Discriminator.Trim('0')) ? "" : $"#{doneByUser.Discriminator}");
+                logEmbed.AddField(
+                    "Actioned By",
+                    string.Join("\n",
+                        "{doneByUser.Mention}",
+                        "`{fmt}`"));
+            }
+            await SendLogEvent(guild, logEmbed);
+        }
+        catch (Exception ex)
+        {
+            var msg = $"Failed to send log message in Guild \"{guild.Name}\" ({guild.Id}) for \"Greeter Channel\" role being updated to \"{channel.Name}\" ({channel.Id})";
+            _log.Warn(ex, msg);
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithGuild(guild)
+                .WithNotes(msg));
+        }
+
+        return new SetGreeterChannelResult(
+            SetGreeterChannelResultKind.Success,
+            [],
+            channel,
+            guild);
+    }
+    public class SetGreeterChannelResult
+    {
+        public SetGreeterChannelResult(
+            SetGreeterChannelResultKind kind,
+            ChannelPermission[] missingPermissions,
+            ITextChannel targetChannel,
+            IGuild targetGuild)
+        {
+            Kind = kind;
+            MissingPermissions = missingPermissions;
+            TargetChannel = targetChannel;
+            TargetGuild = targetGuild;
+        }
+        public SetGreeterChannelResultKind Kind { get; }
+        public ChannelPermission[] MissingPermissions { get; }
+        public ITextChannel TargetChannel { get; }
+        public IGuild TargetGuild { get; }
+
+        public bool IsSuccess => Kind == SetGreeterChannelResultKind.Success;
+        public bool IsFailure => !IsSuccess;
+
+        public string FormatForEmbed()
+        {
+            var fmtChannel = $"<#{TargetChannel.Id}>";
+            switch (Kind)
+            {
+                case SetGreeterChannelResultKind.Success:
+                    return $"Successfully updated Greeter Channel to: {fmtChannel}";
+                case SetGreeterChannelResultKind.MissingPermissions:
+                    return string.Join("\n",
+                        $"Cannot update Greeter Channel to {fmtChannel} - Missing one or more permissions:",
+                        "```",
+                        string.Join("\n", MissingPermissions.Select(e => e.ToString())),
+                        "```",
+                        "Make sure that you give those permissions directly to Xenia, and not a role that Xenia has so permission validation can work more reliably.");
+                default:
+                    return Kind.ToString();
+            }
+        }
+    }
+    public enum SetGreeterChannelResultKind
+    {
+        Success,
+        MissingPermissions,
+    }
+    #endregion
+
+    #region Send Greeter Message
+    public async Task SendGreeterMessage(
+        IGuild guild,
+        IGuildUser newUser)
+    {
+        if (!await IsGreeterEnabled(guild.Id)) return;
+
+        var guildIdStr = guild.Id.ToString();
+        var config = await _db.GuildApprovals.AsNoTracking().FirstOrDefaultAsync(e => e.GuildId == guildIdStr);
+        await SendGreeterMessage(config, guild, newUser);
+    }
+
+    private async Task SendGreeterMessage(
+        GuildApprovalModel? config,
+        IGuild guild,
+        IGuildUser newUser)
+    {
+        if (config?.Enabled != true || config?.EnableGreeter != true) return;
+
+        var channelId = config.GetGreeterChannelId();
+        if (!channelId.HasValue)
+        {
+            await SendLogEvent(guild,
+                new EmbedBuilder()
+                    .WithTitle("Approval - Send Greeter Message")
+                    .WithDescription(string.Join("\n",
+                        "Greeter is enabled, but there is no greeter channel configured.",
+                        "This can be fixed with `/approval-admin set-greeter-channel`"))
+                    .WithColor(Color.Red));
+            return;
+        }
+        if (string.IsNullOrEmpty(config.GreeterMessageTemplate?.Trim()))
+        {
+            await SendLogEvent(guild,
+                new EmbedBuilder()
+                    .WithTitle("Approval - Send Greeter Message")
+                    .WithDescription(string.Join("\n",
+                        "Missing Greeter message template!",
+                        "This can be fixed with `/approval-admin set-greeter-message`"))
+                    .WithColor(Color.Red));
+            return;
+        }
+
+        ITextChannel? textChannel = null;
+        for (int i = 1; i <= 3; i++)
+        {
+            try
+            {
+                textChannel = await guild.GetTextChannelAsync(channelId.Value);
+            }
+            catch (Exception ex)
+            {
+                var exStr = ex.ToString();
+                if (!exStr.Contains("timed out", StringComparison.OrdinalIgnoreCase) || i <= 3)
+                {
+                    await SubmitError(ex);
+                }
+            }
+        }
+        if (textChannel == null)
+        {
+            throw new InvalidOperationException($"Could not find channel: {channelId.Value}");
+        }
+
+        
+        var messageContent = "";
+        if ((!config.GreeterMessageTemplate.Contains("{user_mention}", StringComparison.OrdinalIgnoreCase) || config.GreeterAsEmbed)
+            && config.GreeterMentionUser)
+        {
+            messageContent = newUser.Mention + "\n";
+        }
+
+        var formattedContent = FormatMessageTemplate(config.GreeterMessageTemplate, guild, newUser);
+        for (int i = 1; i <= 3; i++)
+        {
+            try
+            {
+                if (config.GreeterAsEmbed)
+                {
+                    await textChannel.SendMessageAsync(
+                        messageContent,
+                        embed: new EmbedBuilder().WithDescription(formattedContent).Build());
+                }
+                else
+                {
+                    await textChannel.SendMessageAsync(messageContent + formattedContent);
+                }
+            }
+            catch (Exception ex)
+            {
+                var exStr = ex.ToString();
+                if (!exStr.Contains("timed out", StringComparison.OrdinalIgnoreCase) || i <= 3)
+                {
+                    await SubmitError(ex);
+                }
+            }
+        }
+        async Task SubmitError(Exception ex)
+        {
+            var msgSuffix = $"in guild \"{guild.Name}\" ({guild.Id}) for user \"{newUser.Username}#{newUser.Discriminator}\" ({newUser.Id})";
+            var msg = textChannel == null
+                ? $"Failed to get channel \"{channelId}\" {msgSuffix}"
+                : $"Failed to send greeter message in channel \"{textChannel.Name}\" ({textChannel.Id}) {msgSuffix}";
+            _log.Error(ex, msg);
+            await _err.Submit(new ErrorReportBuilder()
+                .WithNotes(msg)
+                .WithException(ex)
+                .WithGuild(guild)
+                .WithUser(newUser)
+                .WithChannel(textChannel));
+        }
+    }
+
+    public static string FormatMessageTemplate(
+        string template,
+        IGuild guild,
+        IGuildUser newUser)
+    {
+        var username = newUser.Username;
+        if (!string.IsNullOrEmpty(newUser.Discriminator.Trim('0')))
+            username += $"#{newUser.Discriminator}";
+        var userDisplayName = username;
+        if (!string.IsNullOrEmpty(newUser.DisplayName))
+            userDisplayName = newUser.DisplayName;
+        else if (!string.IsNullOrEmpty(newUser.GlobalName))
+            userDisplayName = newUser.GlobalName;
+
+        var messageContent = new StringBuilder();
+        var cmdBuf = new StringBuilder();
+        var useCmdBuf = false;
+        foreach (var c in template)
+        {
+            switch (c)
+            {
+                case '}' when useCmdBuf:
+                    switch (cmdBuf.ToString().Trim().ToLower())
+                    {
+                        case "user_id":
+                            messageContent.Append(newUser.Id.ToString());
+                            break;
+                        case "user_mention":
+                            messageContent.Append(newUser.Mention);
+                            break;
+                        case "user_username":
+                            messageContent.Append(username);
+                            break;
+                        case "user_display_name":
+                            messageContent.Append(userDisplayName);
+                            break;
+                        case "guild_name":
+                            messageContent.Append(guild.Name);
+                            break;
+                    }
+                    cmdBuf.Clear();
+                    useCmdBuf = false;
+                    break;
+                case '{' when !useCmdBuf:
+                    useCmdBuf = true;
+                    break;
+                default:
+                    if (useCmdBuf)
+                    {
+                        cmdBuf.Append(c);
+                    }
+                    else
+                    {
+                        messageContent.Append(c);
+                    }
+                    break;
+            }
+        }
+        return messageContent.ToString();
+    }
+    #endregion
+}

--- a/XeniaDiscord.Common/Services/GuildApprovalService.Log.cs
+++ b/XeniaDiscord.Common/Services/GuildApprovalService.Log.cs
@@ -1,0 +1,189 @@
+using Discord;
+using Microsoft.EntityFrameworkCore;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Data;
+using XeniaDiscord.Data.Models.GuildApproval;
+
+namespace XeniaDiscord.Common.Services;
+
+partial class GuildApprovalService
+{
+    #region Action - Set Log Channel
+    public async Task<SetLogChannelResult> SetLogChannel(IGuild guild, ITextChannel channel, IUser? doneByUser = null)
+    {
+        var ourMember = await guild.GetCurrentUserAsync();
+        var ourChannelPermissions = ourMember.GetPermissions(channel);
+        var ourChannelPermissionsList = ourChannelPermissions.ToList();
+        var missingPermissions = RequiredChannelPermissions.Where(e => !ourChannelPermissionsList.Contains(e)).ToArray();
+        if (missingPermissions.Length > 0)
+        {
+            return new SetLogChannelResult(
+                SetLogChannelResultKind.MissingPermissions,
+                missingPermissions,
+                channel,
+                guild);
+        }
+
+
+        ulong? previousChannelId = null;
+        await using var db = _db.CreateSession();
+        await using var trans = await db.Database.BeginTransactionAsync();
+        try
+        {
+
+            var guildIdStr = guild.Id.ToString();
+            if (await db.GuildApprovals.AnyAsync(e => e.GuildId == guildIdStr))
+            {
+                var previousChannelIdStr = await db.GuildApprovals
+                    .Where(e => e.GuildId == guildIdStr)
+                    .Select(e => e.LogChannelId)
+                    .FirstOrDefaultAsync();
+                previousChannelId = previousChannelIdStr.ParseULong(false);
+
+                await db.GuildApprovals.Where(e => e.GuildId == guildIdStr)
+                    .ExecuteUpdateAsync(e => e.SetProperty(p => p.LogChannelId, channel.Id.ToString()));
+            }
+            else
+            {
+                await db.GuildApprovals.AddAsync(new GuildApprovalModel
+                {
+                    GuildId = guildIdStr,
+                    LogChannelId = channel.Id.ToString()
+                });
+            }
+
+            await db.SaveChangesAsync();
+            await trans.CommitAsync();
+        }
+        catch
+        {
+            await trans.RollbackAsync();
+            throw;
+        }
+
+        try
+        {
+            if (previousChannelId.HasValue)
+            {
+                var logEmbed = new EmbedBuilder()
+                    .WithTitle("Approval - Update \"Log Channel\"")
+                    .WithDescription(
+                        string.Join("\n",
+                            $"From: <#{previousChannelId.Value}>",
+                            $"To: <#{channel.Id}>"))
+                    .WithColor(Color.Blue)
+                    .WithCurrentTimestamp();
+                if (doneByUser != null)
+                {
+                    var fmt = doneByUser.Username + (string.IsNullOrEmpty(doneByUser.Discriminator.Trim('0')) ? "" : $"#{doneByUser.Discriminator}");
+                    logEmbed.AddField(
+                        "Actioned By",
+                        string.Join("\n",
+                            "{doneByUser.Mention}",
+                            "`{fmt}`"));
+                }
+                await SendLogEvent(guild, logEmbed);
+            }
+        }
+        catch (Exception ex)
+        {
+            var msg = $"Failed to send log message in Guild \"{guild.Name}\" ({guild.Id}) for \"Greeter Channel\" role being updated to \"{channel.Name}\" ({channel.Id})";
+            _log.Warn(ex, msg);
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithGuild(guild)
+                .WithNotes(msg));
+        }
+
+        return new SetLogChannelResult(
+            SetLogChannelResultKind.Success,
+            [],
+            channel,
+            guild);
+    }
+
+    public class SetLogChannelResult
+    {
+        public SetLogChannelResult(
+            SetLogChannelResultKind kind,
+            ChannelPermission[] missingPermissions,
+            ITextChannel targetChannel,
+            IGuild targetGuild)
+        {
+            Kind = kind;
+            MissingPermissions = missingPermissions;
+            TargetChannel = targetChannel;
+            TargetGuild = targetGuild;
+        }
+        public SetLogChannelResultKind Kind { get; }
+        public ChannelPermission[] MissingPermissions { get; }
+        public ITextChannel TargetChannel { get; }
+        public IGuild TargetGuild { get; }
+
+        public bool IsSuccess => Kind == SetLogChannelResultKind.Success;
+        public bool IsFailure => !IsSuccess;
+
+        public string FormatForEmbed()
+        {
+            var fmtChannel = $"<#{TargetChannel.Id}>";
+            switch (Kind)
+            {
+                case SetLogChannelResultKind.Success:
+                    return $"Successfully updated Log Channel to: {fmtChannel}";
+                case SetLogChannelResultKind.MissingPermissions:
+                    return string.Join("\n",
+                        $"Cannot update Log Channel to {fmtChannel} - Missing one or more permissions:",
+                        "```",
+                        string.Join("\n", MissingPermissions.Select(e => e.ToString())),
+                        "```",
+                        "Please make sure that you give those permissions directly to Xenia, and not a role that Xenia has so permission validation can work more reliably.");
+                default:
+                    return Kind.ToString();
+            }
+        }
+    }
+    public enum SetLogChannelResultKind
+    {
+        Success,
+        MissingPermissions
+    }
+    #endregion
+
+    #region Send Log Event
+    private async Task SendLogEvent(
+        IGuild guild,
+        EmbedBuilder embed)
+    {
+        var guildIdStr = guild.Id.ToString();
+        var logChannelStr = await _db.GuildApprovals.AsNoTracking()
+            .Where(e => e.GuildId == guildIdStr && e.Enabled)
+            .Select(e => e.LogChannelId)
+            .FirstOrDefaultAsync();
+        
+        var channelId = logChannelStr.ParseULong(false);
+        if (!channelId.HasValue) return;
+
+        var channel = await guild.GetTextChannelAsync(channelId.Value);
+        if (channel == null)
+        {
+            _log.Warn($"Could not find channel {channelId} in Guild \"{guild.Name}\" ({guild.Id})");
+            return;
+        }
+        try
+        {
+            await channel.SendMessageAsync(embed: embed.Build());
+        }
+        catch (Exception ex)
+        {
+            var msg = $"Failed to send log message in Channel \"{channel.Name}\" ({channel.Id}) in Guild \"{guild.Name}\" ({guild.Id})";
+            _log.Warn(ex, msg);
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes(msg)
+                .WithGuild(guild)
+                .WithChannel(channel)
+                .AddSerializedAttachment("embedBuilder.json", embed));
+        }
+    }
+    #endregion
+}

--- a/XeniaDiscord.Common/Services/GuildApprovalService.Roles.cs
+++ b/XeniaDiscord.Common/Services/GuildApprovalService.Roles.cs
@@ -1,0 +1,176 @@
+using System.Net;
+using Discord;
+using Microsoft.EntityFrameworkCore;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Data.Models.GuildApproval;
+
+namespace XeniaDiscord.Common.Services;
+
+public partial class GuildApprovalService
+{
+    #region Action - Set "Approved" Role
+    public async Task<SetApprovedRoleResult> SetApprovedRole(
+        IGuild guild,
+        IRole role,
+        IUser? doneByUser = null)
+    {
+        var ourMember = await guild.GetCurrentUserAsync();
+        var ourRoles = await Task.WhenAll(ourMember.RoleIds.Select(id => guild.GetRoleAsync(id)));
+        var ourHighestRole = ourRoles.OrderByDescending(e => e.Position).FirstOrDefault();
+        if (ourHighestRole == null || role.Position > ourHighestRole.Position)
+        {
+            return new SetApprovedRoleResult(
+                SetApprovedRoleResultKind.UnableToGrantRole,
+                role, guild, ourMember, ourHighestRole);
+        }
+        else if (!ourMember.GuildPermissions.ManageRoles)
+        {
+            return new SetApprovedRoleResult(
+                SetApprovedRoleResultKind.MissingPermission_ManageRoles,
+                role, guild, ourMember, ourHighestRole);
+        }
+
+        await using var db = _db.CreateSession();
+        await using var trans = await db.Database.BeginTransactionAsync();
+        try
+        {
+            var guildIdStr = guild.Id.ToString();
+            var roleIdStr = role.Id.ToString();
+            if (await db.GuildApprovals.AnyAsync(e => e.GuildId == guildIdStr))
+            {
+                await db.GuildApprovals.Where(e => e.GuildId == guildIdStr)
+                    .ExecuteUpdateAsync(e => e
+                    .SetProperty(p => p.ApprovedRoleId, roleIdStr));
+            }
+            else
+            {
+                await db.GuildApprovals.AddAsync(new GuildApprovalModel
+                {
+                    GuildId = guildIdStr,
+                    ApprovedRoleId = roleIdStr,
+                    Enabled = true,
+                });
+            }
+            await db.SaveChangesAsync();
+            await trans.CommitAsync();
+
+            _log.Debug($"Set \"Approved\" role to \"{role.Name}\" ({role.Id}) for Guild \"{guild.Name}\" ({guild.Id})");
+        }
+        catch
+        {
+            await trans.RollbackAsync();
+            throw;
+        }
+
+        try
+        {
+            var logEmbed = new EmbedBuilder()
+                .WithTitle("Approval - Update \"Approved Role\"")
+                .WithDescription(
+                    "Role was updated to: {role.Mention}\n"
+                    + string.Join("\n",
+                        "```",
+                        $"Id: {role.Id}",
+                        $"Name: {role.Name}",
+                        $"Position: {role.Position}",
+                        "```"))
+                .WithColor(Color.Blue)
+                .WithCurrentTimestamp();
+            if (doneByUser != null)
+            {
+                var fmt = doneByUser.Username + (string.IsNullOrEmpty(doneByUser.Discriminator.Trim('0')) ? "" : $"#{doneByUser.Discriminator}");
+                logEmbed.AddField(
+                    "Actioned By",
+                    string.Join("\n",
+                        "{doneByUser.Mention}",
+                        "`{fmt}`"));
+            }
+            await SendLogEvent(guild, logEmbed);
+        }
+        catch (Exception ex)
+        {
+            var msg = $"Failed to send log message in Guild \"{guild.Name}\" ({guild.Id}) for \"Approved\" role being updated to: {role.Id}";
+            _log.Warn(ex, msg);
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithGuild(guild)
+                .WithRole(role)
+                .WithNotes(msg));
+        }
+
+        return new SetApprovedRoleResult(
+            SetApprovedRoleResultKind.Success,
+            role, guild, ourMember, ourHighestRole);
+    }
+
+    public class SetApprovedRoleResult
+    {
+        public SetApprovedRoleResult(
+            SetApprovedRoleResultKind kind,
+            IRole role,
+            IGuild guild,
+            IGuildUser ourGuildUser,
+            IRole? ourHighestRole)
+        {
+            Kind = kind;
+            TargetRole = role;
+            Guild = guild;
+            OurGuildUser = ourGuildUser;
+            OurHighestRole = ourHighestRole;
+        }
+        public SetApprovedRoleResultKind Kind { get; }
+        public IRole TargetRole { get; }
+        public IGuildUser OurGuildUser { get; }
+        public IRole? OurHighestRole { get; }
+        public IGuild Guild { get; }
+
+        public bool IsSuccess => Kind == SetApprovedRoleResultKind.Success;
+        public bool IsFailure => !IsSuccess;
+
+        public string FormatForEmbed()
+        {
+            var fmtRole = $"<@&{TargetRole.Id}>";
+            var fmtOurHighest = OurHighestRole == null ? "which we don't have" : $"<@&{OurHighestRole.Id}>";
+            switch (Kind)
+            {
+                case SetApprovedRoleResultKind.Success:
+                    return $"Successfully updated \"Approved\" role to: {fmtRole}";
+                case SetApprovedRoleResultKind.MissingPermission_ManageRoles:
+                    return $"Xenia is missing the permission <code>Manage Roles</code>";
+                case SetApprovedRoleResultKind.UnableToGrantRole:
+                    return $"Unable to use the role {fmtRole} since it's higher than Xenia's highest role, {fmtOurHighest}.\n"
+                         + $"This can be fixed by putting Xenia in a role that's higher than {fmtRole} in the \"Roles\" page of your Guild settings, or making the Xenia role higher than it.";
+                default:
+                    return Kind.ToString();
+            }
+        }
+        public string FormatForWeb()
+        {
+            var roleName = WebUtility.HtmlEncode(TargetRole.Name);
+            var ourHighestRoleName = OurHighestRole == null ? null : WebUtility.HtmlEncode(OurHighestRole.Name);
+
+            var fmtRole = $"<code alt=\"{TargetRole.Id}\">@{roleName}</code>";
+            var fmtOurHighest = OurHighestRole == null ? "which we don't have" : $"<code alt=\"{OurHighestRole?.Id}\">@{ourHighestRoleName}</code>";
+            switch (Kind)
+            {
+                case SetApprovedRoleResultKind.Success:
+                    return $"Successfully updated \"Approved\" role to: {fmtRole}";
+                case SetApprovedRoleResultKind.MissingPermission_ManageRoles:
+                    return $"Xenia is missing the permission <code>Manage Roles</code>";
+                case SetApprovedRoleResultKind.UnableToGrantRole:
+                    return $"Unable to use the role {fmtRole} since it's higher than Xenia's highest role, {fmtOurHighest}.\n"
+                         + $"This can be fixed by putting Xenia in a role that's higher than {fmtRole} in the \"Roles\" page of your Guild settings, or making the Xenia role higher than it.";
+                default:
+                    return Kind.ToString();
+            }
+        }
+    }
+
+    public enum SetApprovedRoleResultKind
+    {
+        Success,
+        MissingPermission_ManageRoles,
+        UnableToGrantRole
+    }
+    #endregion
+}

--- a/XeniaDiscord.Common/Services/GuildApprovalService.cs
+++ b/XeniaDiscord.Common/Services/GuildApprovalService.cs
@@ -1,0 +1,93 @@
+using Discord;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Data;
+using XeniaDiscord.Data.Models.GuildApproval;
+
+namespace XeniaDiscord.Common.Services;
+
+public partial class GuildApprovalService
+{
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
+    private readonly XeniaDbContext _db;
+    private readonly ErrorReportService _err;
+    private readonly ValidationService _validation;
+
+    public GuildApprovalService(IServiceProvider services)
+    {
+        _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
+        _err = services.GetRequiredService<ErrorReportService>();
+        _validation = services.GetRequiredService<ValidationService>();
+    }                       
+
+    public async Task<bool> Exists(ulong guildId)
+    {
+        var guildIdStr = guildId.ToString();
+        return await _db.GuildApprovals.AnyAsync(e => e.GuildId == guildIdStr);
+    }
+    public async Task<bool> IsEnabled(ulong guildId)
+    {
+        var guildIdStr = guildId.ToString();
+        return await _db.GuildApprovals.AnyAsync(e => e.GuildId == guildIdStr && e.Enabled);
+    }
+    public async Task<bool> IsGreeterEnabled(ulong guildId)
+    {
+        var guildIdStr = guildId.ToString();
+        return await _db.GuildApprovals.AnyAsync(e => e.GuildId == guildIdStr && e.Enabled && e.EnableGreeter);
+    }
+
+    public static readonly ChannelPermission[] RequiredChannelPermissions = new[]
+    {
+        ChannelPermission.SendMessages,
+        ChannelPermission.ViewChannel,
+        ChannelPermission.ReadMessageHistory,
+        ChannelPermission.AttachFiles,
+        ChannelPermission.EmbedLinks,
+    };
+    public static readonly GuildPermission[] RequiredGuildPermissions = new[]
+    {
+        GuildPermission.ViewAuditLog,
+        GuildPermission.ManageRoles,
+        
+        GuildPermission.SendMessages,
+        GuildPermission.ViewChannel,
+        GuildPermission.ReadMessageHistory,
+        GuildPermission.AttachFiles,
+        GuildPermission.EmbedLinks
+    };
+
+    public class SetupModalResult
+    {
+        public SetupModalResultFlags Flags { get; }
+
+        public ChannelPermission[] MissingLogChannelPermissions { get; }
+        public ChannelPermission[] MissingGreeterChannelPermissions { get; }
+        public GuildPermission[] MissingPermissions { get; } 
+
+        public ITextChannel TargetLogChannel { get; }
+        public ITextChannel TargetGreeterChannel { get; }
+
+        public bool IsSuccess => Flags == SetupModalResultFlags.Success;
+        public bool IsFailure => !Flags.HasFlag(SetupModalResultFlags.Success);
+    }
+
+    [Flags]
+    public enum SetupModalResultFlags
+    {
+        None = 0,
+        Success = 1 << 0,
+
+        MissingPermissions_LogChannel = 1 << 1,
+        MissingPermissions_GreeterChannel = 1 << 2,
+
+        MissingPermissionsInGuild = 1 << 3,
+    }
+
+    public async Task ValidateAsync(GuildApprovalModel model)
+    {
+        // TODO return a markdown string used in the setup modal to validate config.
+        // use ValidationService for checking channel permissions
+    }
+}

--- a/XeniaDiscord.Common/Services/ValidationService.cs
+++ b/XeniaDiscord.Common/Services/ValidationService.cs
@@ -1,0 +1,164 @@
+using System.Collections.Frozen;
+using CSharpFunctionalExtensions;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.Extensions.DependencyInjection;
+using XeniaBot.Shared.Helpers;
+
+namespace XeniaDiscord.Common.Services;
+
+public class ValidationService
+{
+    private readonly DiscordSocketClient _discord;
+    public ValidationService(IServiceProvider services)
+    {
+        _discord = services.GetRequiredService<DiscordSocketClient>();
+    }
+
+    public async Task<Result<GuildPermissionsResult, FailureData>> Permissions(
+        IGuild guild,
+        GuildPermission[] required)
+    {
+        IGuildUser? member = null;
+        try
+        {
+            await ExceptionHelper.RetryOnTimedOut(async() =>
+            {
+                member = await guild.GetCurrentUserAsync();
+            });
+            if (member == null)
+            {
+                return Result.Failure<GuildPermissionsResult, FailureData>(
+                    new($"Current user ({_discord.CurrentUser.Id}) is not a member in guild \"{guild.Name}\" ({guild.Id})", null, FailureDataKind.CurrentUserIsNotMember));
+            }
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<GuildPermissionsResult, FailureData>(
+                new($"Could not find own user ({_discord.CurrentUser.Id}) in guild \"{guild.Name}\" ({guild.Id})", ex, FailureDataKind.GetSelfAsMemberFailure));
+        }
+
+        var permissions = member.GuildPermissions.ToList();
+        var missing = required.Where(e => !permissions.Contains(e)).ToFrozenSet();
+        return new GuildPermissionsResult(guild, missing, required);
+    }
+    public async Task<Result<ChannelPermissionsResult, FailureData>> Permissions(
+        IGuildChannel channel,
+        ChannelPermission[] required)
+    {
+        IGuildUser? member = null;
+        try
+        {
+            await ExceptionHelper.RetryOnTimedOut(async() =>
+            {
+                member = await channel.Guild.GetCurrentUserAsync();
+            });
+            if (member == null)
+            {
+                return Result.Failure<ChannelPermissionsResult, FailureData>(
+                    new($"Current user ({_discord.CurrentUser.Id}) is not a member in guild \"{channel.Guild.Name}\" ({channel.Guild.Id})", null, FailureDataKind.CurrentUserIsNotMember));
+            }
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<ChannelPermissionsResult, FailureData>(
+                new($"Could not find own user ({_discord.CurrentUser.Id}) in guild \"{channel.Guild.Name}\" ({channel.Guild.Id})", ex, FailureDataKind.GetSelfAsMemberFailure));
+        }
+
+        var channelPermissions = member.GetPermissions(channel);
+        var channelPermissionsList = channelPermissions.ToList();
+        var missing = required.Where(e => !channelPermissionsList.Contains(e)).ToFrozenSet();
+        return new ChannelPermissionsResult(channel, missing, required);
+    }
+    public async Task<Result<ChannelPermissionsResult, FailureData>> ChannelPermissions(
+        ulong guildId,
+        ulong channelId,
+        ChannelPermission[] required)
+    {
+        IGuild? guild = null;
+        IGuildChannel? channel = null;
+        try
+        {
+            await ExceptionHelper.RetryOnTimedOut(async() =>
+            {
+                guild = _discord.GetGuild(guildId);
+            });
+            if (guild == null)
+            {
+                return Result.Failure<ChannelPermissionsResult, FailureData>(
+                    new($"Could not find guild: {guildId}", null, FailureDataKind.GuildNotFound));
+            }
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<ChannelPermissionsResult, FailureData>(
+                new($"Failed to get guild: {guildId}", ex, FailureDataKind.GetGuildFailure));
+        }
+        try
+        {
+            await ExceptionHelper.RetryOnTimedOut(async() =>
+            {
+                channel = await guild.GetChannelAsync(channelId);
+            });
+            if (channel == null)
+            {
+                return Result.Failure<ChannelPermissionsResult, FailureData>(
+                    new($"Could not channel {guildId} in guild \"{guild.Name}\" ({guild.Id})", null, FailureDataKind.ChannelNotFound));
+            }
+
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure<ChannelPermissionsResult, FailureData>(
+                new($"Failed to get channel {channelId} in guild \"{guild.Name}\" ({guild.Id})", ex, FailureDataKind.GetChannelFailure));
+        }
+        return await Permissions(channel, required);
+    }
+
+    public class GuildPermissionsResult(
+        IGuild guild,
+        IEnumerable<GuildPermission> missing,
+        IEnumerable<GuildPermission> expected)
+    {
+        public IGuild Guild { get; } = guild;
+        public IReadOnlySet<GuildPermission> Missing { get; } = missing.ToFrozenSet();
+        public IReadOnlySet<GuildPermission> Expected { get; } = expected.ToFrozenSet();
+
+        public bool AnyMissing => Missing.Count > 0;
+    }
+    public class ChannelPermissionsResult(
+        IGuildChannel channel,
+        IEnumerable<ChannelPermission> missing,
+        IEnumerable<ChannelPermission> expected)
+    {
+        public IGuildChannel Channel { get; } = channel;
+        public IReadOnlySet<ChannelPermission> Missing { get; } = missing.ToFrozenSet();
+        public IReadOnlySet<ChannelPermission> Expected { get; } = expected.ToFrozenSet();
+
+        public bool AnyMissing => Missing.Count > 0;
+    }
+
+    public class FailureData(
+        string message,
+        Exception? exception = null,
+        FailureDataKind kind = FailureDataKind.Unknown)
+    {
+        public string Message { get; } = message;
+        public Exception? Exception { get; } = exception;
+        public FailureDataKind Kind { get; } = kind;
+    }
+    public enum FailureDataKind
+    {
+        Unknown,
+        GetGuildFailure,
+        GuildNotFound,
+
+        GetChannelFailure,
+        ChannelNotFound,
+
+        GetSelfAsMemberFailure,
+        CurrentUserIsNotMember,
+
+        Fatal
+    }
+}

--- a/XeniaDiscord.Common/XeniaDiscordCommon.cs
+++ b/XeniaDiscord.Common/XeniaDiscordCommon.cs
@@ -21,7 +21,9 @@ public static class XeniaDiscordCommon
         {
             typeof(DiscordCacheService),
             typeof(UserCacheService),
-            typeof(GuildCacheService)
+            typeof(GuildCacheService),
+
+            typeof(GuildApprovalService),
         };
         foreach (var t in types)
         {

--- a/XeniaDiscord.Common/XeniaDiscordCommon.cs
+++ b/XeniaDiscord.Common/XeniaDiscordCommon.cs
@@ -12,7 +12,8 @@ public static class XeniaDiscordCommon
         bool includeAsSingleton)
     {
         services.AddSingleton<BanSyncService>()
-            .AddSingleton<DiscordCacheEventHandler>();
+                .AddSingleton<ValidationService>()
+                .AddSingleton<DiscordCacheEventHandler>();
 
         RegisterMappers(services);
 

--- a/XeniaDiscord.Data/Migrations/20260330075500_Create_GuildApprovalModel.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260330075500_Create_GuildApprovalModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260330075500_Create_GuildApprovalModel")]
+    partial class Create_GuildApprovalModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -344,10 +347,6 @@ namespace XeniaDiscord.Data.Migrations
                         .HasColumnType("character varying(40)");
 
                     b.Property<string>("ApprovedRoleId")
-                        .HasMaxLength(40)
-                        .HasColumnType("character varying(40)");
-
-                    b.Property<string>("ApproverRoleId")
                         .HasMaxLength(40)
                         .HasColumnType("character varying(40)");
 

--- a/XeniaDiscord.Data/Migrations/20260330075500_Create_GuildApprovalModel.cs
+++ b/XeniaDiscord.Data/Migrations/20260330075500_Create_GuildApprovalModel.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Create_GuildApprovalModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GuildApproval",
+                columns: table => new
+                {
+                    GuildId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    ApprovedRoleId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    LogChannelId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    Enabled = table.Column<bool>(type: "boolean", nullable: false),
+                    EnableGreeter = table.Column<bool>(type: "boolean", nullable: false),
+                    GreeterChannelId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    GreeterMessageTemplate = table.Column<string>(type: "character varying(5000)", maxLength: 5000, nullable: true),
+                    GreeterAsEmbed = table.Column<bool>(type: "boolean", nullable: false),
+                    GreeterMentionUser = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GuildApproval", x => x.GuildId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GuildApproval_GuildId_Enabled",
+                table: "GuildApproval",
+                columns: new[] { "GuildId", "Enabled" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GuildApproval_GuildId_Enabled_EnableGreeter",
+                table: "GuildApproval",
+                columns: new[] { "GuildId", "Enabled", "EnableGreeter" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GuildApproval");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Migrations/20260330103349_GuildApprovalModel_AddColumn_ApproverRoleId.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260330103349_GuildApprovalModel_AddColumn_ApproverRoleId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260330103349_GuildApprovalModel_AddColumn_ApproverRoleId")]
+    partial class GuildApprovalModel_AddColumn_ApproverRoleId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260330103349_GuildApprovalModel_AddColumn_ApproverRoleId.cs
+++ b/XeniaDiscord.Data/Migrations/20260330103349_GuildApprovalModel_AddColumn_ApproverRoleId.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class GuildApprovalModel_AddColumn_ApproverRoleId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ApproverRoleId",
+                table: "GuildApproval",
+                type: "character varying(40)",
+                maxLength: 40,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ApproverRoleId",
+                table: "GuildApproval");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Migrations/20260330121857_Create_GuildApprovalLogEventModel.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260330121857_Create_GuildApprovalLogEventModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260330121857_Create_GuildApprovalLogEventModel")]
+    partial class Create_GuildApprovalLogEventModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260330121857_Create_GuildApprovalLogEventModel.cs
+++ b/XeniaDiscord.Data/Migrations/20260330121857_Create_GuildApprovalLogEventModel.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Create_GuildApprovalLogEventModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GuildApprovalLogEvent",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    GuildId = table.Column<string>(type: "text", nullable: false),
+                    UserId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    ApprovedByUserId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    RecordCreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GuildApprovalLogEvent", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GuildApprovalLogEvent_GuildId_UserId",
+                table: "GuildApprovalLogEvent",
+                columns: new[] { "GuildId", "UserId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GuildApprovalLogEvent");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Models/GuildApproval/GuildApprovalLogEventModel.cs
+++ b/XeniaDiscord.Data/Models/GuildApproval/GuildApprovalLogEventModel.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace XeniaDiscord.Data.Models.GuildApproval;
+
+public class GuildApprovalLogEventModel
+{
+    public const string TableName = "GuildApprovalLogEvent";
+
+    public GuildApprovalLogEventModel()
+    {
+        Id = Guid.NewGuid();
+        GuildId = "0";
+        UserId = "0";
+        ApprovedByUserId = "0";
+        RecordCreatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Record Id (primary key)
+    /// </summary>
+    public Guid Id { get; set; }
+
+    public string GuildId { get; set; }
+
+    /// <summary>
+    /// Id of the User that was approved (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string UserId { get; set; }
+
+    /// <summary>
+    /// User Id that approved <see cref="UserId"/> (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string ApprovedByUserId { get; set; }
+
+    /// <summary>
+    /// When this record was created (UTC)
+    /// </summary>
+    public DateTime RecordCreatedAt { get; set; }
+
+    public ulong GetGuildId() => GuildId.ParseRequiredULong(nameof(GuildId), false);
+    public ulong GetUserId() => UserId.ParseRequiredULong(nameof(UserId), false);
+    public ulong GetApprovedByUserId() => ApprovedByUserId.ParseRequiredULong(nameof(ApprovedByUserId), false);
+}

--- a/XeniaDiscord.Data/Models/GuildApproval/GuildApprovalModel.cs
+++ b/XeniaDiscord.Data/Models/GuildApproval/GuildApprovalModel.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace XeniaDiscord.Data.Models.GuildApproval;
+
+/// <summary>
+/// Model for configuring the (member) Approval system in a guild.
+/// </summary>
+public class GuildApprovalModel
+{
+    public const string TableName = "GuildApproval";
+
+    public GuildApprovalModel()
+    {
+        GuildId = "0";
+    }
+
+    /// <summary>
+    /// Guild Id (ulong as string, primary key)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string GuildId { get; set; }
+
+    /// <summary>
+    /// Discord Role Id that's given to approved users
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? ApprovedRoleId { get; set; }
+
+    /// <summary>
+    /// Discord Role Id that's given to users who can always approve a user.
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? ApproverRoleId { get; set; }
+
+    /// <summary>
+    /// Log Channel for approvals (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? LogChannelId { get; set; }
+
+    /// <summary>
+    /// Is the approval system enabled?
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Should approved users be greeted in a separate channel?
+    /// </summary>
+    public bool EnableGreeter { get; set; }
+    /// <summary>
+    /// Channel Id to greet new user in (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? GreeterChannelId { get; set; }
+    /// <summary>
+    /// Message template for greeter
+    /// </summary>
+    [MaxLength(5000)]
+    public string? GreeterMessageTemplate { get; set; }
+    /// <summary>
+    /// Should the greeter template be in an embed?
+    /// </summary>
+    public bool GreeterAsEmbed { get; set; }
+    /// <summary>
+    /// Should the new user be mentioned in the content?
+    /// </summary>
+    /// <remarks>
+    /// If <see cref="GreeterMessageTemplate"/> contains <c>{user_mention}</c>, and it's not in an embed, then the user won't be mentioned at the beginning of the message.
+    /// </remarks>
+    public bool GreeterMentionUser { get; set; }
+
+    public ulong GetGuildId() => GuildId.ParseRequiredULong(nameof(GuildId), false);
+    public ulong? GetApprovedRoleId() => ApprovedRoleId.ParseULong(false);
+    public ulong? GetApproverRoleId() => ApproverRoleId.ParseULong(false);
+    public ulong? GetLogChannelId() => LogChannelId.ParseULong(false);
+    public ulong? GetGreeterChannelId() => GreeterChannelId.ParseULong(false);
+}

--- a/XeniaDiscord.Data/Repositories/GuildApprovalRepository.cs
+++ b/XeniaDiscord.Data/Repositories/GuildApprovalRepository.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using NLog;
+using XeniaDiscord.Data.Models.GuildApproval;
+
+namespace XeniaDiscord.Data.Repositories;
+
+public class GuildApprovalRepository
+{
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
+    public async Task InsertOrUpdate(XeniaDbContext db, GuildApprovalModel model)
+    {
+        if (await db.GuildApprovals.AnyAsync(e => e.GuildId == model.GuildId))
+        {
+            await db.GuildApprovals.Where(e => e.GuildId == model.GuildId)
+                .ExecuteUpdateAsync(e => e
+                .SetProperty(p => p.ApprovedRoleId, model.ApprovedRoleId)
+                .SetProperty(p => p.ApproverRoleId, model.ApproverRoleId)
+                .SetProperty(p => p.LogChannelId, model.LogChannelId)
+                .SetProperty(p => p.Enabled, model.Enabled)
+                .SetProperty(p => p.EnableGreeter, model.EnableGreeter)
+                .SetProperty(p => p.GreeterChannelId, model.GreeterChannelId)
+                .SetProperty(p => p.GreeterMessageTemplate, model.GreeterMessageTemplate)
+                .SetProperty(p => p.GreeterAsEmbed, model.GreeterAsEmbed)
+                .SetProperty(p => p.GreeterMentionUser, model.GreeterMentionUser));
+            _log.Debug($"Updated record (GuildId={model.GuildId})");
+        }
+        else
+        {
+            model.GetGuildId();
+            await db.GuildApprovals.AddAsync(model);
+            _log.Debug($"Inserted record (GuildId={model.GuildId})");
+        }
+    }
+}

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -36,6 +36,7 @@ public class XeniaDbContext : DbContext
     #endregion
 
     public DbSet<GuildApprovalModel> GuildApprovals { get; set; }
+    public DbSet<GuildApprovalLogEventModel> GuildApprovalLogEvents { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -147,6 +148,16 @@ public class XeniaDbContext : DbContext
                 e.GuildId,
                 e.Enabled,
                 e.EnableGreeter
+            });
+        });
+        builder.Entity<GuildApprovalLogEventModel>(b =>
+        {
+            b.ToTable(GuildApprovalLogEventModel.TableName).HasKey(e => e.Id);
+
+            b.HasIndex(e => new
+            {
+                e.GuildId,
+                e.UserId
             });
         });
 

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using MongoDB.Driver;
 using XeniaDiscord.Data.Extensions;
 using XeniaDiscord.Data.Models.BanSync;
 using XeniaDiscord.Data.Models.Cache;
+using XeniaDiscord.Data.Models.GuildApproval;
 using XeniaDiscord.Data.Models.PartialSnapshot;
 
 namespace XeniaDiscord.Data;
@@ -34,6 +34,8 @@ public class XeniaDbContext : DbContext
     public DbSet<BanSyncGuildModel> BanSyncGuilds { get; set; }
     public DbSet<BanSyncGuildSnapshotModel> BanSyncGuildSnapshots { get; set; }
     #endregion
+
+    public DbSet<GuildApprovalModel> GuildApprovals { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -130,6 +132,24 @@ public class XeniaDbContext : DbContext
             b.HasIndex(e => new { e.Timestamp, e.GuildId }).IsDescending();
         });
         #endregion
+
+        builder.Entity<GuildApprovalModel>(b =>
+        {
+            b.ToTable(GuildApprovalModel.TableName).HasKey(e => e.GuildId); 
+
+            b.HasIndex(e => new
+            {
+                e.GuildId,
+                e.Enabled
+            });
+            b.HasIndex(e => new
+            {
+                e.GuildId,
+                e.Enabled,
+                e.EnableGreeter
+            });
+        });
+
         builder.HasDbFunction(typeof(XeniaDbContext).GetMethod(nameof(spBanSyncGetMutualRecordsForGuild), [typeof(string)]))
             .HasName("spBanSyncGetMutualRecordsForGuild");
         builder.HasDbFunction(typeof(XeniaDbContext).GetMethod(nameof(spBanSyncGetMutualRecordsForGuild_Paginate), [typeof(string), typeof(int), typeof(int)]))

--- a/XeniaDiscord.Data/XeniaDiscordData.cs
+++ b/XeniaDiscord.Data/XeniaDiscordData.cs
@@ -33,6 +33,8 @@ public static class XeniaDiscordData
             typeof(GuildCacheRepository),
             typeof(GuildMemberCacheRepository),
             typeof(UserCacheRepository),
+
+            typeof(GuildApprovalRepository)
         };
         foreach (var i in types)
         {

--- a/XeniaDiscord.Interactions/ModalYesNo.cs
+++ b/XeniaDiscord.Interactions/ModalYesNo.cs
@@ -1,0 +1,7 @@
+namespace XeniaDiscord.Interactions;
+
+public enum ModalYesNo
+{
+    Yes,
+    No
+}

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalAdminModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalAdminModule.cs
@@ -82,7 +82,7 @@ public class GuildApprovalAdminModule : InteractionModuleBase
         }
     }
 
-    [SlashCommand("set-role", "Set role to be given to approved users")]
+    [SlashCommand("set-approved-role", "Set role to be given to approved users")]
     [RequireUserPermission(GuildPermission.ManageRoles)]
     [RequireBotPermission(GuildPermission.ManageRoles)]
     public async Task SetRoleAsync(

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalAdminModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalAdminModule.cs
@@ -1,0 +1,481 @@
+using System.Text;
+using Discord;
+using Discord.Interactions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using XeniaBot.Shared.Helpers;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Common.Services;
+using XeniaDiscord.Data;
+using XeniaDiscord.Data.Models.GuildApproval;
+using XeniaDiscord.Data.Repositories;
+
+using SetupGreeterModal = XeniaDiscord.Interactions.Modules.GuildApprovalModalModule.SetupGreeterModal;
+
+namespace XeniaDiscord.Interactions.Modules;
+
+[Group("approval-admin", "Guild Config: Approval")]
+[CommandContextType(InteractionContextType.Guild)]
+public class GuildApprovalAdminModule : InteractionModuleBase
+{
+    private readonly XeniaDbContext _db;
+    private readonly ErrorReportService _err;
+    private readonly GuildApprovalService _service;
+    private readonly GuildApprovalRepository _repo;
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
+    public GuildApprovalAdminModule(IServiceProvider services)
+    {
+        _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
+        _err = services.GetRequiredService<ErrorReportService>();
+        _service = (scope?.ServiceProvider ?? services).GetRequiredService<GuildApprovalService>();
+        _repo = (scope?.ServiceProvider ?? services).GetRequiredService<GuildApprovalRepository>();
+    }
+    
+    [SlashCommand("enable", "Enable approval module")]
+    [RequireUserPermission(GuildPermission.ManageRoles)]
+    public async Task Enable()
+    {
+        await DeferAsync();
+        var embed = new EmbedBuilder()
+            .WithTitle("Approval - Enable")
+            .WithColor(Color.Blue);
+        try
+        {
+            var guildIdStr = Context.Guild.Id.ToString();
+            var model = await _db.GuildApprovals.AsNoTracking().FirstOrDefaultAsync(e => e.GuildId == guildIdStr)
+                ?? new()
+                {
+                    GuildId = guildIdStr
+                };
+            model.Enabled = true;
+            
+            await using var db = _db.CreateSession();
+            await using var trans = await db.Database.BeginTransactionAsync();
+            try
+            {
+                await _repo.InsertOrUpdate(db, model);
+                await db.SaveChangesAsync();
+                await trans.CommitAsync();
+            }
+            catch
+            {
+                await trans.RollbackAsync();
+                throw;
+            }
+            embed.WithDescription("Successfully enabled module.");
+            await FollowupAsync(embed: embed.Build());
+        }
+        catch (Exception ex)
+        {
+            const string msg = "Failed to enable approval module";
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes(msg)
+                .WithContext(Context));
+            
+            await FollowupAsync(embed:
+                embed.WithDescription(string.Join("\n", "Failed to enable approval module.", $"`{errorType}`"))
+                    .WithColor(Color.Red)
+                    .Build());
+        }
+    }
+
+    [SlashCommand("set-role", "Set role to be given to approved users")]
+    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RequireBotPermission(GuildPermission.ManageRoles)]
+    public async Task SetRoleAsync(
+        [Summary("Role", "Role that users will get once they've been approved.")]
+        IRole role)
+    {
+        await DeferAsync();
+        var embed = new EmbedBuilder()
+            .WithTitle("Approval - Set Role")
+            .WithColor(Color.Blue);
+        try
+        {
+            embed = await _service.SetApprovedRoleEmbed(Context.Guild, role, Context);
+            /*
+            var ourMember = await Context.Guild.GetCurrentUserAsync();
+            var ourRoles = await Task.WhenAll(ourMember.RoleIds.Select(id => Context.Guild.GetRoleAsync(id)));
+            var ourHighestRole = ourRoles.OrderByDescending(e => e.Position).FirstOrDefault();
+            if (ourHighestRole == null || role.Position > ourHighestRole.Position)
+            {
+                embed.WithDescription(
+                    "Unable to use role, since we won't have permission to give it to users.\n\n" +
+                    $"The Xenia role needs to be higher than {role.Mention} in the \"Role\" settings of your Guild.")
+                    .WithColor(Color.Red);
+                await FollowupAsync(embed: embed.Build());
+                return;
+            }
+            else if (!ourMember.GuildPermissions.ManageRoles)
+            {
+                embed.WithDescription("Xenia does not have (direct) permission to manage roles. This permissions is required for this module.").WithColor(Color.Red);
+                await FollowupAsync(embed: embed.Build());
+                return;
+            }
+
+            await using var db = _db.CreateSession();
+            await using var trans = await db.Database.BeginTransactionAsync();
+            try
+            {
+                var guildIdStr = Context.Guild.Id.ToString();
+                var roleIdStr = role.Id.ToString();
+                if (await db.GuildApprovals.AnyAsync(e => e.GuildId == guildIdStr))
+                {
+                    await db.GuildApprovals.Where(e => e.GuildId == guildIdStr)
+                    .ExecuteUpdateAsync(e => e
+                    .SetProperty(p => p.ApprovedRoleId, roleIdStr));
+                }
+                else
+                {
+                    await db.GuildApprovals.AddAsync(new GuildApprovalModel
+                    {
+                        GuildId = guildIdStr,
+                        ApprovedRoleId = roleIdStr
+                    });
+                }
+                await db.SaveChangesAsync();
+                await trans.CommitAsync();
+            }
+            catch
+            {
+                await trans.RollbackAsync();
+                throw;
+            }
+
+            embed
+                .WithDescription($"Successfully set approved role to: {role.Mention} ({role.Id})")
+                .WithColor(Color.Green);
+            */
+            await FollowupAsync(embed: embed.Build());
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithContext(Context));
+            
+            await FollowupAsync(embed:
+                embed.WithDescription(string.Join("\n", "Failed to add event to channel.", $"`{errorType}`"))
+                .WithColor(Color.Red)
+                .Build());
+        }
+    }
+    
+    [SlashCommand("set-channel", "Set log channel for user approvals")]
+    [RequireUserPermission(GuildPermission.ManageChannels)]
+    public async Task SetLogChannel(
+        [ChannelTypes(ChannelType.Text)] ITextChannel channel)
+    {
+        await DeferAsync();
+        var embed = new EmbedBuilder()
+            .WithTitle("Approval - Set Log Channel")
+            .WithColor(Color.Blue);
+        try
+        {
+            embed = await _service.SetLogChannelEmbed(Context.Guild, channel, Context);
+            await FollowupAsync(embed: embed.Build());
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithContext(Context));
+            
+            await FollowupAsync(embed:
+                embed.WithDescription(string.Join("\n", $"Failed to set log channel to: `{channel.Id}`", $"`{errorType}`"))
+                .WithColor(Color.Red)
+                .Build());
+        }
+        throw new NotImplementedException();
+    }
+    
+    [SlashCommand("set-greeter-channel", "Set channel to send message for greeting user (post-approval)")]
+    [RequireUserPermission(GuildPermission.ManageChannels)]
+    public async Task SetGreeterChannel(
+        [ChannelTypes(ChannelType.Text)] ITextChannel channel)
+    {
+        await DeferAsync();
+        var embed = new EmbedBuilder()
+            .WithTitle("Approval - Set Greeter Channel")
+            .WithColor(Color.Blue);
+        try
+        {
+            embed = await _service.SetGreeterChannelEmbed(Context.Guild, channel, Context);
+            await FollowupAsync(embed: embed.Build());
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithContext(Context));
+            
+            await FollowupAsync(embed:
+                embed.WithDescription(string.Join("\n", $"Failed to set greeter channel to: `{channel.Id}`", $"`{errorType}`"))
+                .WithColor(Color.Red)
+                .Build());
+        }
+    }
+
+    [SlashCommand("get-greeter-msg", "Get the message used for greeting users.")]
+    [RequireUserPermission(GuildPermission.ManageChannels)]
+    public async Task GetGreeterMessage()
+    {
+        await DeferAsync();
+        var embed = new EmbedBuilder()
+            .WithTitle("Approval - Get Greeter Message")
+            .WithColor(Color.Blue);
+        try
+        {
+            var guildIdStr = Context.Guild.Id.ToString();
+            if (!await _db.GuildApprovals.AnyAsync(e => e.GuildId == guildIdStr && !string.IsNullOrEmpty(e.GreeterMessageTemplate)))
+            {
+                embed.WithDescription("No greeter message has been configured.")
+                    .WithColor(Color.Orange);
+                await FollowupAsync(embed: embed.Build());
+                return;
+            }
+            
+            var content = await _db.GuildApprovals.Where(e => e.GuildId == guildIdStr)
+                .Select(e => e.GreeterMessageTemplate)
+                .FirstOrDefaultAsync();
+            if (string.IsNullOrEmpty(content?.Trim()))
+            {
+                embed.WithDescription("No greeter message has been configured (or it's empty)")
+                    .WithColor(Color.Orange);
+                await FollowupAsync(embed: embed.Build());
+            }
+            else
+            {
+                if (content.Length > 2000)
+                {
+                    embed.WithDescription("Greeter message has been attached as `greeter-template.txt`");
+                    await FollowupWithFileAsync(
+                        new MemoryStream(Encoding.UTF8.GetBytes(content)), "greeter-template.txt",
+                        embed: embed.Build());
+                }
+                else
+                {
+                    embed.WithDescription(content);
+                    await FollowupAsync(embed: embed.Build());
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithContext(Context));
+            
+            await FollowupAsync(embed:
+                embed.WithDescription(string.Join("\n", "Failed to get greeter message.", $"`{errorType}`"))
+                    .WithColor(Color.Red)
+                    .Build());
+        }
+    }
+
+
+    [SlashCommand("setup-greeter", "Setup post-approval greeter", runMode: RunMode.Async)]
+    [RequireUserPermission(GuildPermission.ManageChannels)]
+    public async Task SetupGreeter()
+    {
+        ITextChannel? greeterChannel = null;
+        GuildApprovalModel? config = null;
+        try
+        {
+            var guildId = Context.Guild.Id.ToString();
+            config = await _db.GuildApprovals.AsNoTracking().FirstOrDefaultAsync(e => e.GuildId == guildId);
+            var modal = new SetupGreeterModal();
+            if (config != null)
+            {
+                modal.EnableGreeter = config.EnableGreeter ? ModalYesNo.Yes : ModalYesNo.No;
+                if (!string.IsNullOrEmpty(config.GreeterMessageTemplate))
+                {
+                    modal.GreeterMessageTemplate = config.GreeterMessageTemplate;
+                }
+                modal.GreeterAsEmbed = config.GreeterAsEmbed ? ModalYesNo.Yes : ModalYesNo.No;
+            }
+
+            await ExceptionHelper.RetryOnTimedOut(SetGreeterChannelData);
+        
+            modal.GreeterChannel = greeterChannel;
+
+            await RespondWithModalAsync("guild-approval-setup-greeter", modal);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex);
+        }
+
+        async Task SetGreeterChannelData()
+        {
+            var channelId = config?.GetApprovedRoleId();
+            if (!channelId.HasValue) return;
+
+            var role = await Context.Guild.GetTextChannelAsync(channelId.Value);
+            greeterChannel = role;
+        }
+    }
+
+
+    // TODO use GuildApprovalService to validate SetupModal
+    // TODO update GuildApprovalModel from the SetupModal data
+    /*
+    [SlashCommand("setup", "Setup Approvals in your Guild")]
+    public async Task SetupCommand()
+    {
+        var guildId = Context.Guild.Id.ToString();
+        var config = await _db.GuildApprovals.AsNoTracking().FirstOrDefaultAsync(e => e.GuildId == guildId);
+        ITextChannel? logChannel = null;
+        ITextChannel? greeterChannel = null;
+        IRole? approvedRole = null;
+        IRole? approverRole = null;
+
+        var modal = new SetupModal();
+        if (config != null)
+        {
+            modal.Enabled = config.Enabled ? ModalYesNo.Yes : ModalYesNo.No;
+            modal.EnableGreeter = config.EnableGreeter ? ModalYesNo.Yes : ModalYesNo.No;
+
+            if (!string.IsNullOrEmpty(config.GreeterMessageTemplate))
+            {
+                modal.GreeterTemplate = config.GreeterMessageTemplate;
+            }
+            modal.GreeterAsEmbed = config.GreeterAsEmbed ? ModalYesNo.Yes : ModalYesNo.No;
+            modal.GreeterMentionUser = config.GreeterMentionUser ? ModalYesNo.Yes : ModalYesNo.No;
+        }
+
+        await Task.WhenAll(
+            SetLogChannel(),
+            SetGreeterChannel(),
+            SetApprovedRole(),
+            SetApproverRole());
+
+        await RespondWithModalAsync("guild-approval-admin-setup", modal);
+
+        async Task SetLogChannel()
+        {
+            await WrapError(async () =>
+            {
+                var channelId = config?.GetLogChannelId();
+                if (!channelId.HasValue) return;
+
+                var role = await Context.Guild.GetTextChannelAsync(channelId.Value);
+                logChannel = role;
+            });
+        }
+        async Task SetGreeterChannel()
+        {
+            await WrapError(async () =>
+            {
+                var channelId = config?.GetApprovedRoleId();
+                if (!channelId.HasValue) return;
+
+                var role = await Context.Guild.GetTextChannelAsync(channelId.Value);
+                greeterChannel = role;
+            });
+        }
+        async Task SetApprovedRole()
+        {
+            await WrapError(async () =>
+            {
+                var roleId = config?.GetApprovedRoleId();
+                if (!roleId.HasValue) return;
+
+                var role = await Context.Guild.GetRoleAsync(roleId.Value);
+                approvedRole = role;
+            });
+        }
+        async Task SetApproverRole()
+        {
+            await WrapError(async () =>
+            {
+                var roleId = config?.GetApproverRoleId();
+                if (!roleId.HasValue) return;
+
+                var role = await Context.Guild.GetRoleAsync(roleId.Value);
+                approverRole = role;
+            });
+        }
+        async Task WrapError(Func<Task> callback)
+        {
+            for (int i = 0; i <= 3; i++)
+            {
+                try
+                {
+                    await callback();
+                }
+                catch (Exception ex)
+                {
+                    var exStr = ex.ToString();
+                    if (!exStr.Contains("timed out", StringComparison.OrdinalIgnoreCase) || i >= 3)
+                    {
+                        throw;
+                    }
+                }
+            }
+        }
+    }
+
+    [ModalInteraction("guild-approval-admin-setup")]
+    [RequireUserPermission(GuildPermission.ManageChannels)]
+    public async Task HandleSetupModal(SetupModal modal)
+    {
+        Debugger.Break();
+    }
+
+    public class SetupModal : IModal
+    {
+        public string Title => "Approval - Setup";
+        
+        [ModalTextDisplay(content: "Validation errors would go here, but there isn't anything here!")]
+        public string ValidationErrors { get; set; } = "Submit modal to check for any errors.";
+
+        [ModalChannelSelect("enable")]
+        [InputLabel("Enable", "Should this feature be enabled?")]
+        public ModalYesNo Enabled { get; set; } = ModalYesNo.Yes;
+
+        [ModalChannelSelect("log-channel")]
+        [InputLabel("Log Channel", "Channel to log things like who approved who.")]
+        public ITextChannel LogChannel { get; set; }
+
+        [ModalRoleSelect("approved-role")]
+        [InputLabel("Approved Role", "Role to give users once they've been approved.")]
+        public IRole ApprovedRole { get; set; }
+
+        [RequiredInput(false)]
+        [ModalRoleSelect("approver-role")]
+        [InputLabel("Approver Role (optional)", "Users in this role can always approve new users, but only that.")]
+        public IRole? ApproverRole { get; set; }
+
+        [ModalSelectMenu("greeter-enable")]
+        [InputLabel("Greeter - Enable", "Once the user is approved, a pre-generated message would be sent in a channel to \"greet\" the new user.")]
+        public ModalYesNo EnableGreeter { get; set; } = ModalYesNo.Yes;
+
+        [RequiredInput(false)]
+        [ModalChannelSelect("greeter-channel")]
+        [InputLabel("Greeter - Channel", "Channel to greet new users once they've been approved. Required when Greeter is enabled")]
+        public ITextChannel? GreeterChannel { get; set; }
+        
+        [RequiredInput(false)]
+        [ModalTextInput("greeter-message", style: TextInputStyle.Paragraph)]
+        [InputLabel("Greeter - Message Template", "Message template for when greeting approved users.")]
+        public string GreeterTemplate { get; set; }= "Heya {user_mention}, welcome to {server_name}!";
+
+        [ModalSelectMenu("greeter-mention-user")]
+        [InputLabel("Greeter - Always Mention User", "Should the user always be mentioned in the greeter message?")]
+        public ModalYesNo GreeterMentionUser { get; set; } = ModalYesNo.Yes;
+
+        [ModalSelectMenu("greeter-as-embed")]
+        [InputLabel("Greeter - Display as Embed", "Render the parsed greeter template as an embed, instead of a standard message.")]
+        public ModalYesNo GreeterAsEmbed { get; set; } = ModalYesNo.No;
+    }
+    
+    */
+}

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalModalModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalModalModule.cs
@@ -1,0 +1,156 @@
+using Discord;
+using Discord.Interactions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Common.Services;
+using XeniaDiscord.Data;
+using XeniaDiscord.Data.Repositories;
+
+namespace XeniaDiscord.Interactions.Modules;
+
+[CommandContextType(InteractionContextType.Guild)]
+public class GuildApprovalModalModule : InteractionModuleBase
+{
+    private readonly XeniaDbContext _db;
+    private readonly ErrorReportService _err;
+    private readonly ValidationService _validation;
+    private readonly GuildApprovalRepository _repo;
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
+    public GuildApprovalModalModule(IServiceProvider services)
+    {
+        _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
+        _err = services.GetRequiredService<ErrorReportService>();
+        _validation = services.GetRequiredService<ValidationService>();
+        _repo = (scope?.ServiceProvider ?? services).GetRequiredService<GuildApprovalRepository>();
+    }
+    private async Task HandleSetupGreeterModalInternal(SetupGreeterModal modal)
+    {
+        var errors = new List<string>();
+        if (modal.EnableGreeter == ModalYesNo.Yes)
+        {
+            if (modal.GreeterChannel == null)
+            {
+                errors.Add("- Greeter Channel is required when enabled.");
+            }
+            else
+            {
+                var validation = await _validation.ChannelPermissions(
+                    Context.Guild.Id,
+                    modal.GreeterChannel.Id,
+                    GuildApprovalService.RequiredChannelPermissions);
+                if (validation.IsSuccess)
+                {
+                    if (validation.Value.AnyMissing)
+                    {
+                        errors.Add("- Missing permissions on greeter channel: " + string.Join(", ", validation.Value.Missing.Select(e => e.ToString())));
+                    }
+                }
+                else
+                {
+                    errors.Add($"- Failed to validate greeter channel permissions ({validation.Error.Kind})");
+                }
+            }
+        }
+        if (errors.Count > 0)
+        {
+            _log.Trace("Validation errors:\n" + string.Join("\n", errors));
+            modal.ValidationErrors = "Failed to validate user input:\n" + string.Join("\n", errors);
+            await RespondWithModalAsync("guild-approval-setup-greeter", modal);
+            return;
+        }
+
+        var guildIdStr = Context.Guild.Id.ToString();
+        var model = await _db.GuildApprovals.AsNoTracking().FirstOrDefaultAsync(e => e.GuildId == guildIdStr)
+            ?? new()
+            {
+                GuildId = guildIdStr
+            };
+        
+        model.EnableGreeter = modal.EnableGreeter == ModalYesNo.Yes;
+        model.GreeterChannelId = modal.GreeterChannel?.Id.ToString();
+        model.GreeterMessageTemplate = modal.GreeterMessageTemplate;
+        model.GreeterAsEmbed = modal.GreeterAsEmbed == ModalYesNo.Yes;
+        
+        await using var db = _db.CreateSession();
+        await using var trans = await db.Database.BeginTransactionAsync();
+        try
+        {
+            await _repo.InsertOrUpdate(db, model);
+            await db.SaveChangesAsync();
+            await trans.CommitAsync();
+        }
+        catch (Exception ex)
+        {
+            var msg = $"Failed to save configuration for guild \"{Context.Guild.Name}\" ({Context.Guild.Id})";
+            _log.Error(ex, msg);
+            await trans.RollbackAsync();
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes(msg)
+                .WithContext(Context)
+                .AddSerializedAttachment("modal.json", modal)
+                .AddSerializedAttachment("guildApprovalModel.json", model));
+            await RespondAsync("Failed to save greeter configuration\n-# This error has been reported to the developers.");
+            return;
+        }
+        try
+        {
+            await RespondAsync("Successfully updated greeter configuration");
+        }
+        catch (Exception ex)
+        {
+            const string msg = "Failed to follow up to interaction!";
+            _log.Error(ex, msg);
+            await trans.RollbackAsync();
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes(msg)
+                .WithContext(Context)
+                .AddSerializedAttachment("modal.json", modal)
+                .AddSerializedAttachment("guildApprovalModel.json", model));
+        }
+    }
+    
+    [ModalInteraction("guild-approval-setup-greeter", runMode: RunMode.Async)]
+    public async Task HandleSetupGreeterModal(SetupGreeterModal modal)
+    {
+        _log.Trace("Handling modal...");
+        try
+        {
+            await DeferAsync();
+            await HandleSetupGreeterModalInternal(modal);
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex);
+        }
+    }
+
+    public class SetupGreeterModal : IModal
+    {
+        public string Title => "Approval - Setup Greeter";
+
+        [ModalTextDisplay(content: "Validation errors would go here, but there isn't anything here!")]
+        public string ValidationErrors { get; set; } = "Submit modal to check for any errors.";
+
+        [ModalSelectMenu("enable")]
+        [InputLabel("Enable", "Once the user is approved, a message similar in function to the greeter will be sent.")]
+        public ModalYesNo EnableGreeter { get; set; } = ModalYesNo.Yes;
+
+        [RequiredInput(false)]
+        [ModalChannelSelect("greeter-channel")]
+        [InputLabel("Channel", "Channel to greet new users once they've been approved. Required when Greeter is enabled")]
+        public ITextChannel? GreeterChannel { get; set; }
+        
+        [RequiredInput(false)]
+        [ModalTextInput("greeter-message", style: TextInputStyle.Paragraph)]
+        [InputLabel("Message Template", "Message template for when greeting approved users.")]
+        public string GreeterMessageTemplate { get; set; }= "Heya {user_mention}, welcome to {server_name}!";
+
+        [ModalSelectMenu("greeter-message-as-embed")]
+        [InputLabel("Greeter - Display as Embed", "Render the parsed greeter template as an embed, instead of a standard message.")]
+        public ModalYesNo GreeterAsEmbed { get; set; } = ModalYesNo.No;
+    }
+}

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalModule.cs
@@ -1,6 +1,5 @@
 using Discord;
 using Discord.Interactions;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
 using XeniaBot.Shared.Services;

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalModule.cs
@@ -1,0 +1,126 @@
+using Discord;
+using Discord.Interactions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Common.Services;
+using XeniaDiscord.Data;
+
+namespace XeniaDiscord.Interactions.Modules;
+
+[CommandContextType(InteractionContextType.Guild)]
+public class GuildApprovalModule : InteractionModuleBase
+{
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
+    private readonly XeniaDbContext _db;
+    private readonly ErrorReportService _err;
+    private readonly GuildApprovalService _service;
+    public GuildApprovalModule(IServiceProvider services)
+    {
+        _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
+        _err = services.GetRequiredService<ErrorReportService>();
+        _service = services.GetRequiredService<GuildApprovalService>();
+    }
+
+    [SlashCommand("approve", "Approve a user")]
+    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RequireBotPermission(GuildPermission.ManageRoles)]
+    public async Task ApproveUser(IGuildUser user)
+    {
+        await DeferAsync();
+        var embed = new EmbedBuilder()
+            .WithTitle("Approve User")
+            .WithColor(Color.Blue);
+        try
+        {
+            var guildIdStr = Context.Guild.Id.ToString();
+            var config = await _db.GuildApprovals.AsNoTracking().FirstOrDefaultAsync(e => e.GuildId == guildIdStr);
+
+            if (config == null)
+            {
+                embed.WithDescription($"Approval system has not been configured.").WithColor(Color.Red);
+                await FollowupAsync(embed: embed.Build());
+                return;
+            }
+            if (!config.Enabled)
+            {
+                embed.WithDescription("Approval system is not enabled.").WithColor(Color.Red);
+                await FollowupAsync(embed: embed.Build());
+                return;
+            }
+
+            var roleId = config.GetApprovedRoleId();
+            if (!roleId.HasValue)
+            {
+                embed.WithDescription("\"Approved Role\" has not been configured.").WithColor(Color.Red);
+                await FollowupAsync(embed: embed.Build());
+                return;
+            }
+            var role = await Context.Guild.GetRoleAsync(roleId.Value);
+            if (role == null)
+            {
+                embed.WithDescription($"Could not find role: `{roleId.Value}` <@&{roleId.Value}>").WithColor(Color.Red);
+                await FollowupAsync(embed: embed.Build());
+                return;
+            }
+
+            var targetFormatted = user.Username + (string.IsNullOrEmpty(user.Discriminator.Trim('0')?.Trim()) ? "" : $"#{user.Discriminator}");
+            var invokerFormatted = Context.User.Username + (string.IsNullOrEmpty(Context.User.Discriminator.Trim('0')?.Trim()) ? "" : $"#{Context.User.Discriminator}");
+            if (user.RoleIds.Contains(role.Id))
+            {
+                embed.WithDescription($"User already has been approved!\n-# user: `{targetFormatted}` ({user.Id})\n-# role: {role.Mention}")
+                .WithColor(Color.Orange);
+            }
+            else
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    try
+                    {
+                        await user.AddRoleAsync(role);
+                        break;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (!ex.ToString().ToLower().Contains("timed out"))
+                        {
+                            break;
+                        }
+                        else if (i == 2)
+                        {
+                            throw;
+                        }
+                    }
+                }
+                embed.WithDescription($"User {invokerFormatted} ({Context.User.Id})\nHas approved {user.Mention} ({targetFormatted}, {user.Id})")
+                .WithColor(Color.Green);
+            }
+            try
+            {
+                await _service.SendGreeterMessage(Context.Guild, user);
+            }
+            catch (Exception ex)
+            {
+                _log.Warn(ex, $"Failed to send greeter message for user \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{Context.Guild.Name}\" ({Context.Guild.Id})");
+            }
+            await FollowupAsync(embed: embed.Build());
+            return;
+        }
+        catch (Exception ex)
+        {
+            var errorType = $"{ex.GetType().Name}.{ex.GetType().Name}".Replace("`", "\\`");
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes($"Failed to approve user: {user.Username}#{user.Discriminator} ({user.Id})")
+                .WithContext(Context)
+                .WithUser(user));
+            
+            await FollowupAsync(embed:
+                embed.WithDescription(string.Join("\n", "Failed to add event to channel.", $"`{errorType}`"))
+                .WithColor(Color.Red)
+                .Build());
+        }
+    }
+
+}

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalModule.cs
@@ -34,78 +34,8 @@ public class GuildApprovalModule : InteractionModuleBase
             .WithColor(Color.Blue);
         try
         {
-            var guildIdStr = Context.Guild.Id.ToString();
-            var config = await _db.GuildApprovals.AsNoTracking().FirstOrDefaultAsync(e => e.GuildId == guildIdStr);
-
-            if (config == null)
-            {
-                embed.WithDescription($"Approval system has not been configured.").WithColor(Color.Red);
-                await FollowupAsync(embed: embed.Build());
-                return;
-            }
-            if (!config.Enabled)
-            {
-                embed.WithDescription("Approval system is not enabled.").WithColor(Color.Red);
-                await FollowupAsync(embed: embed.Build());
-                return;
-            }
-
-            var roleId = config.GetApprovedRoleId();
-            if (!roleId.HasValue)
-            {
-                embed.WithDescription("\"Approved Role\" has not been configured.").WithColor(Color.Red);
-                await FollowupAsync(embed: embed.Build());
-                return;
-            }
-            var role = await Context.Guild.GetRoleAsync(roleId.Value);
-            if (role == null)
-            {
-                embed.WithDescription($"Could not find role: `{roleId.Value}` <@&{roleId.Value}>").WithColor(Color.Red);
-                await FollowupAsync(embed: embed.Build());
-                return;
-            }
-
-            var targetFormatted = user.Username + (string.IsNullOrEmpty(user.Discriminator.Trim('0')?.Trim()) ? "" : $"#{user.Discriminator}");
-            var invokerFormatted = Context.User.Username + (string.IsNullOrEmpty(Context.User.Discriminator.Trim('0')?.Trim()) ? "" : $"#{Context.User.Discriminator}");
-            if (user.RoleIds.Contains(role.Id))
-            {
-                embed.WithDescription($"User already has been approved!\n-# user: `{targetFormatted}` ({user.Id})\n-# role: {role.Mention}")
-                .WithColor(Color.Orange);
-            }
-            else
-            {
-                for (int i = 0; i < 3; i++)
-                {
-                    try
-                    {
-                        await user.AddRoleAsync(role);
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        if (!ex.ToString().ToLower().Contains("timed out"))
-                        {
-                            break;
-                        }
-                        else if (i == 2)
-                        {
-                            throw;
-                        }
-                    }
-                }
-                embed.WithDescription($"User {invokerFormatted} ({Context.User.Id})\nHas approved {user.Mention} ({targetFormatted}, {user.Id})")
-                .WithColor(Color.Green);
-            }
-            try
-            {
-                await _service.SendGreeterMessage(Context.Guild, user);
-            }
-            catch (Exception ex)
-            {
-                _log.Warn(ex, $"Failed to send greeter message for user \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{Context.Guild.Name}\" ({Context.Guild.Id})");
-            }
+            embed = await _service.ApproveUserEmbed(user, Context.User, Context);
             await FollowupAsync(embed: embed.Build());
-            return;
         }
         catch (Exception ex)
         {

--- a/XeniaDiscord.Interactions/XeniaDiscordInteractions.cs
+++ b/XeniaDiscord.Interactions/XeniaDiscordInteractions.cs
@@ -11,6 +11,9 @@ public static class XeniaDiscordInteractions
         var transaction = SentryHelper.CreateTransaction();
         var types = new Type[]
         {
+            typeof(GuildApprovalModule),
+            typeof(GuildApprovalModalModule),
+            typeof(GuildApprovalAdminModule),
         };
         await Task.WhenAll(types.Select(type => interactions.AddModuleAsync(type, services)));
         transaction.Finish();


### PR DESCRIPTION
This PR adds all the required DB Models, Services, Repositories, and Discord.Net Modules for a basic-ish user approval system.

Minor issues that can be fixed easily later:
- `/approve` doesn't care if you have the "approver" role, and it only cares if you have the "Manage Roles" permission.
- There's only a modal for setting up the "approval greeter" settings, but not for the overall settings. Currently it's commented out since it needs some more work, and should be similar to how `/approval-admin setup-greeter` works.
- There's a command to enable this module (`/approval-admin enable`), but no disable command.
- There's no configuration in the web panel (will be done in a later PR)
- No documentation has been written in [XeniaBot-Website](https://github.com/ktwrd/XeniaBot-Website), but I plan to do that within the next few days.

This was really quickly put together, since [Auttaja](https://auttaja.io) has shut down, and a server I'm in had an approval system setup with it.