### PR TITLE
Refactor Statistics

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="IdGen" Version="3.0.7" />
     <PackageVersion Include="Iminetsoft.CronNET" Version="8.0.2" />
     <PackageVersion Include="kate.shared" Version="1.7.0" />
-    <PackageVersion Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.11.0" />
+    <PackageVersion Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.11.1" />
     <PackageVersion Include="Markdig" Version="1.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.5" />

--- a/XeniaBot.Shared/Services/DiscordService.cs
+++ b/XeniaBot.Shared/Services/DiscordService.cs
@@ -2,14 +2,10 @@
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
-using Prometheus;
 using System;
-using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using XeniaBot.Shared.Helpers;
 
-using Timer = System.Timers.Timer;
 using LogSeverity = Discord.LogSeverity;
 
 namespace XeniaBot.Shared.Services;
@@ -21,7 +17,6 @@ public class DiscordService
     private readonly DiscordSocketClient _client;
     private readonly ConfigData _configData;
     private readonly InteractionHandler? _interactionHandler;
-    private readonly PrometheusService _prom;
     private readonly ProgramDetails _details;
     public DiscordService(IServiceProvider services)
     {
@@ -39,171 +34,19 @@ public class DiscordService
             _interactionHandler = null;
         }
 
-        _prom = services.GetRequiredService<PrometheusService>();
-
-        // Prometheus Events
-        _prom.ServerStart += InitializeMetrics;
-        _client.SlashCommandExecuted += Event_SlashCommandExecuted_Prom;
-
         _client.Log += DiscordClientLogHandler;
-        _client.Ready += _client_Ready;
+        _client.Ready += OnClientReady;
+        _client.MessageReceived += async (arg) =>
+        {
+            MessageReceived?.Invoke(arg);
+        };
     }
 
     public async Task Run()
     {
-        _client.MessageReceived += (arg) =>
-        {
-            new Thread((ThreadStart)delegate
-            {
-                MessageReceived?.Invoke(arg);
-            }).Start();
-            return Task.CompletedTask;
-        };
-
         await _client.LoginAsync(TokenType.Bot, _configData.DiscordToken);
         await _client.StartAsync();
     }
-
-    #region Prometheus Metrics
-    private Gauge? _promCount_GuildCount = null;
-    private Gauge? _promCount_GuildUserCount = null;
-    private Counter? _promCount_InteractionCount = null;
-    private async Task InitializeMetrics()
-    {
-        if (!_configData.Prometheus.Enable)
-        {
-            Log.Warn("Ignoring, Prometheus Metrics are disabled");
-            return;
-        }
-        _promCount_GuildCount = _prom.CreateGauge(
-            "xenia_discord_guild_count",
-            "Amount of guilds this bot is in",
-            publish: false);
-        _promCount_GuildUserCount = _prom.CreateGauge(
-            "xenia_discord_guild_users",
-            "Amount of users per guild",
-            labelNames: new string[]
-            {
-                "guild_name",
-                "guild_id"
-            },
-            publish: false);
-        _promCount_InteractionCount = _prom.CreateCounter(
-            "xenia_discord_interaction_count",
-            "Interactions received",
-            labelNames: new string[]
-            {
-                "guild_name",
-                "guild_id",
-                "author_name",
-                "author_id",
-                "channel_name",
-                "channel_id",
-                "interaction_name",
-                "interaction_id"
-            },
-            publish: false);
-
-        // Once metrics are setup, reload discord-related metrics
-        await ReloadMetrics();
-        Log.Debug("Created all metrics!");
-        // Create timer
-        CreateMetricTimer();
-
-        _prom.ReloadMetrics += ReloadMetrics;
-    }
-
-    #region Metric Timer
-    /// <summary>
-    /// When to update metrics, measured in seconds.
-    /// </summary>
-    private const int MetricTimerInterval = 30;
-
-    private readonly Timer _metricTimer = new Timer(MetricTimerInterval);
-    private void CreateMetricTimer()
-    {
-        if (!_configData.Prometheus.Enable)
-            return;
-        
-        _metricTimer.AutoReset = true;
-        _metricTimer.Enabled = true;
-        _metricTimer.Elapsed += async (sender, args) =>
-        {
-            await ReloadMetrics();
-        };
-
-        _metricTimer.Start();
-    }
-    #endregion
-
-    #region Metrics (Triggered by Timer)
-    public async Task ReloadMetrics()
-    {
-        if (!_configData.Prometheus.Enable)
-            return;
-
-        var taskList = new List<Task>()
-        {
-            ReloadMetrics_GuildCountSlow()
-        };
-        await Task.WhenAll(taskList);
-    }
-    /// <summary>
-    /// Update <see cref="_promCount_GuildCount"/> and <see cref="_promCount_GuildUserCount"/>
-    /// </summary>
-    /// <exception cref="Exception">When <see cref="_promCount_GuildCount"/> or <see cref="_promCount_GuildUserCount"/> is null</exception>
-    private async Task ReloadMetrics_GuildCountSlow()
-    {
-        if (!_configData.Prometheus.Enable)
-            return;
-
-        if (_promCount_GuildCount == null)
-            throw new InvalidOperationException("InitializeMetrics not called, _promCount_GuildCount is null");
-        if (_promCount_GuildUserCount == null)
-            throw new InvalidOperationException("InitializeMetrics not called, _promCount_GuildUserCount is null");
-
-        var taskList = new List<Task>();
-        foreach (var guild in _client.Guilds)
-        {
-            taskList.Add(new Task(delegate
-            {
-                _promCount_GuildUserCount.WithLabels(
-                    guild.Name ?? "<None>",
-                    guild.Id.ToString()
-                ).Set(guild.Users.Count);
-            }));
-        }
-        await XeniaHelper.TaskWhenAll(taskList);
-        _promCount_GuildCount.Set(_client.Guilds.Count);
-    }
-    #endregion
-
-    #region Metrics (Triggered by Events)
-    private Task Event_SlashCommandExecuted_Prom(SocketSlashCommand interaction)
-    {
-        if (!_configData.Prometheus.Enable)
-            return Task.CompletedTask;
-        if (_details.Platform != XeniaPlatform.Bot)
-            return Task.CompletedTask;
-
-        if (_promCount_InteractionCount == null)
-            throw new InvalidOperationException("InitializeMetrics not called, _promCount_InteractionCount is null");
-        SocketGuild? guild =
-            interaction.GuildId == null ? null : _client.GetGuild(interaction.GuildId ?? 0);
-        _promCount_InteractionCount?.WithLabels(
-            guild?.Name ?? "<None>",
-            (guild?.Id ?? 0).ToString(),
-            $"{interaction.User.Username}#{interaction.User.Discriminator}",
-            interaction.User.Id.ToString(),
-            interaction.Channel.Id.ToString(),
-            interaction.Channel.Name,
-            interaction.Data.Name,
-            interaction.Data.Id.ToString()
-        ).Inc();
-        return Task.CompletedTask;
-    }
-    #endregion
-    #endregion
 
     #region Event Emit
     public event DiscordControllerDelegate? Ready;
@@ -221,7 +64,7 @@ public class DiscordService
     #endregion
 
     #region Event Handling
-    private async Task _client_Ready()
+    private async Task OnClientReady()
     {
         InvokeReady();
         if (_interactionHandler != null)
@@ -245,7 +88,6 @@ public class DiscordService
         {
             case LogSeverity.Debug:
             case LogSeverity.Verbose:
-                discordLog.Debug(arg.Exception, arg.Message);
                 discordLog.Debug(arg.Exception, arg.Message);
                 break;
             case LogSeverity.Info:

--- a/XeniaBot.Shared/Services/PrometheusService.cs
+++ b/XeniaBot.Shared/Services/PrometheusService.cs
@@ -5,111 +5,110 @@ using System;
 using System.Threading.Tasks;
 using XeniaBot.Shared.Helpers;
 
-namespace XeniaBot.Shared.Services
+namespace XeniaBot.Shared.Services;
+
+[XeniaController]
+public class PrometheusService : BaseService
 {
-    [XeniaController]
-    public class PrometheusService : BaseService
+    private static readonly Logger Log = LogManager.GetLogger("Xenia." + nameof(PrometheusService));
+    private readonly ConfigData _configData;
+    private readonly ProgramDetails _details;
+    protected Prometheus.KestrelMetricServer? Server { get; private set; }
+    public PrometheusService(IServiceProvider services)
+        : base(services)
     {
-        private static readonly Logger Log = LogManager.GetLogger("Xenia." + nameof(PrometheusService));
-        private ConfigData _configData;
-        private ProgramDetails _details;
-        protected Prometheus.KestrelMetricServer? Server { get; private set; }
-        public PrometheusService(IServiceProvider services)
-            : base(services)
-        {
-            _configData = services.GetRequiredService<ConfigData>();
-            _details = services.GetRequiredService<ProgramDetails>();
-            Server = new Prometheus.KestrelMetricServer(
-            hostname: _configData.Prometheus.Hostname,
-                port: _configData.Prometheus.Port,
-                 url: _configData.Prometheus.Url);
-        }
-        public event TaskDelegate? ServerStart;
-        public event TaskDelegate? ReloadMetrics;
-
-        public void OnReloadMetrics()
-        {
-            ReloadMetrics?.Invoke();
-        }
-        /// <summary>
-        /// Invoked when we want to start the server.
-        /// Ignored when <see cref="ProgramDetails.Platform"/> is <see cref="XeniaPlatform.WebPanel"/> or <see cref="PrometheusConfigItem.Enable"/> is `false`.
-        /// </summary>
-        private void OnServerStart()
-        {
-            if (_details.Platform == XeniaPlatform.WebPanel || !_configData.Prometheus.Enable)
-                return;
-            string address = _configData.Prometheus.Hostname;
-            if (address == "+")
-                address = "0.0.0.0";
-            Log.Info($"Available at http://{address}:{_configData.Prometheus.Port}{_configData.Prometheus.Url}");
-            ServerStart?.Invoke();
-        }
-
-        /// <summary>
-        /// Initialize Prometheus.
-        ///
-        /// Ignored when <see cref="ProgramDetails.Platform"/> is <see cref="XeniaPlatform.WebPanel"/> or <see cref="PrometheusConfigItem.Enable"/> is `false`.
-        /// </summary>
-        public override Task InitializeAsync()
-        {
-            if (!_configData.Prometheus.Enable || _details.Platform == XeniaPlatform.WebPanel)
-            {
-                Log.Debug("Prometheus Metrics is disabled");
-                return Task.CompletedTask;
-            }
-            Log.Debug($"Starting server");
-            Server?.Start();
-            OnServerStart();
-            return base.InitializeAsync();
-        }
-
-
-        #region MetricServer Wrapper Methods
-        public Counter CreateCounter(string name, string help, string[]? labelNames = null, CounterConfiguration? config = null, bool publish = false)
-        {
-            var c = Metrics.CreateCounter(
-                name,
-                help,
-                labelNames ?? Array.Empty<string>(),
-                config);
-            if (publish)
-                c.Publish();
-            return c;
-        }
-        public Gauge CreateGauge(string name, string help, string[]? labelNames = null, GaugeConfiguration? config = null, bool publish = false)
-        {
-            var g = Metrics.CreateGauge(
-                name, 
-                help,
-                labelNames ?? Array.Empty<string>(), 
-                config);
-            if (publish)
-                g.Publish();
-            return g;
-        }
-        public Summary CreateSummary(string name, string help, string[]? labelNames = null, SummaryConfiguration? config = null, bool publish = false)
-        {
-            var s = Metrics.CreateSummary(
-                name, 
-                help,
-                labelNames ?? Array.Empty<string>(), 
-                config);
-            if (publish)
-                s.Publish();
-            return s;
-        }
-        public Histogram CreateHistogram(string name, string help, string[]? labelNames = null, HistogramConfiguration? config = null, bool publish = false)
-        {
-            var h = Metrics.CreateHistogram(
-                name,
-                help,
-                labelNames ?? Array.Empty<string>(),
-                config);
-            if (publish)
-                h.Publish();
-            return h;
-        }
-        #endregion
+        _configData = services.GetRequiredService<ConfigData>();
+        _details = services.GetRequiredService<ProgramDetails>();
+        Server = new Prometheus.KestrelMetricServer(
+        hostname: _configData.Prometheus.Hostname,
+            port: _configData.Prometheus.Port,
+             url: _configData.Prometheus.Url);
     }
+    public event TaskDelegate? ServerStart;
+    public event TaskDelegate? ReloadMetrics;
+
+    public void OnReloadMetrics()
+    {
+        ReloadMetrics?.Invoke();
+    }
+    /// <summary>
+    /// Invoked when we want to start the server.
+    /// Ignored when <see cref="ProgramDetails.Platform"/> is <see cref="XeniaPlatform.WebPanel"/> or <see cref="PrometheusConfigItem.Enable"/> is `false`.
+    /// </summary>
+    private void OnServerStart()
+    {
+        if (_details.Platform != XeniaPlatform.Bot || !_configData.Prometheus.Enable)
+            return;
+        string address = _configData.Prometheus.Hostname;
+        if (address == "+" || address == "*")
+            address = "0.0.0.0";
+        Log.Info($"Available at http://{address}:{_configData.Prometheus.Port}{_configData.Prometheus.Url}");
+        ServerStart?.Invoke();
+    }
+
+    /// <summary>
+    /// Initialize Prometheus.
+    ///
+    /// Ignored when <see cref="ProgramDetails.Platform"/> is <see cref="XeniaPlatform.WebPanel"/> or <see cref="PrometheusConfigItem.Enable"/> is `false`.
+    /// </summary>
+    public override Task InitializeAsync()
+    {
+        if (!_configData.Prometheus.Enable || _details.Platform == XeniaPlatform.WebPanel)
+        {
+            Log.Debug("Prometheus Metrics is disabled");
+            return Task.CompletedTask;
+        }
+        Log.Debug($"Starting server");
+        Server?.Start();
+        OnServerStart();
+        return base.InitializeAsync();
+    }
+
+
+    #region MetricServer Wrapper Methods
+    public Counter CreateCounter(string name, string help, string[]? labelNames = null, CounterConfiguration? config = null, bool publish = false)
+    {
+        var c = Metrics.CreateCounter(
+            name,
+            help,
+            labelNames ?? Array.Empty<string>(),
+            config);
+        if (publish)
+            c.Publish();
+        return c;
+    }
+    public Gauge CreateGauge(string name, string help, string[]? labelNames = null, GaugeConfiguration? config = null, bool publish = false)
+    {
+        var g = Metrics.CreateGauge(
+            name,
+            help,
+            labelNames ?? Array.Empty<string>(),
+            config);
+        if (publish)
+            g.Publish();
+        return g;
+    }
+    public Summary CreateSummary(string name, string help, string[]? labelNames = null, SummaryConfiguration? config = null, bool publish = false)
+    {
+        var s = Metrics.CreateSummary(
+            name,
+            help,
+            labelNames ?? Array.Empty<string>(),
+            config);
+        if (publish)
+            s.Publish();
+        return s;
+    }
+    public Histogram CreateHistogram(string name, string help, string[]? labelNames = null, HistogramConfiguration? config = null, bool publish = false)
+    {
+        var h = Metrics.CreateHistogram(
+            name,
+            help,
+            labelNames ?? Array.Empty<string>(),
+            config);
+        if (publish)
+            h.Publish();
+        return h;
+    }
+    #endregion
 }

--- a/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
+++ b/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
@@ -217,7 +217,9 @@ public class DiscordStatisticsService : BaseService
         {
             ReloadMetrics_GuildCount(),
             ReloadMetrics_GuildChannels(),
-            ReloadMetrics_Channels()
+            ReloadMetrics_Channels(),
+
+            ReloadMetrics_BanSync()
         };
         await Task.WhenAll(taskList);
     }
@@ -233,16 +235,69 @@ public class DiscordStatisticsService : BaseService
         };
         await Task.WhenAll(tasks);
     }
-
-    private async Task ReloadMetrics_Channels()
+    private async Task ReloadMetrics_BanSync()
     {
         if (!_configData.Prometheus.Enable) return;
 
-        long count = (await _client.GetGroupChannelsAsync()).Count();
+        await Task.WhenAll(
+            PerformRecordsByGuild(),
+            PerformGuildsByState(),
+            PerformGuildSnapshots());
+
+        async Task PerformRecordsByGuild()
+        {
+            var recordByGuilds = await _db.BanSyncRecords
+                .Where(e => e.BanSyncGuild != null && e.BanSyncGuild.State == XeniaDiscord.Data.Models.BanSync.BanSyncGuildState.Active)
+                .GroupBy(e => e.GuildId)
+                .Select(e => new {
+                    GuildId = e.Key,
+                    Count = e.Count()
+                })
+                .ToListAsync();
+            var guildIds = recordByGuilds.Select(e => e.GuildId).Where(e => e != null).Distinct().ToList();
+            var guildSnapshots = await _db.GuildPartialSnapshots
+                .DistinctBy(e => e.GuildId)
+                .Where(e => guildIds.Contains(e.GuildId))
+                .Select(e => new { e.GuildId, e.Name })
+                .ToListAsync();
+            foreach (var group in recordByGuilds)
+            {
+                var name = guildSnapshots.FirstOrDefault(e => e.GuildId == group.GuildId)?.Name;
+                _statBanSyncRecords.WithLabels(group.GuildId, name ?? group.GuildId).Set(group.Count);
+            }
+        }
+        async Task PerformGuildsByState()
+        {
+            var guildsByState = await _db.BanSyncGuilds
+                .GroupBy(e => e.State)
+                .Select(e => new {
+                    State = e.Key,
+                    Count = e.Count()
+                })
+                .ToListAsync();
+            foreach (var group in guildsByState)
+            {
+                _statBanSyncGuilds.WithLabels(group.State.ToString()).Set(group.Count);
+            }
+        }
+        async Task PerformGuildSnapshots()
+        {
+            var guildSnapshotCount = await _db.BanSyncGuildSnapshots.LongCountAsync();
+            _statBanSyncGuildSnapshots.Set(guildSnapshotCount);
+        }
+    }
+    private Task ReloadMetrics_Channels()
+    {
+        if (!_configData.Prometheus.Enable) return Task.CompletedTask;
+
+        long count = 0;
+        count += _client.GroupChannels.Count;
         count += _client.PrivateChannels.Count;
         count += _client.Guilds.Select(e => e.Channels.Count).Sum();
 
         _statChannels.Set(count);
+
+        return Task.CompletedTask;
     }
     private async Task ReloadMetrics_GuildChannels()
     {

--- a/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
+++ b/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
@@ -1,0 +1,367 @@
+using Discord;
+using Discord.WebSocket;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using Prometheus;
+using XeniaBot.Shared;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Data;
+
+namespace XeniaDiscord.Common.Services;
+
+[XeniaController]
+public class DiscordStatisticsService : BaseService
+{
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+    private readonly DiscordSocketClient _client;
+    private readonly ConfigData _configData;
+    private readonly PrometheusService _prom;
+    private readonly ProgramDetails _details;
+    private readonly XeniaDbContext _db;
+    public DiscordStatisticsService(IServiceProvider services) : base(services)
+    {
+        _details = services.GetRequiredService<ProgramDetails>();
+
+        _configData = services.GetRequiredService<ConfigData>();
+        _client = services.GetRequiredService<DiscordSocketClient>();
+
+        _prom = services.GetRequiredService<PrometheusService>();
+        _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
+
+        // Prometheus Events
+        _prom.ServerStart += InitializePrometheus;
+        _prom.ReloadMetrics += ReloadMetrics;
+        if (_details.Platform == XeniaPlatform.Bot)
+        {
+            _client.MessageReceived += OnMessageReceived;
+            _client.SlashCommandExecuted += OnSlashCommandExecuted;
+        }
+        
+        _statGuilds = _prom.CreateGauge(
+            "xenia_discord_guild_count",
+            "Amount of guilds this bot is in",
+            publish: false);
+        _statGuildMemberCount = _prom.CreateGauge(
+            "xenia_discord_guild_users",
+            "Amount of users per guild",
+            labelNames: [
+                "guild_name",
+                "guild_id"
+            ],
+            publish: false);
+        _statDiscordLatency = _prom.CreateGauge(
+            "xenia_discord_latency",
+            "Latency (ms) to Discord",
+            labelNames: [
+                "user_id",
+                "username",
+                "global_name",
+                "connection_state"
+            ],
+            publish: false);
+        _statInteractions = _prom.CreateCounter(
+            "xenia_discord_interaction_count",
+            "Interactions received",
+            labelNames: [
+                "guild_name",
+                "guild_id",
+                "author_name",
+                "author_id",
+                "channel_name",
+                "channel_id",
+                "interaction_group",
+                "interaction_name",
+                "interaction_id",
+            ],
+            publish: false);
+        _statMessages = _prom.CreateCounter(
+            "xenia_discord_message_count",
+            "Messages received",
+            labelNames: [
+                "guild_id",
+                "guild_name",
+                "channel_id",
+                "channel_name",
+                "author_id",
+                "author_name"
+            ],
+            publish: false);
+    }
+
+    public override async Task InitializeAsync()
+    {
+        await InitializePrometheus();
+    }
+
+    private Task InitializePrometheus()
+    {
+        CreateCollectionThread();
+        return Task.CompletedTask;
+    }
+
+    private readonly Gauge _statGuilds;
+    private readonly Gauge _statGuildMemberCount;
+    private readonly Gauge _statDiscordLatency;
+    private readonly Counter _statInteractions;
+    private readonly Counter _statMessages;
+
+    #region Collection Thread
+    private bool CollectionThreadExists = false;
+    private void CreateCollectionThread()
+    {
+        if (CollectionThreadExists) return;
+        new Thread(() =>
+        {
+            CollectionThreadExists = true;
+            Log.Info("Created thread");
+            while (true)
+            {
+                try
+                {
+                    MetricCollectionThreadCallback().GetAwaiter().GetResult();
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Log.Warn(ex, $"Failed to call {nameof(MetricCollectionThreadCallback)}");
+                    Task.Delay(500).Wait();
+                }
+            }
+            CollectionThreadExists = false;
+        })
+        {
+            Name = $"{nameof(DiscordStatisticsService)}.MetricCollectionThread"
+        }.Start();
+    }
+    private async Task MetricCollectionThreadCallback()
+    {
+        int i = 1;
+        while (true)
+        {
+            if (_configData.Prometheus.Enable)
+            {
+                await ReloadMetricsFrequent();
+
+                if (i % 3 == 0)
+                {
+                    await ReloadMetricsSlow();
+                    if (i > 1000)
+                    {
+                        i = 1;
+                    }
+                }
+                await Task.Delay(5_000);
+            }
+            else
+            {
+                await Task.Delay(60_000);
+            }
+        }
+    }
+    #endregion
+
+    #region Reload Metrics
+    public async Task ReloadMetrics()
+    {
+        await Task.WhenAll(
+            ReloadMetricsSlow(),
+            ReloadMetricsFrequent()
+        );
+    }
+    /// <summary>
+    /// Called every 15s
+    /// </summary>
+    private async Task ReloadMetricsSlow()
+    {
+        if (!_configData.Prometheus.Enable) return;
+
+        var taskList = new[]
+        {
+            ReloadMetrics_GuildCount()
+        };
+        await Task.WhenAll(taskList);
+    }
+    /// <summary>
+    /// Called every 5s
+    /// </summary>
+    private async Task ReloadMetricsFrequent()
+    {
+        if (!_configData.Prometheus.Enable) return;
+        var tasks = new[]
+        {
+            ReloadMetrics_Latency()
+        };
+        await Task.WhenAll(tasks);
+    }
+    
+    /// <summary>
+    /// Update <see cref="_statGuilds"/> and <see cref="_statGuildMemberCount"/>
+    /// </summary>
+    private async Task ReloadMetrics_GuildCount()
+    {
+        if (!_configData.Prometheus.Enable) return;
+
+        await Task.WhenAll(_client.Guilds.Select(UpdateGuild));
+        _statGuilds.Set(_client.Guilds.Count);
+
+        async Task UpdateGuild(SocketGuild guild)
+        {
+            var guildIdStr = guild.Id.ToString();
+            var name = await _db.GuildPartialSnapshots.AsNoTracking()
+                .Where(e => e.GuildId == guildIdStr)
+                .OrderByDescending(e => e.Timestamp)
+                .Select(e => e.Name)
+                .FirstOrDefaultAsync();
+            _statGuildMemberCount.WithLabels(
+                guild.Name ?? name ?? guildIdStr,
+                guildIdStr
+            ).Set(guild.Users.Count);
+        }
+    }
+    private Task ReloadMetrics_Latency()
+    {
+        if (!_configData.Prometheus.Enable) return Task.CompletedTask;
+
+        var usernameFormatted = _client.CurrentUser.Username;
+        if (!string.IsNullOrEmpty(_client.CurrentUser.Discriminator.Trim('0')))
+            usernameFormatted += $"#{_client.CurrentUser.Discriminator}";
+        var displayName = usernameFormatted;
+        if (!string.IsNullOrEmpty(_client.CurrentUser.GlobalName))
+            displayName = _client.CurrentUser.GlobalName;
+
+        _statDiscordLatency.WithLabels(
+            _client.CurrentUser.Id.ToString(),
+            usernameFormatted,
+            displayName,
+            _client.ConnectionState.ToString()
+        ).Set(_client.Latency);
+        return Task.CompletedTask;
+    }
+    #endregion
+
+    private async Task OnSlashCommandExecuted(SocketSlashCommand interaction)
+    {
+        if (!_configData.Prometheus.Enable) return;
+        if (_details.Platform != XeniaPlatform.Bot) return;
+
+        SocketGuild? guild = interaction.GuildId.HasValue ? _client.GetGuild(interaction.GuildId.Value) : null;
+        var usernameFormatted = interaction.User.Username;
+        if (!string.IsNullOrEmpty(interaction.User.Discriminator?.Trim('0')))
+            usernameFormatted += $"#{interaction.User.Discriminator}";
+
+        var interactionName = interaction.Data.Name;
+        var interactionGroup = string.Empty;
+
+        if (interaction.Data is IApplicationCommandInteractionData data)
+        {
+            var any = false;
+            foreach (var opt in data.Options)
+            {
+                any = true;
+                interactionName += $" {opt.Name}";
+            }
+            if (any)
+            {
+                interactionGroup = data.Name;
+            }
+        }
+
+        _statInteractions.WithLabels(
+            guild?.Name ?? "<None>",
+            interaction.GuildId.GetValueOrDefault(0).ToString(),
+            usernameFormatted,
+            interaction.User.Id.ToString(),
+            interaction.Channel.Id.ToString(),
+            interaction.Channel.Name,
+            interactionGroup,
+            interactionName,
+            interaction.Data.Id.ToString()
+        ).Inc();
+
+        await using var trans = await _db.Database.BeginTransactionAsync();
+        try
+        {
+            var guildIdStr = guild?.Id.ToString();
+            var channelIdStr = interaction.ChannelId.ToString();
+            string authorIdStr = interaction.User.Id.ToString();
+            if (await _db.InteractionStatistics.AnyAsync(e
+                => e.InteractionGroup == interactionGroup
+                && e.InteractionName == interactionName
+                && e.GuildId == guildIdStr
+                && e.ChannelId == channelIdStr
+                && e.UserId == authorIdStr))
+            {
+                if (guildIdStr == null && channelIdStr == null)
+                {
+                    await _db.Database.ExecuteSqlAsync(
+                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {interactionGroup} AND \"InteractionName\" = {interactionName} AND \"GuildId\" IS NULL AND \"ChannelId\" IS NULL AND \"UserId\" = {authorIdStr};");
+                }
+                else if (guildIdStr == null && channelIdStr != null)
+                {
+                    await _db.Database.ExecuteSqlAsync(
+                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {interactionGroup} AND \"InteractionName\" = {interactionName} AND \"GuildId\" = {guildIdStr} AND \"ChannelId\" IS NULL AND \"UserId\" = {authorIdStr};");
+                }
+                else if (guildIdStr != null && channelIdStr == null)
+                {
+                    await _db.Database.ExecuteSqlAsync(
+                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {interactionGroup} AND \"InteractionName\" = {interactionName} AND \"GuildId\" IS NULL AND \"ChannelId\" = {channelIdStr} AND \"UserId\" = {authorIdStr};");
+                }
+                else
+                {
+                    await _db.Database.ExecuteSqlAsync(
+                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {interactionGroup} AND \"InteractionName\" = {interactionName} AND \"GuildId\" = {guildIdStr} AND \"ChannelId\" = {channelIdStr} AND \"UserId\" = {authorIdStr};");
+                }
+            }
+            else
+            {
+                await _db.InteractionStatistics.AddAsync(new Data.Models.InteractionStatisticModel()
+                {
+                    InteractionGroup = interactionGroup,
+                    InteractionName = interactionName,
+                    GuildId = guildIdStr,
+                    ChannelId = channelIdStr,
+                    UserId = authorIdStr,
+                    Count = 1
+                });
+            }
+            await _db.SaveChangesAsync();
+            await trans.CommitAsync();
+        }
+        catch
+        {
+            await trans.RollbackAsync();
+        }
+    }
+
+    private Task OnMessageReceived(SocketMessage message)
+    {
+
+        var usernameFormatted = message.Author.Username;
+        if (!string.IsNullOrEmpty(message.Author.Discriminator?.Trim('0')))
+            usernameFormatted += $"#{message.Author.Discriminator}";
+        var labels = new[]
+        {
+            string.Empty,                   // guild_id
+            string.Empty,                   // guild_name
+            string.Empty,                   // channel_id
+            string.Empty,                   // channel_name
+            message.Author.Id.ToString(),   // author_id
+            usernameFormatted               // author_name
+        };
+        if (message.Channel is SocketGuildChannel guildChannel)
+        {
+            labels[0] = guildChannel.Guild.Id.ToString();
+            labels[1] = guildChannel.Guild.Name;
+        }
+        if (message.Channel != null)
+        {
+            labels[2] = message.Channel.Id.ToString();
+            labels[3] = message.Channel.Name;
+        }
+
+        _statMessages.WithLabels(labels).Inc();
+
+        return Task.CompletedTask;
+    }
+}

--- a/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
+++ b/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
@@ -9,6 +9,7 @@ using XeniaBot.Shared;
 using XeniaBot.Shared.Helpers;
 using XeniaBot.Shared.Services;
 using XeniaDiscord.Data;
+using XeniaDiscord.Data.Models;
 using XeniaDiscord.Data.Models.BanSync;
 
 namespace XeniaDiscord.Common.Services;
@@ -588,7 +589,7 @@ public sealed class DiscordStatisticsService : BaseService
             }
             else
             {
-                await db.InteractionStatistics.AddAsync(new Data.Models.InteractionStatisticModel()
+                await db.InteractionStatistics.AddAsync(new InteractionStatisticModel()
                 {
                     InteractionGroup = info.InteractionGroup,
                     InteractionName = info.InteractionName,

--- a/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
+++ b/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
@@ -47,12 +47,17 @@ public class DiscordStatisticsService : BaseService
             "Amount of users per guild",
             labelNames: [
                 "guild_name",
-                "guild_id"
+                "guild_id",
             ],
             publish: false);
         _statGuildChannels = _prom.CreateGauge(
             "xenia_discord_guild_channel_count",
             "Amount of channels that Xenia is in (per guild)",
+            labelNames: [
+                "guild_name",
+                "guild_id",
+                "channel_type"
+            ],
             publish: false);
         _statChannels = _prom.CreateGauge(
             "xenia_discord_channels",
@@ -144,13 +149,13 @@ public class DiscordStatisticsService : BaseService
     private readonly Gauge _statBanSyncGuildSnapshots;
 
     #region Collection Thread
-    private bool CollectionThreadExists = false;
+    private bool _collectionThreadExists = false;
     private void CreateCollectionThread()
     {
-        if (CollectionThreadExists) return;
+        if (_collectionThreadExists) return;
         new Thread(() =>
         {
-            CollectionThreadExists = true;
+            _collectionThreadExists = true;
             Log.Info("Created thread");
             while (true)
             {
@@ -165,7 +170,7 @@ public class DiscordStatisticsService : BaseService
                     Task.Delay(500).Wait();
                 }
             }
-            CollectionThreadExists = false;
+            _collectionThreadExists = false;
         })
         {
             Name = $"{nameof(DiscordStatisticsService)}.MetricCollectionThread"
@@ -188,11 +193,16 @@ public class DiscordStatisticsService : BaseService
                         i = 1;
                     }
                 }
+                i++;
                 await Task.Delay(5_000);
             }
             else
             {
                 await Task.Delay(60_000);
+            }
+            if (!_collectionThreadExists)
+            {
+                break;
             }
         }
     }
@@ -246,7 +256,10 @@ public class DiscordStatisticsService : BaseService
 
         async Task PerformRecordsByGuild()
         {
-            var recordByGuilds = await _db.BanSyncRecords
+            await using var db = _db.CreateSession();
+            var recordByGuilds = await db.BanSyncRecords
+                .AsNoTracking()
+                .Include(e => e.BanSyncGuild)
                 .Where(e => e.BanSyncGuild != null && e.BanSyncGuild.State == XeniaDiscord.Data.Models.BanSync.BanSyncGuildState.Active)
                 .GroupBy(e => e.GuildId)
                 .Select(e => new {
@@ -254,9 +267,10 @@ public class DiscordStatisticsService : BaseService
                     Count = e.Count()
                 })
                 .ToListAsync();
-            var guildIds = recordByGuilds.Select(e => e.GuildId).Where(e => e != null).Distinct().ToList();
-            var guildSnapshots = await _db.GuildPartialSnapshots
-                .DistinctBy(e => e.GuildId)
+            var guildIds = recordByGuilds.Select(e => e.GuildId).Distinct().ToList();
+            var guildSnapshots = await db.GuildPartialSnapshots
+                .AsNoTracking()
+                .OrderByDescending(e => e.Timestamp)
                 .Where(e => guildIds.Contains(e.GuildId))
                 .Select(e => new { e.GuildId, e.Name })
                 .ToListAsync();
@@ -268,7 +282,9 @@ public class DiscordStatisticsService : BaseService
         }
         async Task PerformGuildsByState()
         {
-            var guildsByState = await _db.BanSyncGuilds
+            await using var db = _db.CreateSession();
+            var guildsByState = await db.BanSyncGuilds
+                .AsNoTracking()
                 .GroupBy(e => e.State)
                 .Select(e => new {
                     State = e.Key,
@@ -282,7 +298,8 @@ public class DiscordStatisticsService : BaseService
         }
         async Task PerformGuildSnapshots()
         {
-            var guildSnapshotCount = await _db.BanSyncGuildSnapshots.LongCountAsync();
+            await using var db = _db.CreateSession();
+            var guildSnapshotCount = await db.BanSyncGuildSnapshots.AsNoTracking().LongCountAsync();
             _statBanSyncGuildSnapshots.Set(guildSnapshotCount);
         }
     }
@@ -302,64 +319,65 @@ public class DiscordStatisticsService : BaseService
     private async Task ReloadMetrics_GuildChannels()
     {
         if (!_configData.Prometheus.Enable) return;
-
-        await Task.WhenAll(_client.Guilds.Select(UpdateGuild));
-
-        async Task UpdateGuild(SocketGuild guild)
+        
+        await using var db = _db.CreateSession();
+        foreach (var guild in _client.Guilds)
         {
             var guildIdStr = guild.Id.ToString();
-            var name = await _db.GuildPartialSnapshots.AsNoTracking()
+            var name = await db.GuildPartialSnapshots.AsNoTracking()
                 .Where(e => e.GuildId == guildIdStr)
                 .OrderByDescending(e => e.Timestamp)
                 .Select(e => e.Name)
                 .FirstOrDefaultAsync();
             var guildName = guild.Name ?? name ?? guildIdStr;
 
-            _statGuildMemberCount.WithLabels(
-                guildIdStr,
+            _statGuildChannels.WithLabels(
                 guildName,
+                guildIdStr,
                 "text"
             ).Set(guild.TextChannels.Count);
             _statGuildChannels.WithLabels(
-                guildIdStr,
                 guildName,
+                guildIdStr,
                 "stage"
                 ).Set(guild.StageChannels.Count);
             _statGuildChannels.WithLabels(
-                guildIdStr,
                 guildName,
+                guildIdStr,
                 "category"
                 ).Set(guild.CategoryChannels.Count);
             _statGuildChannels.WithLabels(
-                guildIdStr,
                 guildName,
+                guildIdStr,
                 "thread"
                 ).Set(guild.ThreadChannels.Count);
             _statGuildChannels.WithLabels(
-                guildIdStr,
                 guildName,
+                guildIdStr,
                 "forum"
                 ).Set(guild.ForumChannels.Count);
             _statGuildChannels.WithLabels(
-                guildIdStr,
                 guildName,
+                guildIdStr,
                 "media"
                 ).Set(guild.MediaChannels.Count);
             _statGuildChannels.WithLabels(
-                guildIdStr,
                 guildName,
+                guildIdStr,
                 "all"
                 ).Set(guild.Channels.Count);
-            var otherCount = guild.Channels.Count
-                - (guild.TextChannels.Count
-                 + guild.StageChannels.Count
-                 + guild.CategoryChannels.Count
-                 + guild.ThreadChannels.Count
-                 + guild.ForumChannels.Count
-                 + guild.MediaChannels.Count);
+            var allCh = guild.TextChannels.Select(e => e.Id)
+                .Concat(guild.StageChannels.Select(e => e.Id))
+                .Concat(guild.CategoryChannels.Select(e => e.Id))
+                .Concat(guild.ThreadChannels.Select(e => e.Id))
+                .Concat(guild.ForumChannels.Select(e => e.Id))
+                .Concat(guild.MediaChannels.Select(e => e.Id))
+                .Distinct()
+                .Count();
+            var otherCount = guild.Channels.Count - allCh;
             _statGuildChannels.WithLabels(
-                guildIdStr,
                 guildName,
+                guildIdStr,
                 "other"
                 ).Set(otherCount);
         }
@@ -372,40 +390,51 @@ public class DiscordStatisticsService : BaseService
     {
         if (!_configData.Prometheus.Enable) return;
 
-        await Task.WhenAll(_client.Guilds.Select(UpdateGuild));
+        foreach (var guild in _client.Guilds)
+        {
+            _statGuildMemberCount.WithLabels(
+                guild.Name,
+                guild.Id.ToString())
+                .Set(guild.Users.Count);
+        }
         _statGuilds.Set(_client.Guilds.Count);
 
-        async Task UpdateGuild(SocketGuild guild)
-        {
-            var guildIdStr = guild.Id.ToString();
-            var name = await _db.GuildPartialSnapshots.AsNoTracking()
-                .Where(e => e.GuildId == guildIdStr)
-                .OrderByDescending(e => e.Timestamp)
-                .Select(e => e.Name)
-                .FirstOrDefaultAsync();
-            _statGuildMemberCount.WithLabels(
-                guild.Name ?? name ?? guildIdStr,
-                guildIdStr
-            ).Set(guild.Users.Count);
-        }
+        Log.Trace("done");
     }
+    
+    private string[] _metricsLatencyStrings = [];
     private Task ReloadMetrics_Latency()
     {
         if (!_configData.Prometheus.Enable) return Task.CompletedTask;
 
-        var usernameFormatted = _client.CurrentUser.Username;
-        if (!string.IsNullOrEmpty(_client.CurrentUser.Discriminator.Trim('0')))
-            usernameFormatted += $"#{_client.CurrentUser.Discriminator}";
-        var displayName = usernameFormatted;
-        if (!string.IsNullOrEmpty(_client.CurrentUser.GlobalName))
-            displayName = _client.CurrentUser.GlobalName;
-
-        _statDiscordLatency.WithLabels(
-            _client.CurrentUser.Id.ToString(),
+        string usernameFormatted = "";
+        string displayName = "";
+        string userId = "";
+        var latency = _client.Latency;
+        if (_client.CurrentUser != null)
+        {
+            userId = _client.CurrentUser.Id.ToString();
+            usernameFormatted = _client.CurrentUser.Username;
+            if (!string.IsNullOrEmpty(_client.CurrentUser.Discriminator.Trim('0')))
+                usernameFormatted += $"#{_client.CurrentUser.Discriminator}";    
+            displayName = usernameFormatted;
+            if (!string.IsNullOrEmpty(_client.CurrentUser.GlobalName))
+                displayName = _client.CurrentUser.GlobalName;
+        }
+        
+        var connectionState = _client.ConnectionState.ToString();
+        if (_metricsLatencyStrings.Length == 4 &&
+            connectionState != _metricsLatencyStrings[3])
+        {
+            _statDiscordLatency.RemoveLabelled(_metricsLatencyStrings);
+        }
+        _metricsLatencyStrings = [
+            userId,
             usernameFormatted,
             displayName,
             _client.ConnectionState.ToString()
-        ).Set(_client.Latency);
+        ];
+        _statDiscordLatency.WithLabels(_metricsLatencyStrings).Set(latency);
         return Task.CompletedTask;
     }
     #endregion
@@ -425,7 +454,7 @@ public class DiscordStatisticsService : BaseService
         if (guildIdStr != null)
         {
             guildName = guild?.Name;
-            if (guildName != null)
+            if (guildName == null)
             {
                 guildName = await _db.GuildPartialSnapshots.AsNoTracking()
                     .Where(e => e.GuildId == guildIdStr)

--- a/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
+++ b/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Discord;
 using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
@@ -5,20 +6,29 @@ using Microsoft.Extensions.DependencyInjection;
 using NLog;
 using Prometheus;
 using XeniaBot.Shared;
+using XeniaBot.Shared.Helpers;
 using XeniaBot.Shared.Services;
 using XeniaDiscord.Data;
+using XeniaDiscord.Data.Models.BanSync;
 
 namespace XeniaDiscord.Common.Services;
 
 [XeniaController]
-public class DiscordStatisticsService : BaseService
+public sealed class DiscordStatisticsService : BaseService
 {
-    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
     private readonly DiscordSocketClient _client;
     private readonly ConfigData _configData;
     private readonly PrometheusService _prom;
     private readonly ProgramDetails _details;
     private readonly XeniaDbContext _db;
+    private readonly IServiceScope? _dbScope;
+    public void Shutdown()
+    {
+        _prom.ServerStart -= InitializePrometheus;
+        _prom.ReloadMetrics -= ReloadMetrics;
+        _dbScope?.Dispose();
+    }
     public DiscordStatisticsService(IServiceProvider services) : base(services)
     {
         _details = services.GetRequiredService<ProgramDetails>();
@@ -27,7 +37,7 @@ public class DiscordStatisticsService : BaseService
         _client = services.GetRequiredService<DiscordSocketClient>();
 
         _prom = services.GetRequiredService<PrometheusService>();
-        _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
+        _db = services.GetRequiredScopedService<XeniaDbContext>(out _dbScope);
 
         // Prometheus Events
         _prom.ServerStart += InitializePrometheus;
@@ -156,7 +166,7 @@ public class DiscordStatisticsService : BaseService
         new Thread(() =>
         {
             _collectionThreadExists = true;
-            Log.Info("Created thread");
+            _log.Info("Created thread");
             while (true)
             {
                 try
@@ -166,7 +176,7 @@ public class DiscordStatisticsService : BaseService
                 }
                 catch (Exception ex)
                 {
-                    Log.Warn(ex, $"Failed to call {nameof(MetricCollectionThreadCallback)}");
+                    _log.Warn(ex, $"Failed to call {nameof(MetricCollectionThreadCallback)}");
                     Task.Delay(500).Wait();
                 }
             }
@@ -245,22 +255,16 @@ public class DiscordStatisticsService : BaseService
         };
         await Task.WhenAll(tasks);
     }
-    private async Task ReloadMetrics_BanSync()
+    private async Task ReloadMetrics_BanSyncRecordsByGuild()
     {
-        if (!_configData.Prometheus.Enable) return;
-
-        await Task.WhenAll(
-            PerformRecordsByGuild(),
-            PerformGuildsByState(),
-            PerformGuildSnapshots());
-
-        async Task PerformRecordsByGuild()
+        using var trans = SentryHelper.CreateTransaction();
+        try
         {
             await using var db = _db.CreateSession();
             var recordByGuilds = await db.BanSyncRecords
                 .AsNoTracking()
                 .Include(e => e.BanSyncGuild)
-                .Where(e => e.BanSyncGuild != null && e.BanSyncGuild.State == XeniaDiscord.Data.Models.BanSync.BanSyncGuildState.Active)
+                .Where(e => e.BanSyncGuild != null && e.BanSyncGuild.State == BanSyncGuildState.Active)
                 .GroupBy(e => e.GuildId)
                 .Select(e => new {
                     GuildId = e.Key,
@@ -279,8 +283,19 @@ public class DiscordStatisticsService : BaseService
                 var name = guildSnapshots.FirstOrDefault(e => e.GuildId == group.GuildId)?.Name;
                 _statBanSyncRecords.WithLabels(group.GuildId, name ?? group.GuildId).Set(group.Count);
             }
+            trans.Finish();
         }
-        async Task PerformGuildsByState()
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to make metrics");
+            trans.Finish(ex);
+        }
+    }
+    
+    private async Task ReloadMetrics_BanSyncGuildsByState()
+    {
+        var trans = SentryHelper.CreateTransaction();
+        try
         {
             await using var db = _db.CreateSession();
             var guildsByState = await db.BanSyncGuilds
@@ -295,13 +310,38 @@ public class DiscordStatisticsService : BaseService
             {
                 _statBanSyncGuilds.WithLabels(group.State.ToString()).Set(group.Count);
             }
+            trans.Finish();
         }
-        async Task PerformGuildSnapshots()
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to make metrics");
+            trans.Finish(ex);
+        }
+    }
+    private async Task ReloadMetrics_BanSyncGuildSnapshots()
+    {
+        var trans = SentryHelper.CreateTransaction();
+        try
         {
             await using var db = _db.CreateSession();
             var guildSnapshotCount = await db.BanSyncGuildSnapshots.AsNoTracking().LongCountAsync();
             _statBanSyncGuildSnapshots.Set(guildSnapshotCount);
+            trans.Finish();
         }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to make metrics");
+            trans.Finish(ex);
+        }
+    }
+    private async Task ReloadMetrics_BanSync()
+    {
+        if (!_configData.Prometheus.Enable) return;
+
+        await Task.WhenAll(
+            ReloadMetrics_BanSyncRecordsByGuild(),
+            ReloadMetrics_BanSyncGuildsByState(),
+            ReloadMetrics_BanSyncGuildSnapshots());
     }
     private Task ReloadMetrics_Channels()
     {
@@ -319,87 +359,81 @@ public class DiscordStatisticsService : BaseService
     private async Task ReloadMetrics_GuildChannels()
     {
         if (!_configData.Prometheus.Enable) return;
-        
-        await using var db = _db.CreateSession();
-        foreach (var guild in _client.Guilds)
+        var trans = SentryHelper.CreateTransaction();
+        try
         {
-            var guildIdStr = guild.Id.ToString();
-            var name = await db.GuildPartialSnapshots.AsNoTracking()
-                .Where(e => e.GuildId == guildIdStr)
-                .OrderByDescending(e => e.Timestamp)
-                .Select(e => e.Name)
-                .FirstOrDefaultAsync();
-            var guildName = guild.Name ?? name ?? guildIdStr;
-
-            _statGuildChannels.WithLabels(
-                guildName,
-                guildIdStr,
-                "text"
-            ).Set(guild.TextChannels.Count);
-            _statGuildChannels.WithLabels(
-                guildName,
-                guildIdStr,
-                "stage"
-                ).Set(guild.StageChannels.Count);
-            _statGuildChannels.WithLabels(
-                guildName,
-                guildIdStr,
-                "category"
-                ).Set(guild.CategoryChannels.Count);
-            _statGuildChannels.WithLabels(
-                guildName,
-                guildIdStr,
-                "thread"
-                ).Set(guild.ThreadChannels.Count);
-            _statGuildChannels.WithLabels(
-                guildName,
-                guildIdStr,
-                "forum"
-                ).Set(guild.ForumChannels.Count);
-            _statGuildChannels.WithLabels(
-                guildName,
-                guildIdStr,
-                "media"
-                ).Set(guild.MediaChannels.Count);
-            _statGuildChannels.WithLabels(
-                guildName,
-                guildIdStr,
-                "all"
-                ).Set(guild.Channels.Count);
-            var allCh = guild.TextChannels.Select(e => e.Id)
-                .Concat(guild.StageChannels.Select(e => e.Id))
-                .Concat(guild.CategoryChannels.Select(e => e.Id))
-                .Concat(guild.ThreadChannels.Select(e => e.Id))
-                .Concat(guild.ForumChannels.Select(e => e.Id))
-                .Concat(guild.MediaChannels.Select(e => e.Id))
-                .Distinct()
-                .Count();
-            var otherCount = guild.Channels.Count - allCh;
-            _statGuildChannels.WithLabels(
-                guildName,
-                guildIdStr,
-                "other"
-                ).Set(otherCount);
+            await using var db = _db.CreateSession();
+            foreach (var guild in _client.Guilds)
+            {
+                var guildIdStr = guild.Id.ToString();
+                var name = await db.GuildPartialSnapshots.AsNoTracking()
+                    .Where(e => e.GuildId == guildIdStr)
+                    .OrderByDescending(e => e.Timestamp)
+                    .Select(e => e.Name)
+                    .FirstOrDefaultAsync();
+                var guildName = guild.Name ?? name ?? guildIdStr;
+                var groups = new (long Count, string Ident)[]
+                {
+                    (guild.TextChannels.Count, "text"),
+                    (guild.StageChannels.Count, "stage"),
+                    (guild.CategoryChannels.Count, "category"),
+                    (guild.ThreadChannels.Count, "thread"),
+                    (guild.ForumChannels.Count, "forum"),
+                    (guild.MediaChannels.Count, "media"),
+                    (guild.Channels.Count, "all"),
+                    (guild.Channels.Count, "other"),
+                };
+                groups[^1].Count = guild.TextChannels.Select(e => e.Id)
+                    .Concat(guild.StageChannels.Select(e => e.Id))
+                    .Concat(guild.CategoryChannels.Select(e => e.Id))
+                    .Concat(guild.ThreadChannels.Select(e => e.Id))
+                    .Concat(guild.ForumChannels.Select(e => e.Id))
+                    .Concat(guild.MediaChannels.Select(e => e.Id))
+                    .Distinct()
+                    .Count();
+                foreach (var (count, ident) in groups)
+                {
+                    _statGuildChannels.WithLabels(
+                        guildName,
+                        guildIdStr,
+                        ident).Set(count);
+                }
+            }
+            trans.Finish();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to make metrics");
+            trans.Finish(ex);
         }
     }
     
     /// <summary>
     /// Update <see cref="_statGuilds"/> and <see cref="_statGuildMemberCount"/>
     /// </summary>
-    private async Task ReloadMetrics_GuildCount()
+    private Task ReloadMetrics_GuildCount()
     {
-        if (!_configData.Prometheus.Enable) return;
+        if (!_configData.Prometheus.Enable) return Task.CompletedTask;
 
-        foreach (var guild in _client.Guilds)
+        var trans = SentryHelper.CreateTransaction();
+        try
         {
-            _statGuildMemberCount.WithLabels(
-                guild.Name,
-                guild.Id.ToString())
-                .Set(guild.Users.Count);
+            foreach (var guild in _client.Guilds)
+            {
+                _statGuildMemberCount.WithLabels(
+                        guild.Name,
+                        guild.Id.ToString())
+                    .Set(guild.Users.Count);
+            }
+            _statGuilds.Set(_client.Guilds.Count);
+            trans.Finish();
         }
-        _statGuilds.Set(_client.Guilds.Count);
-
-        Log.Trace("done");
+        catch (Exception ex)
+        {
+            _log.Error(ex, "Failed to make metrics");
+            trans.Finish(ex);
+        }
+        return Task.CompletedTask;
     }
     
     private string[] _metricsLatencyStrings = [];
@@ -407,9 +441,9 @@ public class DiscordStatisticsService : BaseService
     {
         if (!_configData.Prometheus.Enable) return Task.CompletedTask;
 
-        string usernameFormatted = "";
-        string displayName = "";
-        string userId = "";
+        var usernameFormatted = "";
+        var displayName = "";
+        var userId = "";
         var latency = _client.Latency;
         if (_client.CurrentUser != null)
         {
@@ -439,29 +473,34 @@ public class DiscordStatisticsService : BaseService
     }
     #endregion
 
-    private async Task OnSlashCommandExecuted(SocketSlashCommand interaction)
+    private sealed record SlashCommandInteractionInfo(
+        string? GuildName,
+        string? GuildId,
+        string? ChannelName,
+        string? ChannelId,
+        string AuthorUsername,
+        string AuthorId,
+        string? InteractionGroup,
+        string InteractionName,
+        string InteractionId);
+    
+    private async Task<SlashCommandInteractionInfo> GetInfo(SocketSlashCommand interaction)
     {
-        if (!_configData.Prometheus.Enable) return;
-        if (_details.Platform != XeniaPlatform.Bot) return;
-
-        SocketGuild? guild = interaction.GuildId.HasValue ? _client.GetGuild(interaction.GuildId.Value) : null;
+        var guild = interaction.GuildId.HasValue ? _client.GetGuild(interaction.GuildId.Value) : null;
         var usernameFormatted = interaction.User.Username;
         if (!string.IsNullOrEmpty(interaction.User.Discriminator?.Trim('0')))
             usernameFormatted += $"#{interaction.User.Discriminator}";
 
         var guildIdStr = interaction.GuildId?.ToString();
-        string? guildName = guildIdStr;
+        var guildName = guildIdStr;
         if (guildIdStr != null)
         {
-            guildName = guild?.Name;
-            if (guildName == null)
-            {
-                guildName = await _db.GuildPartialSnapshots.AsNoTracking()
+            guildName = guild?.Name
+                ?? await _db.GuildPartialSnapshots.AsNoTracking()
                     .Where(e => e.GuildId == guildIdStr)
                     .OrderByDescending(e => e.Timestamp)
                     .Select(e => e.Name)
                     .FirstOrDefaultAsync();
-            }
         }
 
         var channelIdStr = interaction.ChannelId?.ToString();
@@ -471,7 +510,7 @@ public class DiscordStatisticsService : BaseService
             channelName = interaction.Channel.Name;
         }
 
-        var interactionName = interaction.Data.Name;
+        var interactionNameBuilder = new StringBuilder(interaction.Data.Name);
         var interactionGroup = string.Empty;
 
         if (interaction.Data is IApplicationCommandInteractionData data)
@@ -480,71 +519,86 @@ public class DiscordStatisticsService : BaseService
             foreach (var opt in data.Options)
             {
                 any = true;
-                interactionName += $" {opt.Name}";
+                interactionNameBuilder.Append($" {opt.Name}");
             }
             if (any)
             {
                 interactionGroup = data.Name;
             }
         }
-
-        _statInteractions.WithLabels(
-            guildName ?? "",
-            guildIdStr ?? "",
+        
+        return new SlashCommandInteractionInfo(
+            guildName,
+            guildIdStr,
+            channelName,
+            channelIdStr,
             usernameFormatted,
             interaction.User.Id.ToString(),
-            channelName ?? "",
-            channelIdStr ?? "",
-            interactionGroup,
-            interactionName,
-            interaction.Data.Id.ToString()
+            string.IsNullOrEmpty(interactionGroup) ? null : interactionGroup,
+            interactionNameBuilder.ToString(),
+            interaction.Id.ToString());
+    }
+    private async Task OnSlashCommandExecutedThread(SocketSlashCommand interaction)
+    {
+        var info = await GetInfo(interaction);
+
+        _statInteractions.WithLabels(
+            info.GuildName ?? "",
+            info.GuildId ?? "",
+            info.AuthorUsername,
+            info.AuthorId,
+            info.ChannelName ?? "",
+            info.ChannelId ?? "",
+            info.InteractionGroup ?? "",
+            info.InteractionName,
+            info.InteractionId
         ).Inc();
 
-        await using var trans = await _db.Database.BeginTransactionAsync();
+        await using var db = _db.CreateSession();
+        await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
-            string authorIdStr = interaction.User.Id.ToString();
-            if (await _db.InteractionStatistics.AnyAsync(e
-                => e.InteractionGroup == interactionGroup
-                && e.InteractionName == interactionName
-                && e.GuildId == guildIdStr
-                && e.ChannelId == channelIdStr
-                && e.UserId == authorIdStr))
+            if (await db.InteractionStatistics.AnyAsync(e
+                => e.InteractionGroup == info.InteractionGroup
+                && e.InteractionName == info.InteractionName
+                && e.GuildId == info.GuildId
+                && e.ChannelId == info.ChannelId
+                && e.UserId == info.AuthorId))
             {
-                if (guildIdStr == null && channelIdStr == null)
+                if (info.GuildId == null && info.ChannelId == null)
                 {
-                    await _db.Database.ExecuteSqlAsync(
-                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {interactionGroup} AND \"InteractionName\" = {interactionName} AND \"GuildId\" IS NULL AND \"ChannelId\" IS NULL AND \"UserId\" = {authorIdStr};");
+                    await db.Database.ExecuteSqlAsync(
+                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {info.InteractionGroup} AND \"InteractionName\" = {info.InteractionName} AND \"GuildId\" IS NULL AND \"ChannelId\" IS NULL AND \"UserId\" = {info.AuthorId};");
                 }
-                else if (guildIdStr == null && channelIdStr != null)
+                else if (info.GuildId == null && info.ChannelId != null)
                 {
-                    await _db.Database.ExecuteSqlAsync(
-                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {interactionGroup} AND \"InteractionName\" = {interactionName} AND \"GuildId\" = {guildIdStr} AND \"ChannelId\" IS NULL AND \"UserId\" = {authorIdStr};");
+                    await db.Database.ExecuteSqlAsync(
+                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {info.InteractionGroup} AND \"InteractionName\" = {info.InteractionName} AND \"GuildId\" = {info.GuildId} AND \"ChannelId\" IS NULL AND \"UserId\" = {info.AuthorId};");
                 }
-                else if (guildIdStr != null && channelIdStr == null)
+                else if (info.GuildId != null && info.ChannelId == null)
                 {
-                    await _db.Database.ExecuteSqlAsync(
-                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {interactionGroup} AND \"InteractionName\" = {interactionName} AND \"GuildId\" IS NULL AND \"ChannelId\" = {channelIdStr} AND \"UserId\" = {authorIdStr};");
+                    await db.Database.ExecuteSqlAsync(
+                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {info.InteractionGroup} AND \"InteractionName\" = {info.InteractionName} AND \"GuildId\" IS NULL AND \"ChannelId\" = {info.ChannelId} AND \"UserId\" = {info.AuthorId};");
                 }
                 else
                 {
-                    await _db.Database.ExecuteSqlAsync(
-                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {interactionGroup} AND \"InteractionName\" = {interactionName} AND \"GuildId\" = {guildIdStr} AND \"ChannelId\" = {channelIdStr} AND \"UserId\" = {authorIdStr};");
+                    await db.Database.ExecuteSqlAsync(
+                        $"UPDATE public.\"Statistics_Interactions\" SET \"Count\" = \"Count\" + 1 WHERE \"InteractionGroup\" = {info.InteractionGroup} AND \"InteractionName\" = {info.InteractionName} AND \"GuildId\" = {info.GuildId} AND \"ChannelId\" = {info.ChannelId} AND \"UserId\" = {info.AuthorId};");
                 }
             }
             else
             {
-                await _db.InteractionStatistics.AddAsync(new Data.Models.InteractionStatisticModel()
+                await db.InteractionStatistics.AddAsync(new Data.Models.InteractionStatisticModel()
                 {
-                    InteractionGroup = interactionGroup,
-                    InteractionName = interactionName,
-                    GuildId = guildIdStr,
-                    ChannelId = channelIdStr,
-                    UserId = authorIdStr,
+                    InteractionGroup = info.InteractionGroup,
+                    InteractionName = info.InteractionName,
+                    GuildId = info.GuildId,
+                    ChannelId = info.ChannelId,
+                    UserId = info.AuthorId,
                     Count = 1
                 });
             }
-            await _db.SaveChangesAsync();
+            await db.SaveChangesAsync();
             await trans.CommitAsync();
         }
         catch
@@ -552,33 +606,63 @@ public class DiscordStatisticsService : BaseService
             await trans.RollbackAsync();
         }
     }
+    private Task OnSlashCommandExecuted(SocketSlashCommand interaction)
+    {
+        if (!_configData.Prometheus.Enable || _details.Platform != XeniaPlatform.Bot) return Task.CompletedTask;
+        var trans = SentryHelper.CreateTransaction();
+        new Thread(() =>
+        {
+            try
+            {
+                OnSlashCommandExecutedThread(interaction).GetAwaiter().GetResult();
+                trans.Finish();
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Failed to make metrics");
+                trans.Finish(ex);
+            }
+        }).Start();
+        return Task.CompletedTask;
+    }
 
     private Task OnMessageReceived(SocketMessage message)
     {
-        var usernameFormatted = message.Author.Username;
-        if (!string.IsNullOrEmpty(message.Author.Discriminator?.Trim('0')))
-            usernameFormatted += $"#{message.Author.Discriminator}";
-        var labels = new[]
+        if (!_configData.Prometheus.Enable || _details.Platform != XeniaPlatform.Bot) return Task.CompletedTask;
+        var trans = SentryHelper.CreateTransaction();
+        try
         {
-            string.Empty,                   // guild_id
-            string.Empty,                   // guild_name
-            string.Empty,                   // channel_id
-            string.Empty,                   // channel_name
-            message.Author.Id.ToString(),   // author_id
-            usernameFormatted               // author_name
-        };
-        if (message.Channel is SocketGuildChannel guildChannel)
-        {
-            labels[0] = guildChannel.Guild.Id.ToString();
-            labels[1] = guildChannel.Guild.Name;
-        }
-        if (message.Channel != null)
-        {
-            labels[2] = message.Channel.Id.ToString();
-            labels[3] = message.Channel.Name;
-        }
+            var usernameFormatted = message.Author.Username;
+            if (!string.IsNullOrEmpty(message.Author.Discriminator?.Trim('0')))
+                usernameFormatted += $"#{message.Author.Discriminator}";
+            var labels = new[]
+            {
+                string.Empty,                   // guild_id
+                string.Empty,                   // guild_name
+                string.Empty,                   // channel_id
+                string.Empty,                   // channel_name
+                message.Author.Id.ToString(),   // author_id
+                usernameFormatted               // author_name
+            };
+            if (message.Channel is SocketGuildChannel guildChannel)
+            {
+                labels[0] = guildChannel.Guild.Id.ToString();
+                labels[1] = guildChannel.Guild.Name;
+            }
+            if (message.Channel != null)
+            {
+                labels[2] = message.Channel.Id.ToString();
+                labels[3] = message.Channel.Name;
+            }
 
-        _statMessages.WithLabels(labels).Inc();
+            _statMessages.WithLabels(labels).Inc();
+            trans.Finish();
+        }
+        catch (Exception ex)
+        {
+            trans.Finish(ex);
+            _log.Error(ex, "Failed to make metrics");
+        }
 
         return Task.CompletedTask;
     }

--- a/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
+++ b/XeniaDiscord.Common/Services/DiscordStatisticsService.cs
@@ -50,6 +50,18 @@ public class DiscordStatisticsService : BaseService
                 "guild_id"
             ],
             publish: false);
+        _statGuildChannels = _prom.CreateGauge(
+            "xenia_discord_guild_channel_count",
+            "Amount of channels that Xenia is in (per guild)",
+            publish: false);
+        _statChannels = _prom.CreateGauge(
+            "xenia_discord_channels",
+            "Amount of channels that Xenia is in. Includes channels in guilds",
+            labelNames: [
+                "guild_name",
+                "guild_id"
+            ],
+            publish: false);
         _statDiscordLatency = _prom.CreateGauge(
             "xenia_discord_latency",
             "Latency (ms) to Discord",
@@ -87,6 +99,25 @@ public class DiscordStatisticsService : BaseService
                 "author_name"
             ],
             publish: false);
+        _statBanSyncRecords = _prom.CreateGauge(
+            "xenia_discord_bansync_records",
+            "BanSync Records",
+            labelNames: [
+                "guild_id",
+                "guild_name"
+            ],
+            publish: false);
+        _statBanSyncGuilds = _prom.CreateGauge(
+            "xenia_discord_bansync_guilds",
+            "BanSync Guilds",
+            labelNames: [
+                "state"
+            ],
+            publish: false);
+        _statBanSyncGuildSnapshots = _prom.CreateGauge(
+            "xenia_discord_bansync_guilds",
+            "BanSync Guild Snapshots",
+            publish: false);
     }
 
     public override async Task InitializeAsync()
@@ -102,9 +133,15 @@ public class DiscordStatisticsService : BaseService
 
     private readonly Gauge _statGuilds;
     private readonly Gauge _statGuildMemberCount;
+    private readonly Gauge _statGuildChannels;
+    private readonly Gauge _statChannels;
     private readonly Gauge _statDiscordLatency;
     private readonly Counter _statInteractions;
     private readonly Counter _statMessages;
+
+    private readonly Gauge _statBanSyncRecords;
+    private readonly Gauge _statBanSyncGuilds;
+    private readonly Gauge _statBanSyncGuildSnapshots;
 
     #region Collection Thread
     private bool CollectionThreadExists = false;
@@ -178,7 +215,9 @@ public class DiscordStatisticsService : BaseService
 
         var taskList = new[]
         {
-            ReloadMetrics_GuildCount()
+            ReloadMetrics_GuildCount(),
+            ReloadMetrics_GuildChannels(),
+            ReloadMetrics_Channels()
         };
         await Task.WhenAll(taskList);
     }
@@ -193,6 +232,82 @@ public class DiscordStatisticsService : BaseService
             ReloadMetrics_Latency()
         };
         await Task.WhenAll(tasks);
+    }
+
+    private async Task ReloadMetrics_Channels()
+    {
+        if (!_configData.Prometheus.Enable) return;
+
+        long count = (await _client.GetGroupChannelsAsync()).Count();
+        count += _client.PrivateChannels.Count;
+        count += _client.Guilds.Select(e => e.Channels.Count).Sum();
+
+        _statChannels.Set(count);
+    }
+    private async Task ReloadMetrics_GuildChannels()
+    {
+        if (!_configData.Prometheus.Enable) return;
+
+        await Task.WhenAll(_client.Guilds.Select(UpdateGuild));
+
+        async Task UpdateGuild(SocketGuild guild)
+        {
+            var guildIdStr = guild.Id.ToString();
+            var name = await _db.GuildPartialSnapshots.AsNoTracking()
+                .Where(e => e.GuildId == guildIdStr)
+                .OrderByDescending(e => e.Timestamp)
+                .Select(e => e.Name)
+                .FirstOrDefaultAsync();
+            var guildName = guild.Name ?? name ?? guildIdStr;
+
+            _statGuildMemberCount.WithLabels(
+                guildIdStr,
+                guildName,
+                "text"
+            ).Set(guild.TextChannels.Count);
+            _statGuildChannels.WithLabels(
+                guildIdStr,
+                guildName,
+                "stage"
+                ).Set(guild.StageChannels.Count);
+            _statGuildChannels.WithLabels(
+                guildIdStr,
+                guildName,
+                "category"
+                ).Set(guild.CategoryChannels.Count);
+            _statGuildChannels.WithLabels(
+                guildIdStr,
+                guildName,
+                "thread"
+                ).Set(guild.ThreadChannels.Count);
+            _statGuildChannels.WithLabels(
+                guildIdStr,
+                guildName,
+                "forum"
+                ).Set(guild.ForumChannels.Count);
+            _statGuildChannels.WithLabels(
+                guildIdStr,
+                guildName,
+                "media"
+                ).Set(guild.MediaChannels.Count);
+            _statGuildChannels.WithLabels(
+                guildIdStr,
+                guildName,
+                "all"
+                ).Set(guild.Channels.Count);
+            var otherCount = guild.Channels.Count
+                - (guild.TextChannels.Count
+                 + guild.StageChannels.Count
+                 + guild.CategoryChannels.Count
+                 + guild.ThreadChannels.Count
+                 + guild.ForumChannels.Count
+                 + guild.MediaChannels.Count);
+            _statGuildChannels.WithLabels(
+                guildIdStr,
+                guildName,
+                "other"
+                ).Set(otherCount);
+        }
     }
     
     /// <summary>
@@ -250,6 +365,28 @@ public class DiscordStatisticsService : BaseService
         if (!string.IsNullOrEmpty(interaction.User.Discriminator?.Trim('0')))
             usernameFormatted += $"#{interaction.User.Discriminator}";
 
+        var guildIdStr = interaction.GuildId?.ToString();
+        string? guildName = guildIdStr;
+        if (guildIdStr != null)
+        {
+            guildName = guild?.Name;
+            if (guildName != null)
+            {
+                guildName = await _db.GuildPartialSnapshots.AsNoTracking()
+                    .Where(e => e.GuildId == guildIdStr)
+                    .OrderByDescending(e => e.Timestamp)
+                    .Select(e => e.Name)
+                    .FirstOrDefaultAsync();
+            }
+        }
+
+        var channelIdStr = interaction.ChannelId?.ToString();
+        string? channelName = null;
+        if (channelIdStr != null && interaction.Channel != null)
+        {
+            channelName = interaction.Channel.Name;
+        }
+
         var interactionName = interaction.Data.Name;
         var interactionGroup = string.Empty;
 
@@ -268,12 +405,12 @@ public class DiscordStatisticsService : BaseService
         }
 
         _statInteractions.WithLabels(
-            guild?.Name ?? "<None>",
-            interaction.GuildId.GetValueOrDefault(0).ToString(),
+            guildName ?? "",
+            guildIdStr ?? "",
             usernameFormatted,
             interaction.User.Id.ToString(),
-            interaction.Channel.Id.ToString(),
-            interaction.Channel.Name,
+            channelName ?? "",
+            channelIdStr ?? "",
             interactionGroup,
             interactionName,
             interaction.Data.Id.ToString()
@@ -282,8 +419,6 @@ public class DiscordStatisticsService : BaseService
         await using var trans = await _db.Database.BeginTransactionAsync();
         try
         {
-            var guildIdStr = guild?.Id.ToString();
-            var channelIdStr = interaction.ChannelId.ToString();
             string authorIdStr = interaction.User.Id.ToString();
             if (await _db.InteractionStatistics.AnyAsync(e
                 => e.InteractionGroup == interactionGroup
@@ -336,7 +471,6 @@ public class DiscordStatisticsService : BaseService
 
     private Task OnMessageReceived(SocketMessage message)
     {
-
         var usernameFormatted = message.Author.Username;
         if (!string.IsNullOrEmpty(message.Author.Discriminator?.Trim('0')))
             usernameFormatted += $"#{message.Author.Discriminator}";

--- a/XeniaDiscord.Common/XeniaDiscordCommon.cs
+++ b/XeniaDiscord.Common/XeniaDiscordCommon.cs
@@ -13,6 +13,7 @@ public static class XeniaDiscordCommon
     {
         services.AddSingleton<BanSyncService>()
                 .AddSingleton<ValidationService>()
+                .AddSingleton<DiscordStatisticsService>()
                 .AddSingleton<DiscordCacheEventHandler>();
 
         RegisterMappers(services);

--- a/XeniaDiscord.Data/DbGlobals.cs
+++ b/XeniaDiscord.Data/DbGlobals.cs
@@ -3,4 +3,9 @@
 public static class DbGlobals
 {
     public const int ulongMaxLength = 40;
+    public class MaxLength
+    {
+        public const int DiscordUsername = 50;
+        public const int DiscordDiscriminator = 8;
+    }
 }

--- a/XeniaDiscord.Data/Migrations/20260403074840_Create_InteractionStatisticModel.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260403074840_Create_InteractionStatisticModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403074840_Create_InteractionStatisticModel")]
+    partial class Create_InteractionStatisticModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260403074840_Create_InteractionStatisticModel.cs
+++ b/XeniaDiscord.Data/Migrations/20260403074840_Create_InteractionStatisticModel.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Create_InteractionStatisticModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Statistics_Interactions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    InteractionGroup = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    InteractionName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    UserId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    ChannelId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    GuildId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    Count = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Statistics_Interactions", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Statistics_Interactions_InteractionGroup_InteractionName_Gu~",
+                table: "Statistics_Interactions",
+                columns: new[] { "InteractionGroup", "InteractionName", "GuildId", "ChannelId", "UserId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Statistics_Interactions");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Models/InteractionStatisticModel.cs
+++ b/XeniaDiscord.Data/Models/InteractionStatisticModel.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace XeniaDiscord.Data.Models;
+
+public class InteractionStatisticModel
+{
+    public const string TableName = "Statistics_Interactions";
+
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Interaction group (first name when there is more than one)
+    /// </summary>
+    [MaxLength(200)]
+    public string? InteractionGroup { get; set; }
+
+    /// <summary>
+    /// Interaction name
+    /// </summary>
+    [MaxLength(200)]
+    public string InteractionName { get; set; } = "";
+
+    /// <summary>
+    /// User Id (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string UserId { get; set; } = "0";
+
+    /// <summary>
+    /// Channel Id (ulong as string, optional)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? ChannelId { get; set; }
+
+    /// <summary>
+    /// Guild Id (ulong as string, optional)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? GuildId { get; set; }
+
+    /// <summary>
+    /// Amount of times the interaction has been used.
+    /// </summary>
+    public long Count { get; set; }
+
+    public ulong GetUserId() => UserId.ParseRequiredULong(nameof(UserId), false);
+    public ulong? GetChannelId() => ChannelId.ParseULong(false);
+    public ulong? GetGuildId() => GuildId.ParseULong(false);
+}

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -173,6 +173,7 @@ public class XeniaDbContext : DbContext
                 e.InteractionGroup,
                 e.InteractionName,
                 e.GuildId,
+                e.ChannelId,
                 e.UserId
             });
         });

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using XeniaDiscord.Data.Extensions;
+using XeniaDiscord.Data.Models;
 using XeniaDiscord.Data.Models.BanSync;
 using XeniaDiscord.Data.Models.Cache;
 using XeniaDiscord.Data.Models.GuildApproval;
@@ -37,6 +38,8 @@ public class XeniaDbContext : DbContext
 
     public DbSet<GuildApprovalModel> GuildApprovals { get; set; }
     public DbSet<GuildApprovalLogEventModel> GuildApprovalLogEvents { get; set; }
+
+    public DbSet<InteractionStatisticModel> InteractionStatistics { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -160,6 +163,20 @@ public class XeniaDbContext : DbContext
                 e.UserId
             });
         });
+
+        #region Statistics
+        builder.Entity<InteractionStatisticModel>(b =>
+        {
+            b.ToTable(InteractionStatisticModel.TableName).HasKey(e => e.Id);
+            b.HasIndex(e => new
+            {
+                e.InteractionGroup,
+                e.InteractionName,
+                e.GuildId,
+                e.UserId
+            });
+        });
+        #endregion
 
         builder.HasDbFunction(typeof(XeniaDbContext).GetMethod(nameof(spBanSyncGetMutualRecordsForGuild), [typeof(string)]))
             .HasName("spBanSyncGetMutualRecordsForGuild");

--- a/force-clean.sh
+++ b/force-clean.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -xeo -u pipefail
+
+for d in ./*/
+do
+    d=${d%*/}
+    if [ -d "$d/obj" ]; then
+        /bin/rm -rf "$d/obj"
+    fi
+    if [ -d "$d/bin" ]; then
+        /bin/rm -rf "$d/bin"
+    fi
+done


### PR DESCRIPTION
Added/Updated the following prometheus metrics:
```
# HELP xenia_discord_guild_count Amount of guilds this bot is in
# TYPE xenia_discord_guild_count gauge

# HELP xenia_discord_guild_users Amount of users per guild
# TYPE xenia_discord_guild_users gauge

# HELP xenia_discord_guild_channel_count Amount of channels that Xenia is in (per guild)
# TYPE xenia_discord_guild_channel_count gauge

# HELP xenia_discord_channels Amount of channels that Xenia is in. Includes channels in guilds
# TYPE xenia_discord_channels gauge

# HELP xenia_discord_latency Latency (ms) to Discord
# TYPE xenia_discord_latency gauge

# HELP xenia_discord_interaction_count Interactions received
# TYPE xenia_discord_interaction_count counter

# HELP xenia_discord_message_count Messages received
# TYPE xenia_discord_message_count counter

# HELP xenia_discord_bansync_records BanSync Records
# TYPE xenia_discord_bansync_records gauge

# HELP xenia_discord_bansync_guilds BanSync Guilds
# TYPE xenia_discord_bansync_guilds gauge
```

Metrics are also stored in the database (but only for interactions)