### PR TITLE
[feat] Role Preserve: Ignored/Blacklisted Roles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -86,3 +86,8 @@ tab_width = 2
 indent_style = space
 indent_size = 2
 tab_width = 4
+
+[*.json]
+indent_style = space
+indent_size = 2
+tab_width = 2

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Iminetsoft.CronNET" Version="8.0.2" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="kate.shared" Version="1.7.0" />
-    <PackageVersion Include="Magick.NET-Q16-HDRI-x64" Version="14.13.0" />
+    <PackageVersion Include="Magick.NET-Q16-HDRI-x64" Version="14.13.1" />
     <PackageVersion Include="Markdig" Version="1.2.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,22 +8,22 @@
     <PackageVersion Include="CSharpFunctionalExtensions" Version="3.7.0" />
     <PackageVersion Include="DiffPlex" Version="1.9.0" />
     <PackageVersion Include="Discord.Net" Version="3.19.1" />
-    <PackageVersion Include="FastCloner" Version="3.5.2" />
+    <PackageVersion Include="FastCloner" Version="3.5.5" />
     <PackageVersion Include="Google.Cloud.Translation.V2" Version="3.5.0" />
     <PackageVersion Include="Humanizer" Version="3.0.10" />
     <PackageVersion Include="IdGen" Version="3.0.7" />
     <PackageVersion Include="Iminetsoft.CronNET" Version="8.0.2" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="kate.shared" Version="1.7.0" />
-    <PackageVersion Include="Markdig" Version="1.1.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.IdentityModel.Logging" Version="8.16.0" />
     <PackageVersion Include="Magick.NET-Q16-HDRI-x64" Version="14.13.0" />
+    <PackageVersion Include="Markdig" Version="1.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.IdentityModel.Logging" Version="8.18.0" />
     <PackageVersion Include="MimeTypesMap" Version="1.0.9" />
     <PackageVersion Include="MongoDB.Bson" Version="3.3.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.3.0" />
@@ -32,14 +32,14 @@
     <PackageVersion Include="NetVips.Extensions" Version="3.2.0" />
     <PackageVersion Include="NetVips.Native.linux-x64" Version="8.16.1" />
     <PackageVersion Include="NetVips.Native.win-x64" Version="8.16.1" />
-    <PackageVersion Include="NLog" Version="6.1.1" />
-    <PackageVersion Include="NLog.Web.AspNetCore" Version="6.1.2" />
+    <PackageVersion Include="NLog" Version="6.1.3" />
+    <PackageVersion Include="NLog.Web.AspNetCore" Version="6.1.3" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageVersion Include="Sentry" Version="6.2.0" />
-    <PackageVersion Include="Sentry.AspNetCore" Version="6.2.0" />
-    <PackageVersion Include="Sentry.NLog" Version="6.2.0" />
+    <PackageVersion Include="Sentry" Version="6.5.0" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.5.0" />
+    <PackageVersion Include="Sentry.NLog" Version="6.5.0" />
     <PackageVersion Include="System.Resources.Extensions" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AspNet.Security.OAuth.Discord" Version="10.0.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="CSharpFunctionalExtensions" Version="3.7.0" />
     <PackageVersion Include="DiffPlex" Version="1.9.0" />
     <PackageVersion Include="Discord.Net" Version="3.19.1" />
@@ -28,6 +29,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.IdentityModel.Logging" Version="8.18.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="MimeTypesMap" Version="1.0.9" />
     <PackageVersion Include="MongoDB.Bson" Version="3.3.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.3.0" />
@@ -38,6 +40,9 @@
     <PackageVersion Include="NetVips.Native.win-x64" Version="8.16.1" />
     <PackageVersion Include="NLog" Version="6.1.3" />
     <PackageVersion Include="NLog.Web.AspNetCore" Version="6.1.3" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.7.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="prometheus-net" Version="8.2.1" />
     <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="Humanizer" Version="3.0.10" />
     <PackageVersion Include="IdGen" Version="3.0.7" />
     <PackageVersion Include="Iminetsoft.CronNET" Version="8.0.2" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="kate.shared" Version="1.7.0" />
     <PackageVersion Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.11.1" />
     <PackageVersion Include="Markdig" Version="1.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,5 +46,6 @@
     <PackageVersion Include="Sentry.NLog" Version="6.5.0" />
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="System.Resources.Extensions" Version="10.0.3" />
+    <PackageVersion Include="Wacton.Unicolour" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,6 +44,7 @@
     <PackageVersion Include="Sentry" Version="6.5.0" />
     <PackageVersion Include="Sentry.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Sentry.NLog" Version="6.5.0" />
+    <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="System.Resources.Extensions" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,6 @@
     <PackageVersion Include="Iminetsoft.CronNET" Version="8.0.2" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="kate.shared" Version="1.7.0" />
-    <PackageVersion Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.11.1" />
     <PackageVersion Include="Markdig" Version="1.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.5" />
@@ -24,6 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.IdentityModel.Logging" Version="8.16.0" />
+    <PackageVersion Include="Magick.NET-Q16-HDRI-x64" Version="14.13.0" />
     <PackageVersion Include="MimeTypesMap" Version="1.0.9" />
     <PackageVersion Include="MongoDB.Bson" Version="3.3.0" />
     <PackageVersion Include="MongoDB.Driver" Version="3.3.0" />

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -19,6 +19,7 @@ namespace XeniaBot.Core.Modules;
 [Group("rolepreserve", "Configure the RolePreserve module.")]
 [RequireBotPermission(GuildPermission.ManageRoles | GuildPermission.ModerateMembers)]
 [CommandContextType(InteractionContextType.Guild)]
+[UsedImplicitly]
 public class RolePreserveModule : InteractionModuleBase
 {
     private readonly Logger _log = LogManager.GetCurrentClassLogger();
@@ -31,9 +32,11 @@ public class RolePreserveModule : InteractionModuleBase
         _repo = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveGuildRepository>();
         _error = services.GetRequiredService<ErrorReportService>();
     }
+
     [SlashCommand("enable", "Grant members preserved roles on re-join.")]
     [RequireUserPermission(GuildPermission.ManageGuild)]
     [RegisterDBLCommand]
+    [UsedImplicitly]
     public async Task Enable()
     {
         await DeferAsync();
@@ -51,7 +54,7 @@ public class RolePreserveModule : InteractionModuleBase
             await trans.CommitAsync();
             
             await FollowupAsync(embed: new EmbedBuilder()
-                .WithTitle("Role Preserve")
+                .WithTitle("Role Preserve - Enable")
                 .WithDescription("Roles will now be granted to members when they re-join (if Xenia can grant those roles)")
                 .WithColor(Color.Blue)
                 .Build());
@@ -62,16 +65,20 @@ public class RolePreserveModule : InteractionModuleBase
             await FollowupAsync(embed: new EmbedBuilder()
                 .WithTitle("Role Preserve - Failed to Enable")
                 .WithDescription("Failed to enable Role Preserve feature")
-                .AddField("Message", ex.Message[..Math.Min(1024, ex.Message.Length)])
+                .AddField("Error", ex.Message[..Math.Min(1024, ex.Message.Length)])
                 .WithColor(Color.Red)
                 .Build());
-            await DiscordHelper.ReportError(ex, Context);
+            await _error.Submit(new ErrorReportBuilder()
+                .WithNotes("Failed to enable role preservation")
+                .WithContext(Context)
+                .WithException(ex));
         }
     }
 
     [SlashCommand("disable", "Disable Role Preservation feature.")]
     [RequireUserPermission(GuildPermission.ManageGuild)]
     [RegisterDBLCommand]
+    [UsedImplicitly]
     public async Task Disable()
     {
         await DeferAsync();
@@ -89,7 +96,7 @@ public class RolePreserveModule : InteractionModuleBase
             await trans.CommitAsync();
             
             await FollowupAsync(embed: new EmbedBuilder()
-                .WithTitle("Role Preserve")
+                .WithTitle("Role Preserve - Disable")
                 .WithDescription("Xenia will continue to track member roles, but they will not be granted when someone re-joins.")
                 .WithColor(Color.Blue)
                 .Build());
@@ -100,49 +107,23 @@ public class RolePreserveModule : InteractionModuleBase
             await FollowupAsync(embed: new EmbedBuilder()
                 .WithTitle("Role Preserve - Failed to Disable")
                 .WithDescription("Failed to disable Role Preserve feature")
-                .AddField("Message", ex.Message[..Math.Min(1024, ex.Message.Length)])
+                .AddField("Error", ex.Message[..Math.Min(1024, ex.Message.Length)])
                 .WithColor(Color.Red)
                 .Build());
-            await DiscordHelper.ReportError(ex, Context);
+            await _error.Submit(new ErrorReportBuilder()
+                .WithNotes("Failed to disable role preservation")
+                .WithContext(Context)
+                .WithException(ex));
         }
     }
-
-    [SlashCommand("ignore", "Add/Remove/List Ignored Roles")]
+    
+    [SlashCommand("blacklist-add", "Add a role to be ignored with role preservation")]
     [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RequireBotPermission(GuildPermission.ManageRoles | GuildPermission.ModerateMembers)]
     [RegisterDBLCommand]
-    public async Task Blacklist(
-        BlacklistAction action,
-        IRole? role = null)
-    {
-        if (action == BlacklistAction.Add && role == null)
-        {
-            await RespondAsync("Target role (`role`) is required when adding a role to the blacklist.");
-            return;
-        }
-        if (action == BlacklistAction.Remove && role == null)
-        {
-            await RespondAsync("Target role (`role`) is required when removing a role from the blacklist.");
-            return;
-        }
-
-
-        await DeferAsync();
-        switch (action)
-        {
-            case BlacklistAction.Add:
-                await BlacklistAdd(role);
-                break;
-            case BlacklistAction.Remove:
-                await BlacklistRemove(role);
-                break;
-            case BlacklistAction.List:
-                await BlacklistList(role);
-                break;
-        }
-    }
-
-    private async Task BlacklistAdd(
-        [NotNull] IRole role)
+    [UsedImplicitly]
+    public async Task BlacklistAdd(
+        IRole role)
     {
         const string title = "Role Preserve - Add to blacklist";
         await using var db = _db.CreateSession();
@@ -208,9 +189,12 @@ public class RolePreserveModule : InteractionModuleBase
                 .Build());
         }
     }
-
-    private async Task BlacklistRemove(
-        [NotNull] IRole role)
+    [SlashCommand("blacklist-add", "Remove a ignored/blacklisted role")]
+    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RequireBotPermission(GuildPermission.ManageRoles | GuildPermission.ModerateMembers)]
+    [RegisterDBLCommand]
+    [UsedImplicitly]
+    public async Task BlacklistRemove(IRole role)
     {
         const string title = "Role Preserve - Remove from blacklist";
         await using var db = _db.CreateSession();
@@ -246,7 +230,7 @@ public class RolePreserveModule : InteractionModuleBase
                          .WithColor(Color.Green);
                     break;
                 case RolePreserveGuildRepository.RoleBlacklistRemoveResult.NotFound:
-                    embed.WithDescription($"Role is not blacklisted: {role.Id}")
+                    embed.WithDescription($"Role is not blacklisted: <@&{role.Id}>")
                          .WithColor(Color.Orange);
                     break;
                 default:
@@ -274,44 +258,124 @@ public class RolePreserveModule : InteractionModuleBase
         }
     }
 
-    private async Task BlacklistList(
-        IRole? role)
+    [SlashCommand("blacklist", "List ignored/blacklisted roles")]
+    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RegisterDBLCommand]
+    [UsedImplicitly]
+    public async Task BlacklistList(int page = 1)
     {
-        var embed = await ListEmbed(Context.Guild);
-        throw new NotImplementedException(
-            "List roles (basic), and implement pagination. Should only show 15 roles per page, and it should have a CSV export function. " +
-            "Data should be fetched with XeniaDiscord.Data.Repositories.RolePreserveGuildRepository.GetBlacklistRolesForGuild(XeniaDbContext, ulong)");
+        await DeferAsync();
+        var (embed, components) = await ListEmbed(Context.Guild, page);
+        await FollowupAsync(
+            embed: embed.Build(),
+            components: components.Build());
+        // throw new NotImplementedException(
+        //     "List roles (basic), and implement pagination. Should only show 15 roles per page, and it should have a CSV export function. " +
+        //     "Data should be fetched with XeniaDiscord.Data.Repositories.RolePreserveGuildRepository.GetBlacklistRolesForGuild(XeniaDbContext, ulong)");
     }
 
-    private async Task<EmbedBuilder> ListEmbed(
+    private sealed record ListEmbedResult(EmbedBuilder Embed, ComponentBuilderV2 ComponentBuilder);
+    private async Task<ListEmbedResult> ListEmbed(
         IGuild guild,
         int page = 1)
     {
-        page = int.Max(1, page);
         const int pageSize = 10;
-        var guildIdStr = guild.Id.ToString();
-        await using var db = _db.CreateSession();
+        const string emptyPageMessageFmt =  "No roles on page `{0}`\nRun `/rolepreserve blacklist` again to see the blacklisted roles."; 
+        
+        page = int.Max(1, page);
         var skip = pageSize * (page - 1);
+        var guildIdStr = guild.Id.ToString();
+
+        await using var db = _db.CreateSession();
+        var totalItemCount = await db.RolePreserveBlacklistedRoles
+            .Where(e => e.GuildId == guildIdStr)
+            .CountAsync();
+        var lastPage = Math.Max(1, Convert.ToInt32(Math.Ceiling(totalItemCount / (float)pageSize)));
+        
+        var components = BuildBlacklistedRolesListingComponents(page, lastPage);
+        
+        var embed = new EmbedBuilder()
+            .WithTitle("Role Preserve - Blacklisted Roles")
+            .WithColor(Color.Blue)
+            .WithFooter($"Page {page}")
+            .WithCurrentTimestamp();
+        
+        // only return early if we're past the last page
+        if (page > lastPage)
+        {
+            embed.Description = string.Format(emptyPageMessageFmt, page);
+            return new(embed, components);
+        }
+
         var items = await db.RolePreserveBlacklistedRoles
             .Where(e => e.GuildId == guildIdStr)
             .OrderByDescending(e => e.CreatedAt)
             .Skip(skip)
             .Take(pageSize)
             .ToListAsync();
-        var embed = new EmbedBuilder()
-            .WithTitle("Role Preserve - Blacklisted Roles")
-            .WithDescription(string.Join("\n", items.Select(e => $"- <@&{e.RoleId}>")))
-            .WithColor(Color.Blue)
-            .WithFooter($"Page {page}")
-            .WithCurrentTimestamp();
-        // generate embed, and include pagination buttons.
-        return embed;
+        
+        if (items.Count < 1)
+        {
+            embed.Description = page == 1
+                ? "No blacklisted roles have been setup. You can do that with `/rolepreserve blacklist-add`"
+                : string.Format(emptyPageMessageFmt, page);
+        }
+        else
+        {
+            embed.Description = string.Join("\n", items.Select(e => $"- <@&{e.RoleId}>"));
+        }
+
+        return new(embed, components);
     }
 
-    public enum BlacklistAction
+    private static ComponentBuilderV2 BuildBlacklistedRolesListingComponents(
+        int currentPage,
+        int lastPage)
     {
-        List,
-        Add,
-        Remove
+        var paginationRow = new List<ButtonBuilder>();
+        if (currentPage > 2)
+        {
+            paginationRow.Add(new ButtonBuilder()
+                .WithCustomId(ViewBlacklistedRolesInteractionName.Replace("*", "1"))
+                .WithLabel("Start")
+                .WithStyle(ButtonStyle.Primary));
+        }
+        if (currentPage > 1)
+        {
+            paginationRow.Add(new ButtonBuilder()
+                .WithCustomId(ViewBlacklistedRolesInteractionName.Replace("*", (currentPage - 1).ToString()))
+                .WithLabel("Previous")
+                .WithStyle(ButtonStyle.Primary));
+        }
+        if (currentPage < lastPage)
+        {
+            paginationRow.Add(new ButtonBuilder()
+                .WithCustomId(ViewBlacklistedRolesInteractionName.Replace("*", (currentPage + 1).ToString()))
+                .WithLabel("Next")
+                .WithStyle(ButtonStyle.Primary));
+        }
+        if (currentPage < lastPage - 1)
+        {
+            paginationRow.Add(new ButtonBuilder()
+                .WithCustomId(ViewBlacklistedRolesInteractionName.Replace("*", lastPage.ToString()))
+                .WithLabel("Last")
+                .WithStyle(ButtonStyle.Primary));
+        }
+        return new ComponentBuilderV2()
+            .WithActionRow(paginationRow);
     }
+
+    [ComponentInteraction("rolepreserve_blacklistedroles_list:page=*")]
+    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [UsedImplicitly]
+    public async Task ViewBlacklistedRolesInteraction(int page)
+    {
+        await DeferAsync();
+        var (embed, components) = await ListEmbed(Context.Guild, page);
+        await FollowupAsync(
+            embed: embed.Build(),
+            components: components.Build());
+    }
+
+    private const string ViewBlacklistedRolesInteractionName = "rolepreserve_blacklistedroles_list:page=*";
 }

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -2,10 +2,15 @@
 using Discord.Interactions;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using NLog;
 using XeniaBot.Core.Helpers;
 using XeniaBot.Shared;
+using XeniaBot.Shared.Helpers;
 using XeniaBot.Shared.Services;
 using XeniaDiscord.Data;
 using XeniaDiscord.Data.Repositories;
@@ -94,6 +99,8 @@ public class RolePreserveModule : InteractionModuleBase
     }
 
     [SlashCommand("ignore", "Add/Remove/List Ignored Roles")]
+    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RegisterDBLCommand]
     public async Task Blacklist(
         BlacklistAction action,
         IRole? role = null)
@@ -111,37 +118,181 @@ public class RolePreserveModule : InteractionModuleBase
 
 
         await DeferAsync();
-        
+        switch (action)
+        {
+            case BlacklistAction.Add:
+                await BlacklistAdd(role);
+                break;
+            case BlacklistAction.Remove:
+                await BlacklistRemove(role);
+                break;
+            case BlacklistAction.List:
+                await BlacklistList(role);
+                break;
+        }
+    }
+
+    private async Task BlacklistAdd(
+        [NotNull] IRole role)
+    {
+        const string title = "Role Preserve - Add to blacklist";
         await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
-
-            
-            if (action != BlacklistAction.List)
+            if (role.Guild.Id != Context.Guild.Id)
             {
-                await db.SaveChangesAsync();
-                await trans.CommitAsync();
+                await FollowupAsync(embed: new EmbedBuilder()
+                    .WithTitle(title)
+                    .WithDescription("Hey! Why are you trying to add a role to a different guild's blacklist?")
+                    .WithColor(Color.Orange)
+                    .WithCurrentTimestamp()
+                    .Build());
             }
 
-            throw new NotImplementedException();
+            var guildUser =
+                await ExceptionHelper.RetryOnTimedOut(async () => await Context.Guild.GetUserAsync(Context.User.Id))
+                ?? throw new InvalidOperationException($"Could not find requestors user in the current guild (guildId={Context.Guild.Id}, userId={Context.User.Id})");
+            var result = await _repo.RoleBlacklistAdd(db, role.Guild, role, guildUser);
+            await db.SaveChangesAsync();
+            await trans.CommitAsync();
+
+            var embed = new EmbedBuilder()
+                .WithTitle(title)
+                .WithFooter($"Role Id: {role.Id}")
+                .WithCurrentTimestamp();
+            switch (result)
+            {
+                case RolePreserveGuildRepository.RoleBlacklistAddResult.Ok:
+                    embed.WithDescription($"Removed role {role.Mention} from the blacklist.")
+                         .WithColor(Color.Green);
+                    break;
+                case RolePreserveGuildRepository.RoleBlacklistAddResult.GuildMismatch:
+                    embed.WithDescription("Hey! Why are you trying to add a role to a different guild's blacklist?")
+                         .WithColor(Color.Orange);
+                    break;
+                case RolePreserveGuildRepository.RoleBlacklistAddResult.AlreadyExists:
+                    embed.WithDescription($"Role is already blacklisted: {role.Id}")
+                         .WithColor(Color.Orange);
+                    break;
+                default:
+                    embed.WithDescription($"{result}\n-# Could not format result code")
+                        .WithColor(Color.Purple);
+                    break;
+            }
+            await FollowupAsync(embed: embed.Build());
         }
         catch (Exception ex)
         {
-            if (action != BlacklistAction.List)
-            {
-                await trans.RollbackAsync();
-            }
-            var msg = $"Failed to perform action \"{action}\" on role {role?.Name} ({role?.Id})";
+            await trans.RollbackAsync();
+            var msg = $"Failed to add role {role.Name} to blacklist (guildId={Context.Guild.Id}, roleId={role.Id})";
             _log.Error(ex, msg);
             await _error.Submit(new ErrorReportBuilder()
                 .WithException(ex)
                 .WithNotes(msg)
                 .WithContext(Context));
-            await FollowupAsync("Failed to perform action!");
+            await FollowupAsync(embed: new EmbedBuilder()
+                .WithTitle(title)
+                .WithDescription($"Failed to add role {role.Mention} to blacklist.\n-# {ex.GetType().Name}")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build());
         }
+    }
 
-        throw new NotImplementedException();
+    private async Task BlacklistRemove(
+        [NotNull] IRole role)
+    {
+        const string title = "Role Preserve - Remove from blacklist";
+        await using var db = _db.CreateSession();
+        await using var trans = await db.Database.BeginTransactionAsync();
+        try
+        {
+            if (role.Guild.Id != Context.Guild.Id)
+            {
+                await FollowupAsync(embed: new EmbedBuilder()
+                    .WithTitle(title)
+                    .WithDescription("Hey! Why are you trying to remove a role from a different guild's blacklist?")
+                    .WithColor(Color.Orange)
+                    .WithCurrentTimestamp()
+                    .Build());
+            }
+
+            var result = await _repo.RoleBlacklistRemove(db, role.Guild.Id, role.Id);
+            await db.SaveChangesAsync();
+            await trans.CommitAsync();
+
+            var embed = new EmbedBuilder()
+                .WithTitle(title)
+                .WithFooter($"Role Id: {role.Id}")
+                .WithCurrentTimestamp();
+            switch (result)
+            {
+                case RolePreserveGuildRepository.RoleBlacklistRemoveResult.Ok:
+                    embed.WithDescription($"Removed role {role.Mention} from the blacklist.")
+                         .WithColor(Color.Green);
+                    break;
+                case RolePreserveGuildRepository.RoleBlacklistRemoveResult.NotFound:
+                    embed.WithDescription($"Role is not blacklisted: {role.Id}")
+                         .WithColor(Color.Orange);
+                    break;
+                default:
+                    embed.WithDescription($"{result}\n-# Could not format result code")
+                        .WithColor(Color.Purple);
+                    break;
+            }
+            await FollowupAsync(embed: embed.Build());
+        }
+        catch (Exception ex)
+        {
+            await trans.RollbackAsync();
+            var msg = $"Failed to remove role {role.Name} from blacklist (roleId={role.Id})";
+            _log.Error(ex, msg);
+            await _error.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes(msg)
+                .WithContext(Context));
+            await FollowupAsync(embed: new EmbedBuilder()
+                .WithTitle(title)
+                .WithDescription($"Failed to remove role {role.Mention} from blacklist.\n-# {ex.GetType().Name}")
+                .WithColor(Color.Red)
+                .WithCurrentTimestamp()
+                .Build());
+        }
+    }
+
+    private async Task BlacklistList(
+        IRole? role)
+    {
+        var embed = await ListEmbed(Context.Guild);
+        throw new NotImplementedException(
+            "List roles (basic), and implement pagination. Should only show 15 roles per page, and it should have a CSV export function. " +
+            "Data should be fetched with XeniaDiscord.Data.Repositories.RolePreserveGuildRepository.GetBlacklistRolesForGuild(XeniaDbContext, ulong)");
+    }
+
+    private async Task<EmbedBuilder> ListEmbed(
+        IGuild guild,
+        int page = 1)
+    {
+        page = int.Max(1, page);
+        const int pageSize = 10;
+        var guildIdStr = guild.Id.ToString();
+        await using var db = _db.CreateSession();
+        var skip = pageSize * (page - 1);
+        var items = await db.RolePreserveBlacklistedRoles
+            .Where(e => e.GuildId == guildIdStr)
+            .OrderByDescending(e => e.CreatedAt)
+            .Skip(skip)
+            .Take(pageSize)
+            .ToListAsync();
+        var embed = new EmbedBuilder()
+            .WithTitle("Role Preserve - Blacklisted Roles")
+            .WithDescription(string.Join("\n", items.Select(e => $"- <@&{e.RoleId}>")))
+            .WithColor(Color.Blue)
+            .WithFooter($"Page {page}")
+            .WithCurrentTimestamp();
+        // generate embed, and include pagination buttons.
+        return embed;
     }
 
     public enum BlacklistAction

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -27,6 +27,7 @@ public class RolePreserveModule : InteractionModuleBase
     private readonly XeniaDbContext _db;
     private readonly RolePreserveGuildRepository _repo;
     private readonly ErrorReportService _error;
+    private readonly ConfigData _config;
     public RolePreserveModule(IServiceProvider services)
     {
         try
@@ -34,6 +35,7 @@ public class RolePreserveModule : InteractionModuleBase
             _db = services.GetRequiredService<XeniaDbContext>();
             _repo = services.GetRequiredService<RolePreserveGuildRepository>();
             _error = services.GetRequiredService<ErrorReportService>();
+            _config = services.GetRequiredService<ConfigData>();
         }
         catch (Exception ex)
         {
@@ -277,7 +279,7 @@ public class RolePreserveModule : InteractionModuleBase
         {
             await DeferAsync();
             await using var db = _db.CreateSession();
-            var (embed, components) = await RolePreserveModuleHelper.ListEmbed(db, Context.Guild, page);
+            var (embed, components) = await RolePreserveModuleHelper.ListEmbed(_config, db, Context.Guild, page);
             if (components != null)
             {
                 await FollowupAsync(
@@ -302,13 +304,13 @@ internal static class RolePreserveModuleHelper
     internal const string ViewBlacklistedRolesInteractionName = "rolepreserve_blacklistedroles_list:page=*";
     internal sealed record ListEmbedResult(EmbedBuilder Embed, ComponentBuilderV2? ComponentBuilder);
     internal static async Task<ListEmbedResult> ListEmbed(
+        ConfigData config,
         XeniaDbContext db,
         IGuild guild,
         int page = 1)
     {
         const int pageSize = 10;
-        const string emptyPageMessageFmt =  "No roles on page `{0}`\nRun `/rolepreserve blacklist` again to see the blacklisted roles."; 
-        
+
         page = int.Max(1, page);
         var skip = pageSize * (page - 1);
         var guildIdStr = guild.Id.ToString();
@@ -319,17 +321,18 @@ internal static class RolePreserveModuleHelper
         var lastPage = Math.Max(1, Convert.ToInt32(Math.Ceiling(totalItemCount / (float)pageSize)));
         
         var components = BuildBlacklistedRolesListingComponents(page, lastPage);
-        
+
+        var pageFmt = page.ToString("N0");
         var embed = new EmbedBuilder()
             .WithTitle("Role Preserve - Blacklisted Roles")
             .WithColor(Color.Blue)
-            .WithFooter($"Page {page}")
+            .WithFooter("Page " + pageFmt)
             .WithCurrentTimestamp();
         
         // only return early if we're past the last page
         if (page > lastPage)
         {
-            embed.Description = string.Format(emptyPageMessageFmt, page);
+            embed.Description = DescriptionForEmptyPage(config, guild.Id, pageFmt);
             return new ListEmbedResult(embed, components);
         }
 
@@ -344,7 +347,7 @@ internal static class RolePreserveModuleHelper
         {
             embed.Description = page == 1
                 ? "No blacklisted roles have been setup. You can do that with `/rolepreserve blacklist-add`"
-                : string.Format(emptyPageMessageFmt, page);
+                : DescriptionForEmptyPage(config, guild.Id, pageFmt);
         }
         else
         {
@@ -352,6 +355,18 @@ internal static class RolePreserveModuleHelper
         }
 
         return new ListEmbedResult(embed, components);
+    }
+
+    private static string DescriptionForEmptyPage(ConfigData config, ulong guildId, string pageFmt)
+    {
+        const string emptyPageMessageFmt = "No roles on page `{0}`\nRun `/rolepreserve blacklist` again to see the blacklisted roles.";
+        const string emptyPageMessageWithDashFmt = emptyPageMessageFmt + "\n\nYou can also see what roles are blacklisted [via the web panel]({1}/Guild/{2}/RolePreserve/Settings).";
+        if (config.HasDashboard)
+            return string.Format(emptyPageMessageWithDashFmt,
+                pageFmt,
+                config.DashboardUrl,
+                guildId);
+        return string.Format(emptyPageMessageFmt, pageFmt);
     }
     private static ComponentBuilderV2? BuildBlacklistedRolesListingComponents(
         int currentPage,

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Discord.WebSocket;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using NLog;
@@ -17,7 +18,7 @@ using XeniaDiscord.Data.Repositories;
 namespace XeniaBot.Core.Modules;
 
 [Group("rolepreserve", "Configure the RolePreserve module.")]
-[RequireBotPermission(GuildPermission.ManageRoles | GuildPermission.ModerateMembers)]
+[RequireBotPermission(GuildPermission.ManageRoles)]
 [CommandContextType(InteractionContextType.Guild)]
 [UsedImplicitly]
 public class RolePreserveModule : InteractionModuleBase
@@ -28,9 +29,17 @@ public class RolePreserveModule : InteractionModuleBase
     private readonly ErrorReportService _error;
     public RolePreserveModule(IServiceProvider services)
     {
-        _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
-        _repo = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveGuildRepository>();
-        _error = services.GetRequiredService<ErrorReportService>();
+        try
+        {
+            _db = services.GetRequiredService<XeniaDbContext>();
+            _repo = services.GetRequiredService<RolePreserveGuildRepository>();
+            _error = services.GetRequiredService<ErrorReportService>();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex);
+            throw new InvalidOperationException("Failed to get services", ex);
+        }
     }
 
     [SlashCommand("enable", "Grant members preserved roles on re-join.")]
@@ -117,14 +126,13 @@ public class RolePreserveModule : InteractionModuleBase
         }
     }
     
-    [SlashCommand("blacklist-add", "Add a role to be ignored with role preservation")]
+    [SlashCommand("blacklist-add", "Ignore/blacklist a role")]
     [RequireUserPermission(GuildPermission.ManageRoles)]
-    [RequireBotPermission(GuildPermission.ManageRoles | GuildPermission.ModerateMembers)]
     [RegisterDBLCommand]
     [UsedImplicitly]
-    public async Task BlacklistAdd(
-        IRole role)
+    public async Task BlacklistAdd(IRole role)
     {
+        await DeferAsync();
         const string title = "Role Preserve - Add to blacklist";
         await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
@@ -154,7 +162,7 @@ public class RolePreserveModule : InteractionModuleBase
             switch (result)
             {
                 case RolePreserveGuildRepository.RoleBlacklistAddResult.Ok:
-                    embed.WithDescription($"Removed role {role.Mention} from the blacklist.")
+                    embed.WithDescription($"Added role {role.Mention} to the blacklist.")
                          .WithColor(Color.Green);
                     break;
                 case RolePreserveGuildRepository.RoleBlacklistAddResult.GuildMismatch:
@@ -174,9 +182,9 @@ public class RolePreserveModule : InteractionModuleBase
         }
         catch (Exception ex)
         {
-            await trans.RollbackAsync();
             var msg = $"Failed to add role {role.Name} to blacklist (guildId={Context.Guild.Id}, roleId={role.Id})";
             _log.Error(ex, msg);
+            await trans.RollbackAsync();
             await _error.Submit(new ErrorReportBuilder()
                 .WithException(ex)
                 .WithNotes(msg)
@@ -189,13 +197,14 @@ public class RolePreserveModule : InteractionModuleBase
                 .Build());
         }
     }
-    [SlashCommand("blacklist-add", "Remove a ignored/blacklisted role")]
+    
+    [SlashCommand("blacklist-remove", "Remove a ignored/blacklisted role")]
     [RequireUserPermission(GuildPermission.ManageRoles)]
-    [RequireBotPermission(GuildPermission.ManageRoles | GuildPermission.ModerateMembers)]
     [RegisterDBLCommand]
     [UsedImplicitly]
     public async Task BlacklistRemove(IRole role)
     {
+        await DeferAsync();
         const string title = "Role Preserve - Remove from blacklist";
         await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
@@ -242,9 +251,9 @@ public class RolePreserveModule : InteractionModuleBase
         }
         catch (Exception ex)
         {
-            await trans.RollbackAsync();
             var msg = $"Failed to remove role {role.Name} from blacklist (roleId={role.Id})";
             _log.Error(ex, msg);
+            await trans.RollbackAsync();
             await _error.Submit(new ErrorReportBuilder()
                 .WithException(ex)
                 .WithNotes(msg)
@@ -264,18 +273,36 @@ public class RolePreserveModule : InteractionModuleBase
     [UsedImplicitly]
     public async Task BlacklistList(int page = 1)
     {
-        await DeferAsync();
-        var (embed, components) = await ListEmbed(Context.Guild, page);
-        await FollowupAsync(
-            embed: embed.Build(),
-            components: components.Build());
-        // throw new NotImplementedException(
-        //     "List roles (basic), and implement pagination. Should only show 15 roles per page, and it should have a CSV export function. " +
-        //     "Data should be fetched with XeniaDiscord.Data.Repositories.RolePreserveGuildRepository.GetBlacklistRolesForGuild(XeniaDbContext, ulong)");
+        try
+        {
+            await DeferAsync();
+            await using var db = _db.CreateSession();
+            var (embed, components) = await RolePreserveModuleHelper.ListEmbed(db, Context.Guild, page);
+            if (components != null)
+            {
+                await FollowupAsync(
+                    embed: embed.Build(),
+                    components: components.Build());
+            }
+            else
+            {
+                await FollowupAsync(
+                    embed: embed.Build());
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex);
+        }
     }
+}
 
-    private sealed record ListEmbedResult(EmbedBuilder Embed, ComponentBuilderV2 ComponentBuilder);
-    private async Task<ListEmbedResult> ListEmbed(
+internal static class RolePreserveModuleHelper
+{
+    internal const string ViewBlacklistedRolesInteractionName = "rolepreserve_blacklistedroles_list:page=*";
+    internal sealed record ListEmbedResult(EmbedBuilder Embed, ComponentBuilderV2? ComponentBuilder);
+    internal static async Task<ListEmbedResult> ListEmbed(
+        XeniaDbContext db,
         IGuild guild,
         int page = 1)
     {
@@ -286,7 +313,6 @@ public class RolePreserveModule : InteractionModuleBase
         var skip = pageSize * (page - 1);
         var guildIdStr = guild.Id.ToString();
 
-        await using var db = _db.CreateSession();
         var totalItemCount = await db.RolePreserveBlacklistedRoles
             .Where(e => e.GuildId == guildIdStr)
             .CountAsync();
@@ -322,13 +348,12 @@ public class RolePreserveModule : InteractionModuleBase
         }
         else
         {
-            embed.Description = string.Join("\n", items.Select(e => $"- <@&{e.RoleId}>"));
+            embed.Description = string.Join("\n", items.Select(e => $"<@&{e.RoleId}>"));
         }
 
         return new(embed, components);
     }
-
-    private static ComponentBuilderV2 BuildBlacklistedRolesListingComponents(
+    private static ComponentBuilderV2? BuildBlacklistedRolesListingComponents(
         int currentPage,
         int lastPage)
     {
@@ -361,21 +386,48 @@ public class RolePreserveModule : InteractionModuleBase
                 .WithLabel("Last")
                 .WithStyle(ButtonStyle.Primary));
         }
+        if (paginationRow.Count < 1) return null;
         return new ComponentBuilderV2()
             .WithActionRow(paginationRow);
     }
+}
 
-    [ComponentInteraction("rolepreserve_blacklistedroles_list:page=*")]
+public class RolePreserveComponentModule : InteractionModuleBase<SocketInteractionContext<SocketMessageComponent>>
+{
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
+    private readonly XeniaDbContext _db;
+    public RolePreserveComponentModule(IServiceProvider services)
+    {
+        try
+        {
+            _db = services.GetRequiredService<XeniaDbContext>();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex);
+            throw new InvalidOperationException("Failed to get services", ex);
+        }
+    }
+    
+    [ComponentInteraction(RolePreserveModuleHelper.ViewBlacklistedRolesInteractionName)]
     [RequireUserPermission(GuildPermission.ManageRoles)]
     [UsedImplicitly]
-    public async Task ViewBlacklistedRolesInteraction(int page)
+    public async Task ListComponent(int page = 1)
     {
-        await DeferAsync();
-        var (embed, components) = await ListEmbed(Context.Guild, page);
-        await FollowupAsync(
-            embed: embed.Build(),
-            components: components.Build());
+        try
+        {
+            await using var db = _db.CreateSession();
+            var (embed, components) = await RolePreserveModuleHelper.ListEmbed(db, Context.Guild, page);
+            await Context.Interaction.UpdateAsync(
+                p =>
+                {
+                    p.Embed = embed.Build();
+                    p.Components = components == null ? new Optional<MessageComponent>(): components.Build();
+                });
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex);
+        }
     }
-
-    private const string ViewBlacklistedRolesInteractionName = "rolepreserve_blacklistedroles_list:page=*";
 }

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -3,8 +3,10 @@ using Discord.Interactions;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Threading.Tasks;
+using NLog;
 using XeniaBot.Core.Helpers;
 using XeniaBot.Shared;
+using XeniaBot.Shared.Services;
 using XeniaDiscord.Data;
 using XeniaDiscord.Data.Repositories;
 
@@ -15,12 +17,15 @@ namespace XeniaBot.Core.Modules;
 [CommandContextType(InteractionContextType.Guild)]
 public class RolePreserveModule : InteractionModuleBase
 {
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
     private readonly XeniaDbContext _db;
-    private readonly RolePreserveGuildRepository _userRepository;
+    private readonly RolePreserveGuildRepository _repo;
+    private readonly ErrorReportService _error;
     public RolePreserveModule(IServiceProvider services)
     {
         _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
-        _userRepository = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveGuildRepository>();
+        _repo = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveGuildRepository>();
+        _error = services.GetRequiredService<ErrorReportService>();
     }
     [SlashCommand("enable", "Grant members preserved roles on re-join.")]
     [RequireUserPermission(GuildPermission.ManageGuild)]
@@ -32,7 +37,7 @@ public class RolePreserveModule : InteractionModuleBase
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
-            await _userRepository.EnableAsync(db, Context.Guild.Id, true);
+            await _repo.EnableAsync(db, Context.Guild.Id, true);
             await db.SaveChangesAsync();
             await trans.CommitAsync();
             
@@ -65,7 +70,7 @@ public class RolePreserveModule : InteractionModuleBase
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
-            await _userRepository.EnableAsync(db, Context.Guild.Id, false);
+            await _repo.EnableAsync(db, Context.Guild.Id, false);
             await db.SaveChangesAsync();
             await trans.CommitAsync();
             
@@ -86,5 +91,63 @@ public class RolePreserveModule : InteractionModuleBase
                 .Build());
             await DiscordHelper.ReportError(ex, Context);
         }
+    }
+
+    [SlashCommand("ignore", "Add/Remove/List Ignored Roles")]
+    public async Task Blacklist(
+        BlacklistAction action,
+        IRole? role = null)
+    {
+        if (action == BlacklistAction.Add && role == null)
+        {
+            await RespondAsync("Target role (`role`) is required when adding a role to the blacklist.");
+            return;
+        }
+        if (action == BlacklistAction.Remove && role == null)
+        {
+            await RespondAsync("Target role (`role`) is required when removing a role from the blacklist.");
+            return;
+        }
+
+
+        await DeferAsync();
+        
+        await using var db = _db.CreateSession();
+        await using var trans = await db.Database.BeginTransactionAsync();
+        try
+        {
+
+            
+            if (action != BlacklistAction.List)
+            {
+                await db.SaveChangesAsync();
+                await trans.CommitAsync();
+            }
+
+            throw new NotImplementedException();
+        }
+        catch (Exception ex)
+        {
+            if (action != BlacklistAction.List)
+            {
+                await trans.RollbackAsync();
+            }
+            var msg = $"Failed to perform action \"{action}\" on role {role?.Name} ({role?.Id})";
+            _log.Error(ex, msg);
+            await _error.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes(msg)
+                .WithContext(Context));
+            await FollowupAsync("Failed to perform action!");
+        }
+
+        throw new NotImplementedException();
+    }
+
+    public enum BlacklistAction
+    {
+        List,
+        Add,
+        Remove
     }
 }

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -411,6 +411,7 @@ public class RolePreserveComponentModule : InteractionModuleBase<SocketInteracti
 {
     private readonly Logger _log = LogManager.GetCurrentClassLogger();
     private readonly XeniaDbContext _db;
+    private readonly ConfigData _config;
     public RolePreserveComponentModule(IServiceProvider services)
     {
         try
@@ -422,6 +423,8 @@ public class RolePreserveComponentModule : InteractionModuleBase<SocketInteracti
             _log.Error(ex);
             throw new InvalidOperationException("Failed to get services", ex);
         }
+
+        _config = services.GetRequiredService<ConfigData>();
     }
     
     [ComponentInteraction(RolePreserveModuleHelper.ViewBlacklistedRolesInteractionName)]
@@ -432,7 +435,7 @@ public class RolePreserveComponentModule : InteractionModuleBase<SocketInteracti
         try
         {
             await using var db = _db.CreateSession();
-            var (embed, components) = await RolePreserveModuleHelper.ListEmbed(db, Context.Guild, page);
+            var (embed, components) = await RolePreserveModuleHelper.ListEmbed(_config, db, Context.Guild, page);
             await Context.Interaction.UpdateAsync(
                 p =>
                 {

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -127,7 +127,7 @@ public class RolePreserveModule : InteractionModuleBase
     }
     
     [SlashCommand("blacklist-add", "Ignore/blacklist a role")]
-    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RequireAnyUserPermission(GuildPermission.ManageGuild | GuildPermission.ManageRoles)]
     [RegisterDBLCommand]
     [UsedImplicitly]
     public async Task BlacklistAdd(IRole role)
@@ -199,7 +199,7 @@ public class RolePreserveModule : InteractionModuleBase
     }
     
     [SlashCommand("blacklist-remove", "Remove a ignored/blacklisted role")]
-    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RequireAnyUserPermission(GuildPermission.ManageGuild | GuildPermission.ManageRoles)]
     [RegisterDBLCommand]
     [UsedImplicitly]
     public async Task BlacklistRemove(IRole role)
@@ -268,7 +268,7 @@ public class RolePreserveModule : InteractionModuleBase
     }
 
     [SlashCommand("blacklist", "List ignored/blacklisted roles")]
-    [RequireUserPermission(GuildPermission.ManageRoles)]
+    [RequireAnyUserPermission(GuildPermission.ManageGuild | GuildPermission.ManageRoles)]
     [RegisterDBLCommand]
     [UsedImplicitly]
     public async Task BlacklistList(int page = 1)

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -3,6 +3,7 @@ using Discord.Interactions;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord.WebSocket;
@@ -24,18 +25,18 @@ namespace XeniaBot.Core.Modules;
 public class RolePreserveModule : InteractionModuleBase
 {
     private readonly Logger _log = LogManager.GetCurrentClassLogger();
-    private readonly XeniaDbContext _db;
     private readonly RolePreserveGuildRepository _repo;
     private readonly ErrorReportService _error;
     private readonly ConfigData _config;
+    private readonly IDbContextFactory<XeniaDbContext> _dbFactory;
     public RolePreserveModule(IServiceProvider services)
     {
         try
         {
-            _db = services.GetRequiredService<XeniaDbContext>();
             _repo = services.GetRequiredService<RolePreserveGuildRepository>();
             _error = services.GetRequiredService<ErrorReportService>();
             _config = services.GetRequiredService<ConfigData>();
+            _dbFactory = services.GetRequiredService<IDbContextFactory<XeniaDbContext>>();
         }
         catch (Exception ex)
         {
@@ -51,7 +52,7 @@ public class RolePreserveModule : InteractionModuleBase
     public async Task Enable()
     {
         await DeferAsync();
-        await using var db = _db.CreateSession();
+        await using var db = await _dbFactory.CreateDbContextAsync();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
@@ -93,7 +94,7 @@ public class RolePreserveModule : InteractionModuleBase
     public async Task Disable()
     {
         await DeferAsync();
-        await using var db = _db.CreateSession();
+        await using var db = await _dbFactory.CreateDbContextAsync();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
@@ -136,7 +137,7 @@ public class RolePreserveModule : InteractionModuleBase
     {
         await DeferAsync();
         const string title = "Role Preserve - Add to blacklist";
-        await using var db = _db.CreateSession();
+        await using var db = await _dbFactory.CreateDbContextAsync();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
@@ -208,7 +209,7 @@ public class RolePreserveModule : InteractionModuleBase
     {
         await DeferAsync();
         const string title = "Role Preserve - Remove from blacklist";
-        await using var db = _db.CreateSession();
+        await using var db = await _dbFactory.CreateDbContextAsync();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
@@ -278,7 +279,7 @@ public class RolePreserveModule : InteractionModuleBase
         try
         {
             await DeferAsync();
-            await using var db = _db.CreateSession();
+            await using var db = await _dbFactory.CreateDbContextAsync();
             var (embed, components) = await RolePreserveModuleHelper.ListEmbed(_config, db, Context.Guild, page);
             if (components != null)
             {
@@ -288,8 +289,7 @@ public class RolePreserveModule : InteractionModuleBase
             }
             else
             {
-                await FollowupAsync(
-                    embed: embed.Build());
+                await FollowupAsync(embed: embed.Build());
             }
         }
         catch (Exception ex)
@@ -415,13 +415,13 @@ internal static class RolePreserveModuleHelper
 public class RolePreserveComponentModule : InteractionModuleBase<SocketInteractionContext<SocketMessageComponent>>
 {
     private readonly Logger _log = LogManager.GetCurrentClassLogger();
-    private readonly XeniaDbContext _db;
+    private readonly IDbContextFactory<XeniaDbContext> _dbFactory;
     private readonly ConfigData _config;
     public RolePreserveComponentModule(IServiceProvider services)
     {
         try
         {
-            _db = services.GetRequiredService<XeniaDbContext>();
+            _dbFactory = services.GetRequiredService<IDbContextFactory<XeniaDbContext>>();
         }
         catch (Exception ex)
         {
@@ -435,11 +435,14 @@ public class RolePreserveComponentModule : InteractionModuleBase<SocketInteracti
     [ComponentInteraction(RolePreserveModuleHelper.ViewBlacklistedRolesInteractionName)]
     [RequireUserPermission(GuildPermission.ManageRoles)]
     [UsedImplicitly]
-    public async Task ListComponent(int page = 1)
+    public async Task ListComponent(
+        [MinValue(1)]
+        [DefaultValue(1)]
+        int page)
     {
         try
         {
-            await using var db = _db.CreateSession();
+            await using var db = await _dbFactory.CreateDbContextAsync();
             var (embed, components) = await RolePreserveModuleHelper.ListEmbed(_config, db, Context.Guild, page);
             await Context.Interaction.UpdateAsync(
                 p =>

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -2,13 +2,12 @@
 using Discord.Interactions;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using NLog;
-using XeniaBot.Core.Helpers;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Helpers;
 using XeniaBot.Shared.Services;
@@ -42,7 +41,12 @@ public class RolePreserveModule : InteractionModuleBase
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
-            await _repo.EnableAsync(db, Context.Guild.Id, true);
+            var guildUser =
+                await ExceptionHelper.RetryOnTimedOut(async () => await Context.Guild.GetUserAsync(Context.User.Id))
+                ?? throw new InvalidOperationException($"Could not find requestors user in the current guild (guildId={Context.Guild.Id}, userId={Context.User.Id})");
+
+            await _repo.EnableAsync(db, Context.Guild.Id, true, guildUser);
+
             await db.SaveChangesAsync();
             await trans.CommitAsync();
             
@@ -75,7 +79,12 @@ public class RolePreserveModule : InteractionModuleBase
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
-            await _repo.EnableAsync(db, Context.Guild.Id, false);
+            var guildUser =
+                await ExceptionHelper.RetryOnTimedOut(async () => await Context.Guild.GetUserAsync(Context.User.Id))
+                ?? throw new InvalidOperationException($"Could not find requestors user in the current guild (guildId={Context.Guild.Id}, userId={Context.User.Id})");
+            
+            await _repo.EnableAsync(db, Context.Guild.Id, false, guildUser);
+            
             await db.SaveChangesAsync();
             await trans.CommitAsync();
             
@@ -218,7 +227,11 @@ public class RolePreserveModule : InteractionModuleBase
                     .Build());
             }
 
-            var result = await _repo.RoleBlacklistRemove(db, role.Guild.Id, role.Id);
+            var guildUser =
+                await ExceptionHelper.RetryOnTimedOut(async () => await Context.Guild.GetUserAsync(Context.User.Id))
+                ?? throw new InvalidOperationException($"Could not find requestors user in the current guild (guildId={Context.Guild.Id}, userId={Context.User.Id})");
+
+            var result = await _repo.RoleBlacklistRemove(db, role.Guild.Id, role.Id, guildUser);
             await db.SaveChangesAsync();
             await trans.CommitAsync();
 

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -372,7 +372,13 @@ internal static class RolePreserveModuleHelper
         int currentPage,
         int lastPage)
     {
-        var paginationRow = new List<ButtonBuilder>();
+        var paginationRow = new List<ButtonBuilder>()
+        {
+            new ButtonBuilder()
+                .WithCustomId(ViewBlacklistedRolesInteractionName.Replace("*", currentPage.ToString()))
+                .WithLabel("Refresh")
+                .WithStyle(ButtonStyle.Primary)
+        };
         if (currentPage > 2)
         {
             paginationRow.Add(new ButtonBuilder()
@@ -401,7 +407,6 @@ internal static class RolePreserveModuleHelper
                 .WithLabel("Last")
                 .WithStyle(ButtonStyle.Primary));
         }
-        if (paginationRow.Count < 1) return null;
         return new ComponentBuilderV2()
             .WithActionRow(paginationRow);
     }
@@ -440,7 +445,9 @@ public class RolePreserveComponentModule : InteractionModuleBase<SocketInteracti
                 p =>
                 {
                     p.Embed = embed.Build();
-                    p.Components = components == null ? new Optional<MessageComponent>(): components.Build();
+                    p.Components = components == null 
+                        ? Optional<MessageComponent>.Unspecified
+                        : components.Build();
                 });
         }
         catch (Exception ex)

--- a/XeniaBot.Core/Modules/RolePreserveModule.cs
+++ b/XeniaBot.Core/Modules/RolePreserveModule.cs
@@ -330,7 +330,7 @@ internal static class RolePreserveModuleHelper
         if (page > lastPage)
         {
             embed.Description = string.Format(emptyPageMessageFmt, page);
-            return new(embed, components);
+            return new ListEmbedResult(embed, components);
         }
 
         var items = await db.RolePreserveBlacklistedRoles
@@ -351,7 +351,7 @@ internal static class RolePreserveModuleHelper
             embed.Description = string.Join("\n", items.Select(e => $"<@&{e.RoleId}>"));
         }
 
-        return new(embed, components);
+        return new ListEmbedResult(embed, components);
     }
     private static ComponentBuilderV2? BuildBlacklistedRolesListingComponents(
         int currentPage,

--- a/XeniaBot.Core/Services/BotAdditions/RoleService.cs
+++ b/XeniaBot.Core/Services/BotAdditions/RoleService.cs
@@ -1,27 +1,29 @@
 ﻿using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
-using XeniaBot.Shared;
+using NLog;
 using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using XeniaBot.MongoData.Models;
 using XeniaBot.MongoData.Repositories;
+using XeniaBot.Shared;
+
 using ReactionMessage = Discord.Cacheable<Discord.IUserMessage, ulong>;
 using ReactionChannel = Discord.Cacheable<Discord.IMessageChannel, ulong>;
-using NLog;
-
 
 namespace XeniaBot.Core.Services.BotAdditions;
 
 [XeniaController]
+[UsedImplicitly]
 public class RoleService : BaseService
 {
     private readonly Logger _log = LogManager.GetLogger("Xenia." + nameof(RoleService));
-    private DiscordSocketClient _client;
-    private RoleConfigRepository _config;
-    private RoleMessageConfigRepository _messageConfig;
+    private readonly DiscordSocketClient _client;
+    private readonly RoleConfigRepository _config;
+    private readonly RoleMessageConfigRepository _messageConfig;
     public RoleService(IServiceProvider services)
         : base (services)
     {
@@ -37,17 +39,17 @@ public class RoleService : BaseService
         return Task.CompletedTask;
     }
 
-    private const string GuildNotFoundForUserTempl
+    private const string GuildNotFoundForUserTemplate
         = "Guild \"{0}\" ({1}) not found for user \"{2}\" ({3}, {4})";
-    private const string MemberNotFoundInGuildTempl
+    private const string MemberNotFoundInGuildTemplate
         = "Member \"{0}\" ({1}, {2}) not found in guild \"{3}\" ({4})";
     private static string GuildNotFoundForUserMessage(IGuildUser user)
-        => string.Format(GuildNotFoundForUserTempl,
+        => string.Format(GuildNotFoundForUserTemplate,
                 user.Guild.Name, user.Guild.Id,
                 user.DisplayName, user.Username, user.Id);
     private static string MemberNotFoundInGuildMessage(
         IGuild guild, IGuildUser user)
-        => string.Format(MemberNotFoundInGuildTempl,
+        => string.Format(MemberNotFoundInGuildTemplate,
             user.DisplayName, user.Username, user.Id,
             guild.Name, guild.Id);
 
@@ -67,7 +69,7 @@ public class RoleService : BaseService
         if (model.BlacklistRoleId != 0)
         {
             var blacklistRole = await guild.GetRoleAsync(model.BlacklistRoleId);
-            var contains = blacklistRole == null ? false : memberRoleIds.Contains(blacklistRole.Id);
+            var contains = blacklistRole != null && memberRoleIds.Contains(blacklistRole.Id);
             if (blacklistRole == null)
             {
                 _log.Warn($"RoleConfigModel.BlacklistRoleId {model.BlacklistRoleId} not found for Guild \"{guild.Name}\" ({guild.Id}) for User \"{user}\" ({user.Id})");
@@ -80,7 +82,7 @@ public class RoleService : BaseService
         else if (model.RequiredRoleId != 0)
         {
             var whitelistRole = await guild.GetRoleAsync(model.RequiredRoleId);
-            var contains = whitelistRole == null ? false : memberRoleIds.Contains(whitelistRole.Id);
+            var contains = whitelistRole != null && memberRoleIds.Contains(whitelistRole.Id);
             if (whitelistRole == null)
             {
                 _log.Warn($"RoleConfigModel.RequiredRoleId not found (guild: {model.GuildId}, role: {model.RequiredRoleId})");
@@ -97,12 +99,13 @@ public class RoleService : BaseService
     {
         var guild = _client.GetGuild(user.Guild.Id);
         if (guild == null)
-            throw new Exception($"Guild {user.Guild.Id} not found");
+            throw new InvalidOperationException($"Guild {user.Guild.Id} not found");
         var member = guild.GetUser(user.Id);
         if (member == null)
-            throw new Exception($"Member {user.Id} not found in guild {guild.Id}");
+            throw new InvalidOperationException($"Member {user.Id} not found in guild {guild.Id}");
 
         var targetRole = await guild.GetRoleAsync(model.RoleId);
+        if (targetRole == null) return;
 
         await member.RemoveRoleAsync(targetRole);
     }
@@ -117,10 +120,10 @@ public class RoleService : BaseService
             return;
 
         // Ignore if the emote isn't a valid reaction role.
-        if (!messageConfig.ReactionRoleMap.ContainsKey(reaction.Emote.Name))
+        if (!messageConfig.ReactionRoleMap.TryGetValue(reaction.Emote.Name, out var targetRoleConfigId))
             return;
+        targetRoleConfigId ??= "";
 
-        var targetRoleConfigId = messageConfig.ReactionRoleMap[reaction.Emote.Name] ?? "";
         var roleConfigAll = await _config.GetAll(false, uid: targetRoleConfigId);
         var roleConfig = roleConfigAll?.FirstOrDefault();
         if (roleConfig == null)
@@ -144,12 +147,13 @@ public class RoleService : BaseService
             return;
 
         // Ignore if the emote isn't a valid reaction role.
-        if (!messageConfig.ReactionRoleMap.ContainsKey(reaction.Emote.Name))
+        if (!messageConfig.ReactionRoleMap.TryGetValue(reaction.Emote.Name, out var targetRoleConfigId))
             return;
+        targetRoleConfigId ??= "";
 
-        var targetRoleConfigId = messageConfig.ReactionRoleMap[reaction.Emote.Name] ?? "";
         var roleConfigAll = await _config.GetAll(false, uid: targetRoleConfigId);
-        var roleConfig = roleConfigAll?.FirstOrDefault();
+        var roleConfig = roleConfigAll.FirstOrDefault();
+        if (roleConfig == null) return;
 
         var validateResult = ValidateReactionObjects(message, reaction, roleConfig, targetRoleConfigId);
         if (!validateResult)
@@ -160,7 +164,7 @@ public class RoleService : BaseService
 
         await GrantUser(member, roleConfig);
     }
-    private bool ValidateReactionObjects(ReactionMessage message, SocketReaction reaction, RoleConfigModel model, string targetRoleConfigId)
+    private bool ValidateReactionObjects(ReactionMessage message, SocketReaction reaction, RoleConfigModel? model, string targetRoleConfigId)
     {
         if (model == null)
         {

--- a/XeniaBot.Core/XeniaBot.Core.csproj
+++ b/XeniaBot.Core/XeniaBot.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="DiffPlex" />
     <PackageReference Include="Google.Cloud.Translation.V2" />
     <PackageReference Include="IdGen" />
-    <PackageReference Include="Magick.NET-Q16-HDRI-AnyCPU" />
+    <PackageReference Include="Magick.NET-Q16-HDRI-x64" />
     <PackageReference Include="MimeTypesMap" />
     <PackageReference Include="Sentry.AspNetCore" />
   </ItemGroup>

--- a/XeniaBot.Core/XeniaBot.Core.csproj
+++ b/XeniaBot.Core/XeniaBot.Core.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="DiffPlex" />
     <PackageReference Include="Google.Cloud.Translation.V2" />
     <PackageReference Include="IdGen" />
+    <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Magick.NET-Q16-HDRI-x64" />
     <PackageReference Include="MimeTypesMap" />
     <PackageReference Include="Sentry.AspNetCore" />

--- a/XeniaBot.Core/XeniaBot.Core.csproj
+++ b/XeniaBot.Core/XeniaBot.Core.csproj
@@ -23,8 +23,13 @@
     <PackageReference Include="Magick.NET-Q16-HDRI-x64" />
     <PackageReference Include="MimeTypesMap" />
     <PackageReference Include="Sentry.AspNetCore" />
+    <PackageReference Include="Snappier" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/XeniaBot.Core/XeniaDiscordInteractions.cs
+++ b/XeniaBot.Core/XeniaDiscordInteractions.cs
@@ -27,6 +27,7 @@ public static class XeniaDiscordCoreInteractions
             interactions.AddModuleAsync<RandomAnimalModule>(services),
             interactions.AddModuleAsync<ReminderModule>(services),
             interactions.AddModuleAsync<RolePreserveModule>(services),
+            interactions.AddModuleAsync<RolePreserveComponentModule>(services),
             interactions.AddModuleAsync<TicketModule>(services),
             interactions.AddModuleAsync<TranslateModule>(services),
             interactions.AddModuleAsync<WeatherModule>(services)

--- a/XeniaBot.Core/XeniaDiscordInteractions.cs
+++ b/XeniaBot.Core/XeniaDiscordInteractions.cs
@@ -3,6 +3,8 @@ using System;
 using System.Threading.Tasks;
 using XeniaBot.Core.Modules;
 using XeniaBot.Shared.Helpers;
+#pragma warning disable S1186
+#pragma warning disable IDE0130
 
 namespace XeniaDiscord;
 

--- a/XeniaBot.MongoData/Repositories/RoleMenu/RoleConfigRepository.cs
+++ b/XeniaBot.MongoData/Repositories/RoleMenu/RoleConfigRepository.cs
@@ -47,7 +47,7 @@ public class RoleConfigRepository : BaseRepository<RoleConfigModel>
     /// <param name="name"></param>
     /// <param name="group"></param>
     /// <returns>IEnumerable of role configs</returns>
-    public async Task<ICollection<RoleConfigModel>?> GetAll(
+    public async Task<ICollection<RoleConfigModel>> GetAll(
         bool all = false,
         ulong? guildId = null,
         ulong? roleId = null,
@@ -92,7 +92,7 @@ public class RoleConfigRepository : BaseRepository<RoleConfigModel>
 
 
         var results = await BaseFind(filter);
-        return results.ToList();
+        return await results.ToListAsync();
     }
 
     public async Task<ICollection<RoleConfigModel>?> GetAll()

--- a/XeniaBot.Shared/Emotes.cs
+++ b/XeniaBot.Shared/Emotes.cs
@@ -3,4 +3,5 @@
 public static class Emotes
 {
     public const string Warning = "⚠️";
+    public const string Tada = "🎉";
 }

--- a/XeniaBot.Shared/Extensions.cs
+++ b/XeniaBot.Shared/Extensions.cs
@@ -1,5 +1,7 @@
 ﻿using Discord;
 using System;
+using System.IO;
+using System.Text;
 
 namespace XeniaBot.Shared;
 
@@ -18,5 +20,10 @@ public static class Extensions
         return str.Contains("Missing Access", StringComparison.OrdinalIgnoreCase)
             || str.Contains("50001", StringComparison.OrdinalIgnoreCase)
             || str.Contains("50013", StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static MemoryStream ToMemoryStream(this string value, Encoding encoding)
+    {
+        return new MemoryStream(encoding.GetBytes(value));
     }
 }

--- a/XeniaBot.Shared/Extensions.cs
+++ b/XeniaBot.Shared/Extensions.cs
@@ -7,15 +7,16 @@ public static class Extensions
 {
     public static string FormatUsername(this IUser user)
     {
-        if (user.DiscriminatorValue == 0) return user.Username;
-        return $"{user.Username}#{user.Discriminator}";
+        return user.DiscriminatorValue == 0
+            ? user.Username
+            : $"{user.Username}#{user.Discriminator}";
     }
 
     public static bool IsMissingDiscordPermissions(this Exception ex)
     {
         var str = ex.ToString();
         return str.Contains("Missing Access", StringComparison.OrdinalIgnoreCase)
-            || str.Contains("50001")
-            || str.Contains("50013");
+            || str.Contains("50001", StringComparison.OrdinalIgnoreCase)
+            || str.Contains("50013", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/XeniaBot.Shared/FeatureFlags.cs
+++ b/XeniaBot.Shared/FeatureFlags.cs
@@ -12,12 +12,12 @@ public static class FeatureFlags
     private static readonly Logger Log = LogManager.GetLogger(nameof(FeatureFlags));
     #region Parsing
     /// <summary>
-    /// Parses an environment variable as a boolean. When trimmed&lowercased to `true` it will return true, but anything else will return `false`.
+    /// Parses an environment variable as a boolean. When trimmed and lowercased to <c>true</c> it will return <see langword="true"/>, but anything else will return <c>false</c>
     /// When the environment variable isn't found, it wil default to <see cref="defaultValue"/>
     /// </summary>
     /// <param name="environmentKey"></param>
     /// <param name="defaultValue">Used when environment variable is not set.</param>
-    /// <returns>`true` when envar is true, `false` when not true, <see cref="defaultValue"/> when not found.</returns>
+    /// <returns><see langword="true"/> when envar is true, <see langword="false"/> when not true, <see cref="defaultValue"/> when not found.</returns>
     private static bool ParseBool(string environmentKey, bool defaultValue)
     {
         var item = Environment.GetEnvironmentVariable(environmentKey)
@@ -27,7 +27,7 @@ public static class FeatureFlags
     }
 
     /// <summary>
-    /// Just <see cref="Environment.GetEnvironmentVariable(string variable)"/> but when null it's <see cref="defaultValue"/>
+    /// Just <see cref="Environment.GetEnvironmentVariable(string)"/> but when null it's <see cref="defaultValue"/>
     /// </summary>
     private static string ParseString(string environmentKey, string defaultValue)
     {
@@ -35,7 +35,7 @@ public static class FeatureFlags
     }
 
     /// <summary>
-    /// Parse environment variable into a string array, seperated by the `;` character
+    /// Parse environment variable into a string array, separated by the <c>;</c> character
     /// </summary>
     /// <param name="envKey">Environment Key to search in</param>
     /// <param name="defaultValue">Default return value when null</param>
@@ -51,7 +51,7 @@ public static class FeatureFlags
     /// - Fetch Environment variable (when null, set to <see cref="defaultValue"/> as string)
     /// - Do regex match ^([0-9]+)$
     /// - When success, parse item as integer then return
-    /// - When fail, return default value
+    /// - When failed, return default value
     /// </summary>
     /// <returns></returns>
     private static int ParseInt(string envKey, int defaultValue)
@@ -131,7 +131,7 @@ public static class FeatureFlags
     /// <summary>
     /// Key: CONFIG_CONTENT
     /// Default: {}
-    /// Default (with <see cref="ConfigContentIsBase64"/>: e30=
+    /// Default (with <see cref="ConfigContentIsBase64"/>): e30=
     ///
     /// Will use this variable as the config when <see cref="ConfigFromEnvironment"/> is set.
     ///

--- a/XeniaBot.Shared/Helpers/ArrayHelper.cs
+++ b/XeniaBot.Shared/Helpers/ArrayHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 
 namespace XeniaBot.Shared.Helpers;
 
@@ -14,38 +12,47 @@ public static class ArrayHelper
     /// <returns>2D chunked array of <paramref name="source"/> with the inner array having the maximum size of <paramref name="itemsPerChunk"/></returns>
     public static T[][] Chunk<T>(IEnumerable<T> source, int itemsPerChunk)
     {
-        var result = new List<List<T>>();
-        for (int i = 0; i < source.Count(); i++)
+        var result = new List<T[]>();
+        var innerList = new List<T>();
+        foreach (var item in source)
         {
-            int rootArrayIndex = (int)Math.Floor(i / (float)itemsPerChunk);
-            if (result.Count <= rootArrayIndex)
-                result.Add(new List<T>());
-
-            int innerArrayIndex = i % itemsPerChunk;
-
-            result[rootArrayIndex].Add(source.ElementAt(i));
+            if (innerList.Count + 1 >= itemsPerChunk)
+            {
+                result.Add(innerList.ToArray());
+                innerList = [];
+            }
+            innerList.Add(item);
+        }
+        if (innerList.Count > 0)
+        {
+            result.Add(innerList.ToArray());
         }
 
-        return result.Select(v => v.ToArray()).ToArray();
+        return result.ToArray();
     }
 
     public static string[][] ChunkLength(IEnumerable<string> source, int maximumLengthPerChunk)
     {
-        var result = new List<List<string>>();
-        for (int i = 0; i < source.Count(); i++)
+        var result = new List<string[]>();
+        var innerList = new List<string>();
+        var innerListCount = 0;
+        foreach (var item in source)
         {
-            if (result.Count < 1)
+            if (innerListCount + item.Length >= maximumLengthPerChunk)
             {
-                result.Add(new List<string>());
+                result.Add(innerList.ToArray());
+                innerList = [];
+                innerListCount = 0;
             }
-
-            if (result.Last().Select(v => v.Length).Sum() > maximumLengthPerChunk)
-            {
-                result.Add(new List<string>());
-            }
-            result.Last().Add(source.ElementAt(i));
+            innerList.Add(item);
+            innerListCount += item.Length;
         }
 
-        return result.Select(v => v.ToArray()).ToArray();
+        if (innerList.Count > 0)
+        {
+            result.Add(innerList.ToArray());
+        }
+
+        return result.ToArray();
     }
 }

--- a/XeniaBot.Shared/Helpers/Delegates.cs
+++ b/XeniaBot.Shared/Helpers/Delegates.cs
@@ -1,8 +1,7 @@
 ﻿using System.Threading.Tasks;
 using XeniaBot.Shared.Services;
 
-namespace XeniaBot.Shared.Helpers
-{
-    public delegate void DiscordControllerDelegate(DiscordService service);
-    public delegate Task TaskDelegate();
-}
+namespace XeniaBot.Shared.Helpers;
+
+public delegate void DiscordControllerDelegate(DiscordService service);
+public delegate Task TaskDelegate();

--- a/XeniaBot.Shared/Helpers/ExceptionHelper.cs
+++ b/XeniaBot.Shared/Helpers/ExceptionHelper.cs
@@ -1,12 +1,27 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace XeniaBot.Shared.Helpers;
 
 public static class ExceptionHelper
 {
+    /// <summary>
+    /// Retry <paramref name="callback"/> multiple times (defined by <paramref name="count"/>) if the exception that's thrown is assumed to be a timeout exception (detected by <see cref="IsTimedOut"/>)
+    /// </summary>
+    /// <param name="callback">Method to call. Will be invoked multiple times, no more than the amount of times defined in <paramref name="count"/></param>
+    /// <param name="count">Amount of retries before giving up and throwing <see cref="AggregateException"/> with all the exceptions that were thrown by <paramref name="callback"/>.
+    /// If this is &lt;1, then it'll be reset to <c>1</c></param>
+    /// <exception cref="AggregateException">
+    /// Thrown if the amount of retries exceeds the <paramref name="count"/> defined, but if <paramref name="count"/> is <c>1</c>, then it'll re-throw the captured exception type.
+    /// </exception>
+    /// <remarks>
+    /// If <paramref name="count"/> is set to <c>1</c> and it fails, then the exception that was captured will be re-thrown instead of being wrapped in an <see cref="ArgumentException"/>
+    /// </remarks>
     public static async Task RetryOnTimedOut(Func<Task> callback, int count = 3)
     {
+        count = Math.Max(1, count);
+        var exceptions = new List<Exception>(count);
         for (int i = 0; i <= count; i++)
         {
             try
@@ -16,16 +31,23 @@ public static class ExceptionHelper
             }
             catch (Exception ex)
             {
-                var exStr = ex.ToString();
-                if (!exStr.Contains("timed out", StringComparison.OrdinalIgnoreCase) || i >= 3)
-                {
-                    throw;
-                }
+                exceptions.Add(ex);
+                if (IsTimedOut(ex) && i < 3) continue;
+                // just rethrow if this is the only exception, otherwise throw AggregateException
+                if (exceptions.Count == 1) throw;
+                throw new AggregateException(exceptions);
             }
         }
     }
+
+    /// <returns>
+    /// Result data from a successful attempt of calling the <paramref name="callback"/> provided.
+    /// </returns>
+    /// <inheritdoc cref="RetryOnTimedOut(Func{Task}, int)"/>
     public static async Task<TResult> RetryOnTimedOut<TResult>(Func<Task<TResult>> callback, int count = 3)
     {
+        count = Math.Max(1, count);
+        var exceptions = new List<Exception>(count);
         for (int i = 0; i <= count; i++)
         {
             try
@@ -34,13 +56,62 @@ public static class ExceptionHelper
             }
             catch (Exception ex)
             {
-                var exStr = ex.ToString();
-                if (!exStr.Contains("timed out", StringComparison.OrdinalIgnoreCase) || i >= 3)
-                {
-                    throw;
-                }
+                exceptions.Add(ex);
+                if (IsTimedOut(ex) && i < 3) continue;
+                // just rethrow if this is the only exception, otherwise throw AggregateException
+                if (exceptions.Count == 1) throw;
+                throw new AggregateException(exceptions);
             }
         }
         throw new NotImplementedException();
+    }
+
+    /// <inheritdoc cref="RetryOnTimedOut(Func{Task}, int)"/>
+    public static void RetryOnTimedOut(Action callback, int count = 3)
+    {
+        RetryOnTimedOut(InnerCallback, count).GetAwaiter().GetResult();
+        return;
+
+        Task InnerCallback()
+        {
+            callback();
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <inheritdoc cref="RetryOnTimedOut{TResult}(Func{Task{TResult}}, int)"/>
+    public static TResult RetryOnTimedOut<TResult>(Func<TResult> callback, int count = 3)
+    {
+        return RetryOnTimedOut(InnerCallback, count).GetAwaiter().GetResult();
+
+        Task<TResult> InnerCallback()
+        {
+            var result = callback();
+            return Task.FromResult(result);
+        }
+    }
+
+    /// <summary>
+    /// Is the exception provided assumed to be a timeout exception?
+    /// Checks if it's <see cref="TimeoutException"/>, then if it's <see cref="TaskCanceledException"/> and the inner exception is <see cref="TimeoutException"/>
+    /// or if the exception as a string matches the following regular expression: <c>time(?:d)?\s?out</c>
+    /// </summary>
+    /// <param name="exception"></param>
+    /// <returns></returns>
+    public static bool IsTimedOut(Exception exception)
+    {
+        switch (exception)
+        {
+            case TimeoutException:
+            case TaskCanceledException { InnerException: TimeoutException }:
+                return true;
+            default:
+            {
+                var exceptionStr = exception.ToString();
+                return exceptionStr.Contains("timed out", StringComparison.OrdinalIgnoreCase)
+                       || exceptionStr.Contains("time out", StringComparison.OrdinalIgnoreCase)
+                       || exceptionStr.Contains("timeout", StringComparison.OrdinalIgnoreCase);
+            }
+        }
     }
 }

--- a/XeniaBot.Shared/Helpers/SentryHelper.cs
+++ b/XeniaBot.Shared/Helpers/SentryHelper.cs
@@ -41,116 +41,120 @@ public static class SentryHelper
         return result;
     }
 
-    public static void SetInteractionInfo(this Scope scope, IDiscordInteraction? interaction)
+    extension(Scope scope)
     {
-        if (interaction == null) return;
-
-        var tags = new Dictionary<string, string>();
-        var extra = new Dictionary<string, object?>();
-        if (interaction.Data is IApplicationCommandInteractionData data)
+        public void SetInteractionInfo(IDiscordInteraction? interaction)
         {
-            tags["interaction.name"] = data.Name;
-            tags["interaction.id"] = data.Id.ToString();
+            if (interaction == null) return;
 
-            var optionIndex = 0;
-            foreach (var option in data.Options)
+            var tags = new Dictionary<string, string>();
+            var extra = new Dictionary<string, object?>();
+            if (interaction.Data is IApplicationCommandInteractionData data)
             {
-                if (optionIndex == 0 && option.Type == ApplicationCommandOptionType.SubCommand)
+                tags["interaction.name"] = data.Name;
+                tags["interaction.id"] = data.Id.ToString();
+
+                var optionIndex = 0;
+                foreach (var option in data.Options)
                 {
-                    tags["interaction.group"] = data.Name;
-                    tags["interaction.name"] = option.Name;
-                    tags["command.name"] = option.Name;
-                    tags["command.group"] = data.Name;
+                    if (optionIndex == 0 && option.Type == ApplicationCommandOptionType.SubCommand)
+                    {
+                        tags["interaction.group"] = data.Name;
+                        tags["interaction.name"] = option.Name;
+                        tags["command.name"] = option.Name;
+                        tags["command.group"] = data.Name;
+                    }
+
+                    var p = $"interaction.data.options[{optionIndex}]";
+                    extra[p + ".name"] = option.Name;
+                    extra[p + ".options.count"] = option.Options.Count;
+                    extra[p + ".type"] = option.Type.ToString();
+                    try
+                    {
+                        extra[p + ".value"] = option.Value;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, $"Failed to set value for interaction {data.Id} (value type: {option.Value?.GetType()})" + string.Join("\n", tags.Select(kvp => $"{kvp.Key}={kvp.Value}")));
+                    }
+
+                    optionIndex++;
                 }
 
-                var p = $"interaction.data.options[{optionIndex}]";
-                extra[p + ".name"] = option.Name;
-                extra[p + ".options.count"] = option.Options.Count;
-                extra[p + ".type"] = option.Type.ToString();
-                try
+                if (optionIndex == 0)
                 {
-                    extra[p + ".value"] = option.Value;
+                    tags["command.name"] = data.Name;
                 }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, $"Failed to set value for interaction {data.Id} (value type: {option.Value?.GetType()})" + string.Join("\n", tags.Select(kvp => $"{kvp.Key}={kvp.Value}")));
-                }
-
-                optionIndex++;
             }
 
-            if (optionIndex == 0)
+
+            tags["channel.id"] = interaction.ChannelId.ToString() ?? "";
+            tags["guild.id"] = interaction.GuildId?.ToString() ?? "";
+            if (interaction is SocketInteraction socketInteraction)
             {
-                tags["command.name"] = data.Name;
+                if (socketInteraction.Channel != null)
+                {
+                    extra["channel.name"] = socketInteraction.Channel.Name;
+                }
+                if (socketInteraction.InteractionChannel is IGuildChannel { Guild: not null } guildChannel)
+                {
+                    extra["guild.id"] = guildChannel.Guild.Id.ToString();
+                    extra["guild.name"] = guildChannel.Guild.Name;
+                    extra["guild.owner.id"] = guildChannel.Guild.OwnerId.ToString();
+                    try
+                    {
+                        var owner = guildChannel.Guild.GetOwnerAsync().GetAwaiter().GetResult();
+                        extra["guild.owner.username"] = owner?.Username ?? "";
+                        extra["guild.owner.global_name"] = owner?.GlobalName ?? "";
+                    }
+                    catch { }
+                }
+                tags["author.id"] = socketInteraction.User.Id.ToString();
+                tags["author.username"] = socketInteraction.User.Username;
+                tags["author.global_name"] = socketInteraction.User.GlobalName;
             }
+
+            scope.SetTags(tags);
+            scope.SetExtras(extra);
         }
 
-
-        tags["channel.id"] = interaction.ChannelId.ToString() ?? "";
-        tags["guild.id"] = interaction.GuildId?.ToString() ?? "";
-        if (interaction is SocketInteraction socketInteraction)
+        public void SetInteractionInfo(IInteractionContext? context)
         {
-            if (socketInteraction.Channel != null)
+            if (context?.Interaction == null)
+                return;
+
+            scope.SetInteractionInfo(context.Interaction);
+            var extra = new Dictionary<string, object?>();
+        
+            if (context.Guild != null)
             {
-                extra["channel.name"] = socketInteraction.Channel.Name;
-            }
-            if (socketInteraction.InteractionChannel is IGuildChannel guildChannel
-                && guildChannel.Guild != null)
-            {
-                extra["guild.id"] = guildChannel.Guild.Id.ToString();
-                extra["guild.name"] = guildChannel.Guild.Name;
-                extra["guild.owner.id"] = guildChannel.Guild.OwnerId.ToString();
+                extra["guild.name"] = context.Guild.Name;
+                extra["guild.owner.id"] = context.Guild.OwnerId.ToString();
                 try
                 {
-                    var owner = guildChannel.Guild.GetOwnerAsync().GetAwaiter().GetResult();
+                    var owner = context.Guild.GetOwnerAsync().GetAwaiter().GetResult();
                     extra["guild.owner.username"] = owner?.Username ?? "";
                     extra["guild.owner.global_name"] = owner?.GlobalName ?? "";
                 }
                 catch { }
             }
-            tags["author.id"] = socketInteraction.User.Id.ToString();
-            tags["author.username"] = socketInteraction.User.Username;
-            tags["author.global_name"] = socketInteraction.User.GlobalName;
-        }
 
-        scope.SetTags(tags);
-        scope.SetExtras(extra);
+            scope.SetExtras(extra);
+        }
     }
 
-    public static void SetInteractionInfo(this Scope scope, IInteractionContext? context)
+    extension(ITransactionTracer transaction)
     {
-        if (context == null || context.Interaction == null)
-            return;
-
-        scope.SetInteractionInfo(context.Interaction);
-        var tags = new Dictionary<string, string>();
-        var extra = new Dictionary<string, object?>();
-        
-        if (context.Guild != null)
+        public TimeSpan GetDuration()
         {
-            extra["guild.name"] = context.Guild.Name;
-            extra["guild.owner.id"] = context.Guild.OwnerId.ToString();
-            try
-            {
-                var owner = context.Guild.GetOwnerAsync().GetAwaiter().GetResult();
-                extra["guild.owner.username"] = owner?.Username ?? "";
-                extra["guild.owner.global_name"] = owner?.GlobalName ?? "";
-            }
-            catch { }
+            var end = transaction.EndTimestamp ?? DateTimeOffset.UtcNow;
+            return end - transaction.StartTimestamp;
         }
 
-        scope.SetTags(tags);
-        scope.SetExtras(extra);
-    }
-
-    public static TimeSpan GetDuration(this ITransactionTracer transaction)
-    {
-        var end = transaction.EndTimestamp ?? DateTimeOffset.UtcNow;
-        return end - transaction.StartTimestamp;
-    }
-    public static string FormatDuration(this ITransactionTracer transaction)
-    {
-        var ts = transaction.GetDuration();
-        return FormatHelper.Duration(ts);
+        public string FormatDuration()
+        {
+            var ts = transaction.GetDuration();
+            return FormatHelper.Duration(ts);
+        }
     }
 }

--- a/XeniaBot.Shared/Helpers/WeatherHelper.cs
+++ b/XeniaBot.Shared/Helpers/WeatherHelper.cs
@@ -7,12 +7,12 @@ namespace XeniaBot.Shared.Helpers
         /// <summary>
         /// When true, then the result given is perfectly fine. The result parameter in ValidateResponse will always be not-null when true.
         /// </summary>
-        public bool Success;
-        public string Message;
+        public bool Success { get; set; }
+        public string Message { get; set; }
         /// <summary>
         /// Populated when <see cref="WeatherResponse.Error"/> is not null.
         /// </summary>
-        public int ErrorCode = 0;
+        public int ErrorCode { get; set; }
         public override string ToString()
         {
             return Message;
@@ -28,29 +28,16 @@ namespace XeniaBot.Shared.Helpers
     {
         public static string FetchErrorDescription(WeatherError error)
         {
-            string content = $"`{error.Code}` ";
-            switch (error.Code)
+            var content = $"`{error.Code}` ";
+            content += error.Code switch
             {
-                case 1003:
-                case 1006:
-                    content += $"Location not found ({error.Code})";
-                    break;
-                case 1008:
-                    content += $"API key cannot fetch historical data.";
-                    break;
-                case 2006:
-                    content += $"API Key is invalid";
-                    break;
-                case 2009:
-                    content += $"API key does not have access to this resource.";
-                    break;
-                case 9999:
-                    content += $"Interal application error from weatherapi.com";
-                    break;
-                default:
-                    content += error.Message;
-                    break;
-            }
+                1003 or 1006 => $"Location not found ({error.Code})",
+                1008 => $"API key cannot fetch historical data.",
+                2006 => $"API Key is invalid",
+                2009 => $"API key does not have access to this resource.",
+                9999 => $"Internal application error from weatherapi.com",
+                _ => error.Message
+            };
             return content;
         }
         /// <summary>

--- a/XeniaBot.Shared/Helpers/XeniaHelper.cs
+++ b/XeniaBot.Shared/Helpers/XeniaHelper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ public static class XeniaHelper
     public static EmbedBuilder BaseEmbed(EmbedBuilder? builder = null)
     {
         if (CoreContext.Instance == null)
-            throw new Exception("CoreContext hasn't been initialized.");
+            throw new InvalidOperationException("CoreContext hasn't been initialized.");
 
         var client = CoreContext.Instance.GetRequiredService<DiscordSocketClient>();
         return BaseEmbed(client, builder);
@@ -129,23 +130,22 @@ public static class XeniaHelper
     /// <returns>Formatted result</returns>
     public static string FormatPascalCase(string input)
     {
-        string result = "";
-        for (int i = 0; i < input.Length; i++)
+        var length = input.Length;
+        var sb = new StringBuilder();
+        for (int i = 0; i < length; i++)
         {
-            char c = input[i];
-            string cs = input[i].ToString();
-            if (cs.ToUpper() == cs && i != 0)
-                result += $" {c}";
-            else
-                result += c;
+            var c = input[i];
+            if (char.IsUpper(c)) sb.Append(' ');
+            sb.Append(c);
         }
-        return result;
+
+        return sb.ToString();
     }
     public static string GetGuildPrefix(ulong guildId, ConfigData data)
     {
         return data.Prefix;
     }
-    public static string[] GenerateDifference(string before, string after)
+    public static string[] GenerateDifference(string? before, string? after)
     {
         if (before == null)
             before = "";
@@ -155,17 +155,14 @@ public static class XeniaHelper
         var lines = new List<string>();
         foreach (var line in diff.Lines)
         {
-            var lineContent = "";
-            if (line.Type == ChangeType.Inserted)
-                lineContent += "+ ";
-            else if (line.Type == ChangeType.Deleted)
-                lineContent += "- ";
-            else if (line.Type == ChangeType.Modified)
-                lineContent += "M ";
-            else if (line.Type == ChangeType.Imaginary)
-                lineContent += "I ";
-            else
-                lineContent += "  ";
+            var lineContent = line.Type switch
+            {
+                ChangeType.Inserted => "+ ",
+                ChangeType.Deleted => "- ",
+                ChangeType.Modified => "M ",
+                ChangeType.Imaginary => "I ",
+                _ => "  "
+            };
             lineContent += line.Text;
             lines.Add(lineContent);
         }
@@ -197,8 +194,8 @@ public static class XeniaHelper
     public static Discord.Color FromHex(string hex)
     {
         var str = "";
-        if (!hex.StartsWith("#"))
-            str += "#";
+        if (!hex.StartsWith('#'))
+            str += '#';
         str += hex;
         var color = System.Drawing.ColorTranslator.FromHtml(str);
         return new Discord.Color(color.R, color.G, color.B);
@@ -206,7 +203,7 @@ public static class XeniaHelper
 
     public static Dictionary<string, object?>? ReflectionToDictionary(object? obj, out List<string> skippedProperties)
     {
-        skippedProperties = new();
+        skippedProperties = [];
         if (obj == null)
             return null;
         var dict = new Dictionary<string, object?>();
@@ -223,20 +220,17 @@ public static class XeniaHelper
         };
         foreach (var x in properties)
         {
-            bool found = false;
-            foreach (var it in allowedTypes)
+            var found = false;
+            foreach (var it in allowedTypes.Where(e => e.IsAssignableFrom(x.PropertyType)))
             {
-                if (it.IsAssignableFrom(x.PropertyType))
-                {
-                    // only allow enums to be casted into non-strings.
-                    if (x.PropertyType.IsEnum &&
-                        (typeof(string).IsAssignableFrom(x.PropertyType) ||
-                         typeof(char).IsAssignableFrom(x.PropertyType)))
-                        continue;
-                    dict[x.Name] = x.GetValue(obj)?.ToString();
-                    found = true;
-                    break;
-                }
+                // only allow enums to be casted into non-strings.
+                if (x.PropertyType.IsEnum &&
+                    (typeof(string).IsAssignableFrom(x.PropertyType) ||
+                     typeof(char).IsAssignableFrom(x.PropertyType)))
+                    continue;
+                dict[x.Name] = x.GetValue(obj)?.ToString();
+                found = true;
+                break;
             }
 
             if (!found)

--- a/XeniaBot.Shared/HumanizerHelper.cs
+++ b/XeniaBot.Shared/HumanizerHelper.cs
@@ -1,0 +1,13 @@
+﻿using Humanizer;
+
+namespace XeniaBot.Shared;
+
+public class HumanizerHelper
+{
+    public static void UpdateVocabulary()
+    {
+        Vocabularies.Default.AddPlural("role", "roles");
+        Vocabularies.Default.AddPlural("guild", "guilds");
+        Vocabularies.Default.AddPlural("record", "records");
+    }
+}

--- a/XeniaBot.Shared/ProgramDetails.cs
+++ b/XeniaBot.Shared/ProgramDetails.cs
@@ -23,7 +23,7 @@ public class ProgramDetails
     public bool SetStatus { get; set; } = false;
 
     /// <summary>
-    /// Unique tag identifiying the instance in a cluster.
+    /// Unique tag identifying the instance in a cluster.
     /// </summary>
     public string? PlatformTag { get; set; }
 
@@ -56,7 +56,7 @@ public class ProgramDetails
             var sb = new StringBuilder(Version);
             if (VersionRaw?.Build > 365)
             {
-                sb.AppendFormat(" ({0})", VersionDate.ToString("yyyy/MM/dd HH:mm:ss"));
+                sb.AppendFormat(" ({0:yyyy/MM/dd HH:mm:ss})", VersionDate);
             }
             return sb.ToString();
         }

--- a/XeniaBot.Shared/RandomExtensions.cs
+++ b/XeniaBot.Shared/RandomExtensions.cs
@@ -1,19 +1,18 @@
 ﻿using System;
 
-namespace XeniaBot.Shared
+namespace XeniaBot.Shared;
+
+public static class RandomExtensions
 {
-    public static class RandomExtensions
+    public static void Shuffle<T>(this Random rng, T[] array)
     {
-        public static void Shuffle<T>(this Random rng, T[] array)
+        var n = array.Length;
+        while (n > 1)
         {
-            int n = array.Length;
-            while (n > 1)
-            {
-                int k = rng.Next(n--);
-                T temp = array[n];
-                array[n] = array[k];
-                array[k] = temp;
-            }
+            var k = rng.Next(n--);
+            var temp = array[n];
+            array[n] = array[k];
+            array[k] = temp;
         }
     }
 }

--- a/XeniaBot.Shared/RegisterDBLCommandAttribute.cs
+++ b/XeniaBot.Shared/RegisterDBLCommandAttribute.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace XeniaBot.Shared;
 

--- a/XeniaBot.Shared/RequireAnyUserPermissionAttribute.cs
+++ b/XeniaBot.Shared/RequireAnyUserPermissionAttribute.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Interactions;
+
+namespace XeniaBot.Shared;
+
+/// <summary>
+/// Precondition Attribute used to limit a module to only be used by users who have any of the defined Channel or Guild permissions.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+public class RequireAnyUserPermissionAttribute : PreconditionAttribute
+{
+    public RequireAnyUserPermissionAttribute(GuildPermission guildPermission)
+    {
+        GuildPermission = guildPermission;
+    }
+    public RequireAnyUserPermissionAttribute(ChannelPermission channelPermission)
+    {
+        ChannelPermission = channelPermission;
+    }
+    public GuildPermission? GuildPermission { get; set; }
+    public ChannelPermission? ChannelPermission { get; set; }
+
+    public string? NotAGuildErrorMessage { get; set; }
+
+    public override Task<PreconditionResult> CheckRequirementsAsync(
+        IInteractionContext context,
+        ICommandInfo commandInfo,
+        IServiceProvider services)
+    {
+        if (context.User is not IGuildUser user)
+        {
+            return Task.FromResult(PreconditionResult.FromError(this.NotAGuildErrorMessage ?? "Command must be used in a guild channel."));
+        }
+
+        var found = false;
+        if (this.GuildPermission.HasValue)
+        {
+            foreach (var flag in Enum.GetValues<GuildPermission>())
+            {
+                if (GuildPermission.Value.HasFlag(flag) &&
+                    user.GuildPermissions.Has(flag))
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if (this.ChannelPermission.HasValue)
+        {
+            ChannelPermissions perms;
+            if (context.Channel is IGuildChannel guildChannel)
+            {
+                perms = user.GetPermissions(guildChannel);
+            }
+            else
+            {
+                perms = ChannelPermissions.All(context.Channel);
+            }
+            foreach (var flag in Enum.GetValues<ChannelPermission>())
+            {
+                if (ChannelPermission.Value.HasFlag(flag) &&
+                    perms.Has(flag))
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if (found) return Task.FromResult(PreconditionResult.FromSuccess());
+
+        var reason = this.ErrorMessage ?? string.Empty;
+        if (!string.IsNullOrEmpty(reason))
+            return Task.FromResult(PreconditionResult.FromError(reason));
+        
+        if (GuildPermission.HasValue)
+        {
+            reason = "User requires any of the following guild permissions: ";
+            reason += string.Join(", ",
+                Enum.GetValues<GuildPermission>()
+                    .Where(e => GuildPermission.Value.HasFlag(e))
+                    .Select(e => e.ToString()));
+        }
+
+        if (ChannelPermission.HasValue)
+        {
+            if (GuildPermission.HasValue)
+            {
+                reason += ". Or any of the following channel permissions: ";
+            }
+            else
+            {
+                reason = "User required any of the following channel permissions: ";
+            }
+            reason += string.Join(", ",
+                Enum.GetValues<ChannelPermission>()
+                    .Where(e => ChannelPermission.Value.HasFlag(e))
+                    .Select(e => e.ToString()));
+        }
+        return Task.FromResult(PreconditionResult.FromError(reason));
+    }
+    
+}

--- a/XeniaBot.Shared/Schema/WeatherAPI/AirQuality.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/AirQuality.cs
@@ -6,43 +6,43 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
     {
         // Carbon Monoxide (μg/m3)
         [JsonPropertyName("co")]
-        public double CarbonMonoxide;
+        public double CarbonMonoxide { get; set; }
 
         /// <summary>
         /// Ozone (μg/m3)
         /// </summary>
         [JsonPropertyName("o3")]
-        public double Ozone;
+        public double Ozone { get; set; }
 
         /// <summary>
         /// Nitrogen Dioxide (μg/m3)
         /// </summary>
         [JsonPropertyName("no2")]
-        public double Nitrogen;
+        public double Nitrogen { get; set; }
 
         /// <summary>
         /// Sulphur dioxide (μg/m3)
         /// </summary>
         [JsonPropertyName("so2")]
-        public double Sulphur;
+        public double Sulphur { get; set; }
 
         /// <summary>
         /// PM2.5 (μg/m3)
         /// </summary>
         [JsonPropertyName("pm2_5")]
-        public double PM25;
+        public double PM25 { get; set; }
 
         /// <summary>
         /// PM10 (μg/m3)
         /// </summary>
         [JsonPropertyName("pm10")]
-        public double PM10;
+        public double PM10 { get; set; }
 
         /// <summary>
         /// United States EPA Standard Index
         /// </summary>
         [JsonPropertyName("us-epa-index")]
-        public int EPAValue = 0;
+        public int EPAValue { get; set; } = 0;
         /// <summary>
         /// United States EPA Standard cast to user-friendly names
         /// </summary>
@@ -50,7 +50,7 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
         {
             get
             {
-                if (EPAValue < 1 || EPAValue > 6)
+                if (EPAValue is < 1 or > 6)
                     return USEPAIndex.Unknown;
                 return (USEPAIndex)EPAValue;
             }
@@ -60,24 +60,22 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
         /// UK Defra Index Value
         /// </summary>
         [JsonPropertyName("gb-defra-index")]
-        public int DefraValue = 0;
+        public int DefraValue { get; set; } = 0;
         /// <summary>
-        /// UK Defra Index casted to band
+        /// UK Defra Index cast to band
         /// </summary>
         public UKDefraBand DefraBand
         {
             get
             {
-                if (DefraValue < 1)
-                    return UKDefraBand.Unknown;
-                else if (DefraValue >= 1 && DefraValue <= 3)
-                    return UKDefraBand.Low;
-                else if (DefraValue >= 4 && DefraValue <= 6)
-                    return UKDefraBand.Moderate;
-                else if (DefraValue >= 7 && DefraValue <= 9)
-                    return UKDefraBand.High;
-                else
-                    return UKDefraBand.VeryHigh;
+                return DefraValue switch
+                {
+                    < 1 => UKDefraBand.Unknown,
+                    <= 3 => UKDefraBand.Low,
+                    <= 6 => UKDefraBand.Moderate,
+                    <= 9 => UKDefraBand.High,
+                    _ => UKDefraBand.VeryHigh
+                };
             }
         }
     }

--- a/XeniaBot.Shared/Schema/WeatherAPI/BaseForecastData.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/BaseForecastData.cs
@@ -8,111 +8,112 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
         /// Temperature in celcius
         /// </summary>
         [JsonPropertyName("temp_c")]
-        public double TemperatureCelcius;
+        public double TemperatureCelcius { get; set; }
         /// <summary>
         /// Feels like temperature in celcius
         /// </summary>
         [JsonPropertyName("feelslike_c")]
-        public double TemperatureFeelsLikeCelcius;
+        public double TemperatureFeelsLikeCelcius { get; set; }
         /// <summary>
         /// Temperature in fahrenheit
         /// </summary>
         [JsonPropertyName("temp_f")]
-        public double TemperatureFahrenheit;
+        public double TemperatureFahrenheit { get; set; }
         // Feels like temperature in fahrenheit
         [JsonPropertyName("feelslike_f")]
-        public double TemperatureFeelsLikeFahrenheit;
+        public double TemperatureFeelsLikeFahrenheit { get; set; }
 
 
         [JsonPropertyName("is_day")]
-        public int IsDayValue = 1;
+        public int IsDayValue { get; set; } = 1;
         /// <summary>
         /// Whether to show day condition icon or night icon
         /// </summary>
         public bool IsDay => IsDayValue == 1;
+        
         [JsonPropertyName("condition")]
-        public WeatherCondition? Condition = null;
+        public WeatherCondition? Condition { get; set; }
 
         /// <summary>
         /// Wind speed in miles per hour
         /// </summary>
         [JsonPropertyName("wind_mph")]
-        public double WindSpeedMph;
+        public double WindSpeedMph { get; set; }
         /// <summary>
         /// Wind speed in kilometres per hour
         /// </summary>
         [JsonPropertyName("wind_kph")]
-        public double WindSpeedKph;
+        public double WindSpeedKph { get; set; }
         /// <summary>
         /// Wind direction in degrees
         /// </summary>
         [JsonPropertyName("wind_degree")]
-        public double WindAngle;
+        public double WindAngle { get; set; }
         /// <summary>
         /// Wind direction as a 16 point compass 
         /// </summary>
         [JsonPropertyName("wind_dir")]
-        public string WindDirection;
+        public string WindDirection { get; set; }
 
         /// <summary>
         /// Pressure in Millibars
         /// </summary>
         [JsonPropertyName("pressure_mb")]
-        public double PressureMb;
+        public double PressureMb { get; set; }
         /// <summary>
         /// Pressure in inches
         /// </summary>
         [JsonPropertyName("pressure_in")]
-        public double PressureIn;
+        public double PressureIn { get; set; }
 
         /// <summary>
         /// Precipitation in Millimetres
         /// </summary>
         [JsonPropertyName("precip_mm")]
-        public double PrecipitationMm;
+        public double PrecipitationMm { get; set; }
         /// <summary>
         /// Precipitation in Inches
         /// </summary>
         [JsonPropertyName("precip_in")]
-        public double PrecipitationIn;
+        public double PrecipitationIn { get; set; }
 
         /// <summary>
         /// Humidity as percentage (0 to 100)
         /// </summary>
         [JsonPropertyName("humidity")]
-        public double Humidity;
+        public double Humidity { get; set; }
         /// <summary>
         /// Cloud Coverage as percentage (0 to 100)
         /// </summary>
         [JsonPropertyName("cloud")]
-        public double CloudCoverage;
+        public double CloudCoverage { get; set; }
 
         /// <summary>
         /// Visibility in kilometres
         /// </summary>
         [JsonPropertyName("vis_km")]
-        public double VisibilityKm;
+        public double VisibilityKm { get; set; }
         /// <summary>
         /// Visibility in miles
         /// </summary>
         [JsonPropertyName("vis_miles")]
-        public double VisiblityMiles;
+        public double VisiblityMiles { get; set; }
 
         /// <summary>
         /// UV Levels
         /// </summary>
         [JsonPropertyName("uv")]
-        public double UV;
+        public double UV { get; set; }
 
         /// <summary>
         /// Gust speed in miles per hour
         /// </summary>
         [JsonPropertyName("gust_mph")]
-        public double GustMph;
+        public double GustMph { get; set; }
         /// <summary>
         /// Gust speed in kilometres per hour
         /// </summary>
         [JsonPropertyName("gust_kph")]
-        public double GustKph;
+        public double GustKph { get; set; }
     }
 }

--- a/XeniaBot.Shared/Schema/WeatherAPI/ForecastCurrent.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/ForecastCurrent.cs
@@ -9,26 +9,22 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
         /// Local time when the real time data was updated.
         /// </summary>
         [JsonPropertyName("last_updated")]
-        public string LastUpdatedString = "1970-01-01 00:00";
+        public string LastUpdatedString { get; set; } = "1970-01-01 00:00";
         /// <summary>
         /// Local time when the real time data was updated in unix time seconds.
         /// </summary>
         [JsonPropertyName("last_updated_epoch")]
-        public int LastUpdatedTimestamp = 0;
+        public int LastUpdatedTimestamp { get; set; } = 0;
         /// <summary>
         /// <see cref="LastUpdatedTimestamp"/> parsed with <see cref="DateTimeOffset.FromUnixTimeSeconds(long)"/>
         /// </summary>
         public DateTime LastUpdated
-        {
-            get
-            {
-                return DateTimeOffset.FromUnixTimeSeconds(LastUpdatedTimestamp).DateTime;
-            }
-        }
+            => DateTimeOffset.FromUnixTimeSeconds(LastUpdatedTimestamp).DateTime;
+
         /// <summary>
         /// Null when fetched with "aqi" url parameter to "no"
         /// </summary>
         [JsonPropertyName("air_quality")]
-        public AirQuality? AirQuality = null;
+        public AirQuality? AirQuality { get; set; }
     }
 }

--- a/XeniaBot.Shared/Schema/WeatherAPI/ForecastDay.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/ForecastDay.cs
@@ -6,22 +6,19 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
     public class ForecastDay
     {
         [JsonPropertyName("date")]
-        public string DateString;
+        public string DateString { get; set; }
         [JsonPropertyName("date_epoch")]
-        public long DateTimestamp;
+        public long DateTimestamp { get; set; }
+        [JsonIgnore]
         public DateTime Date
-        {
-            get
-            {
-                return DateTimeOffset.FromUnixTimeSeconds(DateTimestamp).Date;
-            }
-        }
+            => DateTimeOffset.FromUnixTimeSeconds(DateTimestamp).Date;
+
         [JsonPropertyName("day")]
-        public ForecastDayChild? Day;
+        public ForecastDayChild? Day { get; set; }
         [JsonPropertyName("astro")]
-        public ForecastAstrology? Astrology;
+        public ForecastAstrology? Astrology { get; set; }
         [JsonPropertyName("hour")]
-        public ForecastHourItem[] Hour;
+        public ForecastHourItem[] Hour { get; set; }
 
         public ForecastDay()
         {
@@ -29,79 +26,81 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
             DateTimestamp = 0;
             Day = null;
             Astrology = null;
-            Hour = Array.Empty<ForecastHourItem>();
+            Hour = [];
         }
     }
     public class ForecastDayChild
     {
         [JsonPropertyName("maxtemp_c")]
-        public double TemperatureMaximumCelcius;
+        public double TemperatureMaximumCelcius { get; set; }
         [JsonPropertyName("maxtemp_f")]
-        public double TemperatureMaximumFahrenheit;
+        public double TemperatureMaximumFahrenheit { get; set; }
         [JsonPropertyName("mintemp_c")]
-        public double TemperatureMinimumCelcius;
+        public double TemperatureMinimumCelcius { get; set; }
         [JsonPropertyName("mintemp_f")]
-        public double TemperatureMinimumFahrenheit;
+        public double TemperatureMinimumFahrenheit { get; set; }
         [JsonPropertyName("avgtemp_c")]
-        public double TemperatureAverageCelcius;
+        public double TemperatureAverageCelcius { get; set; }
         [JsonPropertyName("avgtemp_f")]
-        public double TemperatureAverageFahrenheit;
+        public double TemperatureAverageFahrenheit { get; set; }
         [JsonPropertyName("maxwind_mph")]
-        public double WindSpeedMaximumMph;
+        public double WindSpeedMaximumMph { get; set; }
         [JsonPropertyName("maxwind_kph")]
-        public double WindSpeedMaximumKph;
+        public double WindSpeedMaximumKph { get; set; }
         [JsonPropertyName("totalprecip_mm")]
-        public double TotalPrecipitationMm;
+        public double TotalPrecipitationMm { get; set; }
         [JsonPropertyName("totalprecip_in")]
-        public double TotalPrecipitationIn;
+        public double TotalPrecipitationIn { get; set; }
         [JsonPropertyName("totalsnow_cm")]
-        public double TotalSnow;
+        public double TotalSnow { get; set; }
         [JsonPropertyName("avgvis_km")]
-        public double VisibilityAverageKm;
+        public double VisibilityAverageKm { get; set; }
         [JsonPropertyName("avgvis_miles")]
-        public double VisibilityAverageMiles;
+        public double VisibilityAverageMiles { get; set; }
         [JsonPropertyName("avghumidity")]
-        public double HumidityAverage;
+        public double HumidityAverage { get; set; }
         [JsonPropertyName("daily_will_it_rain")]
-        public int WillItRainValue = 0;
+        public int WillItRainValue { get; set; } = 0;
         public bool WillItRain => WillItRainValue == 1;
         [JsonPropertyName("daily_chance_of_rain")]
-        public int ChanceOfRain;
+        public int ChanceOfRain { get; set; }
         [JsonPropertyName("daily_will_it_snow")]
-        public int WillItSnowValue = 0;
+        public int WillItSnowValue { get; set; } = 0;
         public bool WillItSnow => WillItSnowValue == 1;
         [JsonPropertyName("daily_chance_of_snow")]
-        public int ChanceOfSnow;
+        public int ChanceOfSnow { get; set; }
         [JsonPropertyName("condition")]
-        public WeatherCondition? Condition = null;
+        public WeatherCondition? Condition { get; set; }
         [JsonPropertyName("uv")]
-        public double UV;
+        public double UV { get; set; }
     }
     public class ForecastAstrology
     {
         [JsonPropertyName("sunrise")]
-        public string Sunrise = "00:00 AM";
+        public string Sunrise { get; set; } = "00:00 AM";
         [JsonPropertyName("sunset")]
-        public string Sunset = "00:00 AM";
+        public string Sunset { get; set; } = "00:00 AM";
         [JsonPropertyName("moonrise")]
-        public string Moonrise = "00:00 AM";
+        public string Moonrise { get; set; } = "00:00 AM";
         [JsonPropertyName("moonset")]
-        public string Moonset = "00:00 AM";
+        public string Moonset { get; set; } = "00:00 AM";
         [JsonPropertyName("moon_phase")]
-        public string MoonPhase = "00:00 AM";
+        public string MoonPhase { get; set; } = "00:00 AM";
         [JsonPropertyName("moon_illumination")]
-        public int MoonIllumination = 0;
+        public int MoonIllumination { get; set; } = 0;
         [JsonPropertyName("is_moon_up")]
-        public int IsMoonUpValue = 0;
+        public int IsMoonUpValue { get; set; } = 0;
         [JsonPropertyName("is_sun_up")]
-        public int IsSunUpValue = 0;
+        public int IsSunUpValue { get; set; } = 0;
+        [JsonIgnore]
         public bool IsMoonUp => IsMoonUpValue == 1;
+        [JsonIgnore]
         public bool IsSunUp => IsSunUpValue == 1;
     }
     public class AstronomyParent
     {
         [JsonPropertyName("astro")]
-        public ForecastAstrology? Data = null;
+        public ForecastAstrology? Data { get; set; }
     }
     public class ForecastHourItem : BaseForecastData
     {
@@ -109,73 +108,71 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
         /// Time as epoch in seconds
         /// </summary>
         [JsonPropertyName("time_epoch")]
-        public long Timestamp = 0;
+        public long Timestamp { get; set; } = 0;
         /// <summary>
         /// Date and time as YYYY-MM-DD hh:mm
         /// </summary>
         [JsonPropertyName("time")]
-        public string TimeValue = "1970-01-01 00:00";
+        public string TimeValue { get; set; } = "1970-01-01 00:00";
         /// <summary>
         /// Date parsed from <see cref="Timestamp"/>
         /// </summary>
+        [JsonIgnore]
         public DateTime Time
-        {
-            get
-            {
-                return DateTimeOffset.FromUnixTimeSeconds(Timestamp).DateTime;
-            }
-        }
+            => DateTimeOffset.FromUnixTimeSeconds(Timestamp).DateTime;
 
 
         /// <summary>
         /// Chance of rain as percentage
         /// </summary>
         [JsonPropertyName("chance_of_rain")]
-        public int ChanceOfRain;
+        public int ChanceOfRain { get; set; }
         /// <summary>
         /// Chance of snow as percentage
         /// </summary>
         [JsonPropertyName("chance_of_snow")]
-        public int ChanceOfSnow;
+        public int ChanceOfSnow { get; set; }
         /// <summary>
         /// Dew point in celcius
         /// </summary>
         [JsonPropertyName("dewpoint_c")]
-        public double DewPointCelcius;
+        public double DewPointCelcius { get; set; }
         /// <summary>
         /// Dew point in fahrenheit
         /// </summary>
         [JsonPropertyName("dewpoint_f")]
-        public double DewPointFarenheit;
+        public double DewPointFarenheit { get; set; }
 
         /// <summary>
         /// Heat index in celcius
         /// </summary>
         [JsonPropertyName("heatindex_c")]
-        public double HeatIndexCelcius;
+        public double HeatIndexCelcius { get; set; }
         /// <summary>
         /// Heat index in fahrenheit
         /// </summary>
         [JsonPropertyName("heatindex_f")]
-        public double HeatIndexFarenheit;
+        public double HeatIndexFarenheit { get; set; }
 
         /// <summary>
         /// 1 = Yes 0 = No
         /// </summary>
         [JsonPropertyName("will_it_rain")]
-        public int WillItRainValue = 0;
+        public int WillItRainValue { get; set; } = 0;
         /// <summary>
         /// 1 = Yes 0 = No
         /// </summary>
         [JsonPropertyName("will_it_snow")]
-        public int WillItSnowValue = 0;
+        public int WillItSnowValue { get; set; } = 0;
         /// <summary>
         /// Will it will rain or not
         /// </summary>
+        [JsonIgnore]
         public bool WillItRain => WillItRainValue == 1;
         /// <summary>
         /// Will it snow or not
         /// </summary>
+        [JsonIgnore]
         public bool WillItSnow => WillItSnowValue == 1;
     }
 }

--- a/XeniaBot.Shared/Schema/WeatherAPI/ForecastParent.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/ForecastParent.cs
@@ -6,6 +6,6 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
     public class ForecastParent
     {
         [JsonPropertyName("forecastday")]
-        public ForecastDay[] ForecastDay = Array.Empty<ForecastDay>();
+        public ForecastDay[] ForecastDay { get; set; } = Array.Empty<ForecastDay>();
     }
 }

--- a/XeniaBot.Shared/Schema/WeatherAPI/WeatherAPI.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/WeatherAPI.cs
@@ -6,28 +6,30 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
     public class WeatherResponse
     {
         [JsonPropertyName("location")]
-        public WeatherLocation? Location = null;
+        public WeatherLocation? Location { get; set; }
         [JsonPropertyName("current")]
-        public ForecastCurrent? Current = null;
+        public ForecastCurrent? Current { get; set; }
         [JsonPropertyName("forecast")]
-        public ForecastParent? Forecast = null;
+        public ForecastParent? Forecast { get; set; }
         [JsonPropertyName("alerts")]
-        public WeatherAlert? Alert = null;
+        public WeatherAlert? Alert { get; set; }
 
         [JsonPropertyName("astronomy")]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public AstronomyParent? AstronomyValue = null;
+        public AstronomyParent? AstronomyValue { get; set; }
 
+        [JsonIgnore]
         public ForecastAstrology? Astronomy => AstronomyValue?.Data;
+        
         [JsonPropertyName("error")]
-        public WeatherError? Error = null;
+        public WeatherError? Error { get; set; }
     }
     public class WeatherError
     {
         [JsonPropertyName("code")]
-        public int Code;
+        public int Code { get; set; }
         [JsonPropertyName("message")]
-        public string Message = "";
+        public string Message { get; set; } = "";
     }
 
     public enum USEPAIndex
@@ -70,29 +72,29 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
     public class WeatherCondition
     {
         [JsonPropertyName("text")]
-        public string Text;
+        public string Text { get; set; } = string.Empty;
         [JsonPropertyName("icon")]
-        public string IconUrl;
+        public string IconUrl { get; set; } = string.Empty;
         [JsonPropertyName("code")]
-        public int Code;
+        public int Code { get; set; }
     }
     public class WeatherLocation
     {
         [JsonPropertyName("name")]
-        public string Name;
+        public string Name { get; set; } = string.Empty;
         [JsonPropertyName("region")]
-        public string Region;
+        public string Region { get; set; } = string.Empty;
         [JsonPropertyName("country")]
-        public string Country;
+        public string Country { get; set; } = string.Empty;
         [JsonPropertyName("lat")]
-        public double Latitude;
+        public double Latitude { get; set; }
         [JsonPropertyName("lon")]
-        public double Longitude;
+        public double Longitude { get; set; }
         [JsonPropertyName("tz_id")]
-        public string TimezoneId;
+        public string TimezoneId { get; set; }
         [JsonPropertyName("localtime_epoch")]
-        public long LocalTimestampEpoch;
+        public long LocalTimestampEpoch { get; set; }
         [JsonPropertyName("localtime")]
-        public string LocalTimestamp;
+        public string LocalTimestamp { get; set; } = "0";
     }
 }

--- a/XeniaBot.Shared/Schema/WeatherAPI/WeatherAlert.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/WeatherAlert.cs
@@ -6,6 +6,6 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
     public class WeatherAlert
     {
         [JsonPropertyName("alert")]
-        public WeatherAlertItem[] Items = Array.Empty<WeatherAlertItem>();
+        public WeatherAlertItem[] Items { get; set; } = Array.Empty<WeatherAlertItem>();
     }
 }

--- a/XeniaBot.Shared/Schema/WeatherAPI/WeatherAlertItem.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/WeatherAlertItem.cs
@@ -6,64 +6,55 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
     public class WeatherAlertItem
     {
         [JsonPropertyName("headline")]
-        public string Headline = "";
+        public string Headline { get; set; } = "";
         [JsonPropertyName("msgType")]
-        public string MessageType = "";
+        public string MessageType { get; set; } = "";
         [JsonPropertyName("severity")]
-        public string Severity = "";
+        public string Severity { get; set; } = "";
         [JsonPropertyName("urgency")]
-        public string Urgency = "";
+        public string Urgency { get; set; } = "";
         [JsonPropertyName("areas")]
-        public string Areas = "";
+        public string Areas { get; set; } = "";
         [JsonPropertyName("category")]
-        public string Category = "";
+        public string Category { get; set; } = "";
         [JsonPropertyName("certainty")]
-        public string Certainty = "";
+        public string Certainty { get; set; } = "";
         [JsonPropertyName("event")]
-        public string Event = "";
+        public string Event { get; set; } = "";
         [JsonPropertyName("note")]
-        public string Note = "";
+        public string Note { get; set; } = "";
         /// <summary>
         /// Alert Description
         /// </summary>
         [JsonPropertyName("desc")]
-        public string Description = "";
+        public string Description { get; set; } = "";
         /// <summary>
         /// Instructions
         /// </summary
         [JsonPropertyName("instruction")]
-        public string Instructions = "";
+        public string Instructions { get; set; } = "";
 
         /// <summary>
         /// When weather alert is effective of.
         /// </summary>
         [JsonPropertyName("effective")]
-        public string EffectiveDateValue = "1970-01-01T00:00:00+00:00";
+        public string EffectiveDateValue { get; set; } = "1970-01-01T00:00:00+00:00";
         /// <summary>
         /// When weather alert expires
         /// </summary>
         [JsonPropertyName("expires")]
-        public string ExpiresDateValue = "1970-01-01T00:00:00+00:00";
+        public string ExpiresDateValue { get; set; } = "1970-01-01T00:00:00+00:00";
 
         /// <summary>
         /// <see cref="EffectiveDateValue"/> piped through <see cref="DateTime.Parse(string)"/>
         /// </summary>
-        public DateTime EffectiveDate
-        {
-            get
-            {
-                return DateTime.Parse(EffectiveDateValue);
-            }
-        }
+        [JsonIgnore]
+        public DateTime EffectiveDate => DateTime.Parse(EffectiveDateValue);
+
         /// <summary>
         /// <see cref="ExpiresDateValue"/> piped through <see cref="DateTime.Parse(string)"/>
         /// </summary>
-        public DateTime ExpiresDate
-        {
-            get
-            {
-                return DateTime.Parse(ExpiresDateValue);
-            }
-        }
+        [JsonIgnore]
+        public DateTime ExpiresDate => DateTime.Parse(ExpiresDateValue);
     }
 }

--- a/XeniaBot.Shared/Schema/WeatherAPI/WeatherSearchItem.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPI/WeatherSearchItem.cs
@@ -6,23 +6,23 @@ namespace XeniaBot.Shared.Schema.WeatherAPI
     public class WeatherSearchItem
     {
         [JsonPropertyName("id")]
-        public int Id;
+        public int Id { get; set; }
         [JsonPropertyName("name")]
-        public string Name;
+        public string Name { get; set; } = string.Empty;
         [JsonPropertyName("region")]
-        public string Region;
+        public string Region { get; set; } = string.Empty;
         [JsonPropertyName("country")]
-        public string Country;
+        public string Country { get; set; } = string.Empty;
         [JsonPropertyName("lat")]
-        public double Latitude;
+        public double Latitude { get; set; }
         [JsonPropertyName("lon")]
-        public double Longitude;
+        public double Longitude { get; set; }
         [JsonPropertyName("url")]
-        public string Url;
+        public string Url { get; set; } = string.Empty;
     }
     public class WeatherSearchResponse
     {
-        public WeatherSearchItem[] Response = Array.Empty<WeatherSearchItem>();
-        public WeatherError? Error = null;
+        public WeatherSearchItem[] Response { get; set; } = [];
+        public WeatherError? Error { get; set; }
     }
 }

--- a/XeniaBot.Shared/Schema/WeatherAPIEndpoint.cs
+++ b/XeniaBot.Shared/Schema/WeatherAPIEndpoint.cs
@@ -4,16 +4,16 @@ namespace XeniaBot.Shared.Schema
 {
     public static class WeatherAPIEndpoint
     {
-        public static int[] StatusCodeError => new int[]
-        {
+        public static int[] StatusCodeError =>
+        [
             400,
             401,
             403
-        };
-        public static int[] StatusCodeSuccess => new int[]
-        {
+        ];
+        public static int[] StatusCodeSuccess =>
+        [
             200
-        };
+        ];
         public static string BaseUrl => "http://api.weatherapi.com";
         private static string encode(string value) => HttpUtility.UrlEncode(value);
         private static string encodeBool(bool value) => value ? "yes" : "no";

--- a/XeniaBot.Shared/Services/CoreContext.cs
+++ b/XeniaBot.Shared/Services/CoreContext.cs
@@ -34,6 +34,7 @@ public class CoreContext
             throw new InvalidOperationException("An instance of CoreContext exists already.");
         }
 
+        HumanizerHelper.UpdateVocabulary();
         Details = details;
         RegisteredBaseControllers = [];
         Instance = this;

--- a/XeniaBot.Shared/XeniaBot.Shared.csproj
+++ b/XeniaBot.Shared/XeniaBot.Shared.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="FastCloner" />
     <PackageReference Include="Humanizer" />
     <PackageReference Include="Iminetsoft.CronNET" />
+    <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="kate.shared" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />

--- a/XeniaBot.Shared/XeniaBot.Shared.csproj
+++ b/XeniaBot.Shared/XeniaBot.Shared.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="prometheus-net.AspNetCore" />
     <PackageReference Include="Sentry" />
     <PackageReference Include="Sentry.NLog" />
+    <PackageReference Include="Snappier" />
   </ItemGroup>
 
 </Project>

--- a/XeniaBot.Shared/_Config/AuthentikConfigItem.cs
+++ b/XeniaBot.Shared/_Config/AuthentikConfigItem.cs
@@ -6,8 +6,10 @@ public class AuthentikConfigItem
 {
     [DefaultValue(false)]
     public bool Enable { get; set; } = false;
+    
     [DefaultValue("")]
     public string Token { get; set; } = "";
+    
     [DefaultValue("")]
     public string Url { get; set; } = "";
 

--- a/XeniaBot.Shared/_Config/ConfigData.cs
+++ b/XeniaBot.Shared/_Config/ConfigData.cs
@@ -70,7 +70,11 @@ public class ConfigData
         && !string.IsNullOrEmpty(DashboardUrl)
         && Uri.TryCreate(DashboardUrl, UriKind.Absolute, out var _);
 
-    public string? DashboardUrl { get; set; }
+    public string? DashboardUrl
+    {
+        get;
+        set => field = value?.TrimEnd('/');
+    }
 
     /// <summary>
     /// <para>Is this instance responsible for upgrading database schema?</para>

--- a/XeniaBot.Shared/_Config/ConfigDataV1.cs
+++ b/XeniaBot.Shared/_Config/ConfigDataV1.cs
@@ -5,8 +5,8 @@ namespace XeniaBot.Shared;
 
 public class ConfigDataV1
 {
-    public static string[] IgnoredValidationKeys => new string[]
-    {
+    public static string[] IgnoredValidationKeys =>
+    [
         "DeveloperMode",
         "DeveloperMode_Server",
         "UserWhitelistEnable",
@@ -24,10 +24,10 @@ public class ConfigDataV1
         "Health_Enable",
         "Health_Port",
         "BackpackTFApiKey"
-    };
+    ];
     
-    public static string[] RequiredKeys => new string[]
-    {
+    public static string[] RequiredKeys =>
+    [
         "DiscordToken",
         "ErrorGuild",
         "ErrorChannel",
@@ -35,13 +35,13 @@ public class ConfigDataV1
         "Invite_ClientId",
         "Invite_Permissions",
         "UserWhitelist"
-    };
-    public static string[] RequiredBotKeys => RequiredKeys.Concat(new string[]
+    ];
+    public static string[] RequiredBotKeys => RequiredKeys.Concat(new[]
     {
         "HasDashboard",
         "DashboardLocation"
     }).Distinct().ToArray();
-    public static string[] RequiredDashKeys => RequiredKeys.Concat(new string[]
+    public static string[] RequiredDashKeys => RequiredKeys.Concat(new[]
     {
         "OAuth_ClientId",
         "OAuth_ClientSecret"
@@ -59,152 +59,152 @@ public class ConfigDataV1
     /// <summary>
     /// Discord user token
     /// </summary>
-    public string DiscordToken = "";
+    public string DiscordToken { get; set; } = "";
     /// <summary>
     /// Restrict commands
     /// </summary>
-    public bool DeveloperMode = true;
+    public bool DeveloperMode { get; set; } = true;
     /// <summary>
     /// ServerId to restrict commands to when <see cref="DeveloperMode"/> is `true`
     /// </summary>
-    public ulong DeveloperMode_Server = 0;
-    public bool UserWhitelistEnable = false;
+    public ulong DeveloperMode_Server { get; set; } = 0;
+    public bool UserWhitelistEnable { get; set; } = false;
     /// <summary>
     /// Text Command User whitelist when <see cref="UserWhitelistEnable"/> is `true`
     /// </summary>
-    public ulong[] UserWhitelist = Array.Empty<ulong>();
+    public ulong[] UserWhitelist { get; set; } = Array.Empty<ulong>();
     
     /// <summary>
     /// Text command prefix
     /// </summary>
-    public string Prefix = "x.";
+    public string Prefix { get; set; } = "x.";
 
     /// <summary>
     /// Server Id for error logs
     /// </summary>
-    public ulong ErrorGuild = 0;
+    public ulong ErrorGuild { get; set; } = 0;
     /// <summary>
     /// Channel Id in <see cref="ErrorGuild"/> for error logs
     /// </summary>
-    public ulong ErrorChannel = 0;
+    public ulong ErrorChannel { get; set; } = 0;
     
     /// <summary>
     /// MongoDB Connection URI
     /// </summary>
-    public string MongoDBServer = "";
+    public string MongoDBServer { get; set; } = "";
     
     /// <summary>
     /// Used for custom snowflakes
     /// </summary>
-    public int GeneratorId = 0;
+    public int GeneratorId { get; set; } = 0;
     
     /// <summary>
     /// Server Id for Ban Sync stuff
     /// </summary>
-    public ulong BanSync_AdminServer = 0;
+    public ulong BanSync_AdminServer { get; set; } = 0;
     /// <summary>
     /// Channel Id for ban sync logs
     /// </summary>
-    public ulong BanSync_GlobalLogChannel = 0;
+    public ulong BanSync_GlobalLogChannel { get; set; } = 0;
     /// <summary>
     /// Channel Id for Ban Sync Requesting
     /// </summary>
-    public ulong BanSync_RequestChannel = 0;
+    public ulong BanSync_RequestChannel { get; set; } = 0;
     
     /// <summary>
     /// API Key for weatherapi.com
     /// </summary>
-    public string WeatherAPI_Key = "";
+    public string WeatherAPI_Key { get; set; } = "";
     
     /// <summary>
     /// Google Cloud Key for translation
     /// </summary>
-    public GoogleCloudKey GCSKey_Translate = new GoogleCloudKey();
+    public GoogleCloudKey GCSKey_Translate { get; set; } = new GoogleCloudKey();
     
     /// <summary>
     /// Username for e621.net
     /// </summary>
-    public string ESix_Username = "";
+    public string ESix_Username { get; set; } = "";
     /// <summary>
     /// Api key for e621.net
     /// </summary>
-    public string ESix_ApiKey = "";
+    public string ESix_ApiKey { get; set; } = "";
 
     /// <summary>
     /// Enable prometheus exporter
     /// </summary>
-    public bool   Prometheus_Enable = true;
+    public bool Prometheus_Enable { get; set; } = true;
     /// <summary>
     /// Port to listen the prometheus exporter on
     /// </summary>
-    public int    Prometheus_Port = 4828;
+    public int Prometheus_Port { get; set; } = 4828;
     /// <summary>
     /// Url for the prometheus exporter
     /// </summary>
-    public string Prometheus_Url = "/metrics";
+    public string Prometheus_Url { get; set; } = "/metrics";
     /// <summary>
     /// Hostname for the prometheus exporter. `+` for all/any.
     /// </summary>
-    public string Prometheus_Hostname = "+";
+    public string Prometheus_Hostname { get; set; } = "+";
 
     /// <summary>
     /// ClientId for invite
     /// </summary>
-    public ulong Invite_ClientId = 0;
+    public ulong Invite_ClientId { get; set; } = 0;
     /// <summary>
     /// Calculated permissions for invite link
     /// </summary>
-    public ulong Invite_Permissions = 415471496311;
+    public ulong Invite_Permissions { get; set; } = 415471496311;
 
     /// <summary>
     /// API Token for Authentik server
     /// </summary>
-    public string AuthentikToken = "";
+    public string AuthentikToken { get; set; } = "";
     /// <summary>
     /// Base URL for Authentik server
     /// </summary>
-    public string AuthentikUrl = "";
+    public string AuthentikUrl { get; set; } = "";
     /// <summary>
     /// Enable Authentik admin module
     /// </summary>
-    public bool   AuthentikEnable = false;
+    public bool AuthentikEnable { get; set; } = false;
 
     /// <summary>
     /// Is there a dashboard setup for the bot
     /// </summary>
-    public bool HasDashboard = false;
+    public bool HasDashboard { get; set; } = false;
     /// <summary>
     /// Url for this bot's dashboard.
     /// </summary>
-    public string DashboardLocation = "";
+    public string DashboardLocation { get; set; } = "";
     
     /// <summary>
     /// Client ID for OAuth Web Panel
     /// </summary>
-    public string OAuth_ClientId = "";
+    public string OAuth_ClientId { get; set; } = "";
     /// <summary>
     /// Client Secret for OAuth Web Panel
     /// </summary>
-    public string OAuth_ClientSecret = "";
+    public string OAuth_ClientSecret { get; set; } = "";
 
     /// <summary>
     /// API Token for discordbotlist.com
     /// </summary>
-    public string DiscordBotList_Token = "";
+    public string DiscordBotList_Token { get; set; } = "";
 
-    public bool Health_Enable = false;
-    public int Health_Port = 4829;
+    public bool Health_Enable { get; set; } = false;
+    public int Health_Port { get; set; } = 4829;
 
     /// <summary>
     /// API Key for Backpack.tf
     /// </summary>
-    public string? BackpackTFApiKey = null;
+    public string? BackpackTFApiKey { get; set; } = null;
 
-    public bool Lavalink_Enable = false;
-    public string? Lavalink_Hostname = null;
-    public ushort Lavalink_Port = 2333;
-    public string Lavalink_Auth = "";
-    public bool Lavalink_Secure = false;
+    public bool Lavalink_Enable { get; set; } = false;
+    public string? Lavalink_Hostname { get; set; } = null;
+    public ushort Lavalink_Port { get; set; } = 2333;
+    public string Lavalink_Auth { get; set; } = "";
+    public bool Lavalink_Secure { get; set; } = false;
 
-    public string SupportServerUrl = "";
+    public string SupportServerUrl { get; set; } = string.Empty;
 }

--- a/XeniaBot.Shared/_Config/ConfigValidationResponse.cs
+++ b/XeniaBot.Shared/_Config/ConfigValidationResponse.cs
@@ -8,15 +8,15 @@ public class ConfigValidationResponse
     /// <summary>
     /// Array of keys which haven't been changed from the default values.
     /// </summary>
-    public string[] UnchangedKeys = Array.Empty<string>();
+    public string[] UnchangedKeys { get; set; } = Array.Empty<string>();
     /// <summary>
     /// Array of keys which haven't been changed from the default value. Includes any keys in 
     /// </summary>
-    public string[] UnchangedKeysNoIgnore = Array.Empty<string>();
+    public string[] UnchangedKeysNoIgnore { get; set; } = Array.Empty<string>();
     /// <summary>
     /// Array of keys which are missing from the provided config in <see cref="ConfigService.Validate(Config)"/>
     /// </summary>
-    public string[] MissingKeys = Array.Empty<string>();
+    public string[] MissingKeys { get; set; } = Array.Empty<string>();
     public bool Failure => UnchangedKeys.Length > 0 && MissingKeys.Length > 0;
     public int FailureCount => UnchangedKeys.Length + MissingKeys.Length;
 }

--- a/XeniaBot.Shared/_Config/DevModeConfigItem.cs
+++ b/XeniaBot.Shared/_Config/DevModeConfigItem.cs
@@ -6,11 +6,13 @@ public class DevModeConfigItem
 {
     [DefaultValue(false)]
     public bool Enable { get; set; }
+    
     /// <summary>
     /// GuildId to restrict things to. This doesn't really work all the time, it's best to have a separate private bot for development/testing.
     /// </summary>
     [DefaultValue(0)]
     public ulong GuildId { get; set; }
+    
     [DefaultValue(null)]
     public ulong? GenericLoggingChannelId { get; set; }
 

--- a/XeniaBot.Shared/_Config/GoogleCloudKey.cs
+++ b/XeniaBot.Shared/_Config/GoogleCloudKey.cs
@@ -2,29 +2,28 @@
 
 namespace XeniaBot.Shared;
 
-
 public class GoogleCloudKey
 {
     [JsonPropertyName("type")]
-    public string Type;
+    public string Type { get; set; }
     [JsonPropertyName("project_id")]
-    public string ProjectId;
+    public string ProjectId { get; set; }
     [JsonPropertyName("private_key_id")]
-    public string PrivateKeyId;
+    public string PrivateKeyId { get; set; }
     [JsonPropertyName("private_key")]
-    public string PrivateKey;
+    public string PrivateKey { get; set; }
     [JsonPropertyName("client_email")]
-    public string ClientEmail;
+    public string ClientEmail { get; set; }
     [JsonPropertyName("client_id")]
-    public string ClientId;
+    public string ClientId { get; set; }
     [JsonPropertyName("auth_uri")]
-    public string AuthUri;
+    public string AuthUri { get; set; }
     [JsonPropertyName("token_uri")]
-    public string TokenUri;
+    public string TokenUri { get; set; }
     [JsonPropertyName("auth_provider_x509_cert_url")]
-    public string AuthProviderCertUrl;
+    public string AuthProviderCertUrl { get; set; }
     [JsonPropertyName("client_x509_cert_url")]
-    public string ClientCertUrl;
+    public string ClientCertUrl { get; set; }
     public GoogleCloudKey()
     {
         Type = "";

--- a/XeniaBot.Shared/_Reflection/AttributeHelper.cs
+++ b/XeniaBot.Shared/_Reflection/AttributeHelper.cs
@@ -16,14 +16,12 @@ public static class AttributeHelper
         foreach (var item in classes)
         {
             var descriptor = new ServiceDescriptor(item, item, ServiceLifetime.Singleton);
-            if (!services.Any(e
-                => e.ServiceType == descriptor.ServiceType
-                && e.ImplementationType == descriptor.ImplementationType
-                && e.Lifetime == descriptor.Lifetime))
-            {
-                services.Add(descriptor);
-                Log.Trace($"Registered type: {item}");
-            }
+            if (services.Any(e
+                    => e.ServiceType == descriptor.ServiceType
+                       && e.ImplementationType == descriptor.ImplementationType
+                       && e.Lifetime == descriptor.Lifetime)) continue;
+            services.Add(descriptor);
+            Log.Trace($"Registered type: {item}");
         }
     }
     public static void InjectControllerAttributes(string name, IServiceCollection services)
@@ -38,10 +36,7 @@ public static class AttributeHelper
     }
     public static IEnumerable<Type> GetTypesWithAttribute<T>(Assembly assembly)
     {
-        foreach(Type type in assembly.GetTypes()) {
-            if (type.GetCustomAttributes(typeof(T), true).Length > 0 && type.IsAssignableTo(typeof(IBaseService)) && type != typeof(IBaseService)) {
-                yield return type;
-            }
-        }
+        return assembly.GetTypes()
+            .Where(type => type.GetCustomAttributes(typeof(T), true).Length > 0 && type.IsAssignableTo(typeof(IBaseService)) && type != typeof(IBaseService));
     }
 }

--- a/XeniaBot.Shared/_Reflection/BaseRepository.cs
+++ b/XeniaBot.Shared/_Reflection/BaseRepository.cs
@@ -9,8 +9,8 @@ namespace XeniaBot.Shared;
 /// <summary>
 /// Base controller that interacts with MongoDB
 /// </summary>
-/// <typeparam name="TH">Type of the target collection specified at <see cref="MongoCollectionName"/></typeparam>
-public class BaseRepository<TH> : BaseService
+/// <typeparam name="TCollectionModel">Type of the target collection specified at <see cref="MongoCollectionName"/></typeparam>
+public class BaseRepository<TCollectionModel> : BaseService
 {
     protected IMongoDatabase _db { get; private set; }
     /// <summary>
@@ -44,24 +44,24 @@ public class BaseRepository<TH> : BaseService
     /// <summary>
     /// Get collection with the name of <see cref="MongoCollectionName"/>
     /// </summary>
-    /// <returns>MongoDB Collection with assumed type of <typeparamref name="TH"/> or null if the collection doesn't exist.</returns>
-    public IMongoCollection<TH>? GetCollection()
-        => GetCollection<TH>();
+    /// <returns>MongoDB Collection with assumed type of <typeparamref name="TCollectionModel"/> or null if the collection doesn't exist.</returns>
+    public IMongoCollection<TCollectionModel>? GetCollection()
+        => GetCollection<TCollectionModel>();
 
     /// <summary>
     /// Get collection by <paramref name="name"/>
     /// </summary>
     /// <param name="name">Collection name to fetch</param>
-    /// <returns>MongoDB Collection with assumed type of <typeparamref name="TH"/> or null if the collection doesn't exist.</returns>
-    protected IMongoCollection<TH>? GetCollection(string name)
-        => GetCollection<TH>(name);
+    /// <returns>MongoDB Collection with assumed type of <typeparamref name="TCollectionModel"/> or null if the collection doesn't exist.</returns>
+    protected IMongoCollection<TCollectionModel>? GetCollection(string name)
+        => GetCollection<TCollectionModel>(name);
 
-    public Task<IAsyncCursor<TH>> BaseFind(FilterDefinition<TH> filter, SortDefinition<TH>? sort = null, int? limit = null)
+    public Task<IAsyncCursor<TCollectionModel>> BaseFind(FilterDefinition<TCollectionModel> filter, SortDefinition<TCollectionModel>? sort = null, int? limit = null)
     {
         var collection = GetCollection();
         if (collection == null)
             throw new NoNullAllowedException("GetCollection resulted in null");
-        var opts = new FindOptions<TH, TH>();
+        var opts = new FindOptions<TCollectionModel, TCollectionModel>();
         if (sort != null)
             opts.Sort = sort;
         if (limit != null && limit.HasValue)

--- a/XeniaBot.Shared/_Reflection/BaseService.cs
+++ b/XeniaBot.Shared/_Reflection/BaseService.cs
@@ -9,7 +9,7 @@ public abstract class BaseService : IBaseService
     protected IServiceProvider Services { get; }
     protected BaseService(IServiceProvider services)
     {
-        Priority = Int32.MaxValue;
+        Priority = int.MaxValue;
         Services = services;
     }
 

--- a/XeniaBot.Shared/_Reflection/InteractionHandler.cs
+++ b/XeniaBot.Shared/_Reflection/InteractionHandler.cs
@@ -1,10 +1,12 @@
-﻿using Discord.Interactions;
+﻿using Discord;
+using Discord.Interactions;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
 using Sentry;
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using XeniaBot.Shared.Helpers;
 using XeniaBot.Shared.Services;
@@ -48,16 +50,16 @@ public class InteractionHandler
             lines.Add($"- {item.Name} ({count})");
         }
         Log.Debug($"Loaded [{_interactionService.Modules.Count}] modules\n" + string.Join("\n", lines));
-        _client.InteractionCreated += InteractionCreateAsync;
         _client.ModalSubmitted += ModalSubmittedAsync;
         _client.ButtonExecuted += ButtonExecutedAsync;
+        _client.InteractionCreated += InteractionCreateAsync;
     }
 
     private async Task ButtonExecutedAsync(SocketMessageComponent interaction)
     {
         try
         {
-            var context = new SocketInteractionContext(
+            var context = new SocketInteractionContext<SocketMessageComponent>(
                 _client,
                 interaction);
             var result = await _interactionService.ExecuteCommandAsync(
@@ -82,7 +84,7 @@ public class InteractionHandler
     {
         try
         {
-            var context = new SocketInteractionContext(
+            var context = new SocketInteractionContext<SocketModal>(
                 _client,
                 interaction);
             var result = await _interactionService.ExecuteCommandAsync(
@@ -107,7 +109,7 @@ public class InteractionHandler
     {
         try
         {
-            Log.Trace(interaction.Id);
+            Log.Trace(FormatName(interaction));
             var context = new SocketInteractionContext(
                 _client,
                 interaction);
@@ -127,5 +129,17 @@ public class InteractionHandler
                 scope.SetInteractionInfo(interaction);
             });
         }
+    }
+
+    private static string FormatName(IDiscordInteraction interaction)
+    {
+        var sb = new StringBuilder(interaction.Id.ToString());
+        if (interaction.Data is SocketMessageComponentData messageComponentData)
+        {
+            sb.Append(" - ");
+            sb.Append(messageComponentData.CustomId);
+        }
+
+        return sb.ToString();
     }
 }

--- a/XeniaBot.Shared/_Reflection/InteractionHandler.cs
+++ b/XeniaBot.Shared/_Reflection/InteractionHandler.cs
@@ -73,7 +73,7 @@ public class InteractionHandler
             Log.Error(ex, $"Failed to handle interation {interaction.Id} invoked by user \"{interaction.User.GlobalName}\" ({interaction.User.Username}, {interaction.User.Id})");
             SentrySdk.CaptureException(ex, scope =>
             {
-                SentryHelper.SetInteractionInfo(scope, interaction);
+                scope.SetInteractionInfo(interaction);
             });
         }
     }
@@ -98,7 +98,7 @@ public class InteractionHandler
             Log.Error(ex, $"Failed to handle interation {interaction.Id} invoked by user \"{interaction.User.GlobalName}\" ({interaction.User.Username}, {interaction.User.Id})");
             SentrySdk.CaptureException(ex, scope =>
             {
-                SentryHelper.SetInteractionInfo(scope, interaction);
+                scope.SetInteractionInfo(interaction);
             });
         }
     }
@@ -124,7 +124,7 @@ public class InteractionHandler
             Log.Error(ex, $"Failed to handle interation {interaction.Id} invoked by user \"{interaction.User.GlobalName}\" ({interaction.User.Username}, {interaction.User.Id})");
             SentrySdk.CaptureException(ex, scope =>
             {
-                SentryHelper.SetInteractionInfo(scope, interaction);
+                scope.SetInteractionInfo(interaction);
             });
         }
     }

--- a/XeniaBot.Shared/_Reflection/InteractionHandler.cs
+++ b/XeniaBot.Shared/_Reflection/InteractionHandler.cs
@@ -50,6 +50,32 @@ public class InteractionHandler
         Log.Debug($"Loaded [{_interactionService.Modules.Count}] modules\n" + string.Join("\n", lines));
         _client.InteractionCreated += InteractionCreateAsync;
         _client.ModalSubmitted += ModalSubmittedAsync;
+        _client.ButtonExecuted += ButtonExecutedAsync;
+    }
+
+    private async Task ButtonExecutedAsync(SocketMessageComponent interaction)
+    {
+        try
+        {
+            var context = new SocketInteractionContext(
+                _client,
+                interaction);
+            var result = await _interactionService.ExecuteCommandAsync(
+                context,
+                _services);
+            if (result.Error != null)
+            {
+                Log.Warn(result.ErrorReason);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed to handle interation {interaction.Id} invoked by user \"{interaction.User.GlobalName}\" ({interaction.User.Username}, {interaction.User.Id})");
+            SentrySdk.CaptureException(ex, scope =>
+            {
+                SentryHelper.SetInteractionInfo(scope, interaction);
+            });
+        }
     }
 
     private async Task ModalSubmittedAsync(SocketModal interaction)
@@ -59,9 +85,13 @@ public class InteractionHandler
             var context = new SocketInteractionContext(
                 _client,
                 interaction);
-            await _interactionService.ExecuteCommandAsync(
+            var result = await _interactionService.ExecuteCommandAsync(
                 context,
                 _services);
+            if (result.Error != null)
+            {
+                Log.Warn(result.ErrorReason);
+            }
         }
         catch (Exception ex)
         {
@@ -77,12 +107,17 @@ public class InteractionHandler
     {
         try
         {
+            Log.Trace(interaction.Id);
             var context = new SocketInteractionContext(
                 _client,
                 interaction);
-            await _interactionService.ExecuteCommandAsync(
+            var result = await _interactionService.ExecuteCommandAsync(
                 context,
                 _services);
+            if (!result.IsSuccess)
+            {
+                Log.Warn(result.ErrorReason);
+            }
         }
         catch (Exception ex)
         {

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/AuditController.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/AuditController.cs
@@ -21,7 +21,7 @@ namespace XeniaBot.WebPanel.Areas.RolePreserve.Controllers;
 [AuthRequired]
 [Area("RolePreserve")]
 [Route("~/Guild/{guildId}/[area]/[controller]")]
-[RestrictToGuild(GuildIdRouteKey = "guildId")]
+[RestrictToGuild(GuildIdRouteKey = "guildId", RequiredPermission = GuildPermission.ViewAuditLog)]
 public class AuditController : Controller
 {
     private readonly DiscordSocketClient _discord;

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/AuditController.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/AuditController.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using XeniaBot.Shared.Helpers;
+using XeniaBot.WebPanel.Areas.RolePreserve.Models.Audit;
+using XeniaBot.WebPanel.Extensions;
+using XeniaBot.WebPanel.Models;
+using XeniaDiscord.Data;
+using XeniaDiscord.Data.Models.Snapshot;
+
+namespace XeniaBot.WebPanel.Areas.RolePreserve.Controllers;
+
+[Area("RolePreserve")]
+[Route("~/[area]/[controller]")]
+[AuthRequired]
+[Authorize]
+public class AuditController : Controller
+{
+    private readonly DiscordSocketClient _discord;
+    private readonly XeniaDbContext _db;
+
+    public AuditController(IServiceProvider services)
+    {
+        _discord = services.GetRequiredService<DiscordSocketClient>();
+        _db = services.GetRequiredService<XeniaDbContext>();
+    }
+
+    [HttpGet("Details")]
+    public async Task<IActionResult> GetDetails(Guid id)
+    {
+        if (!HttpContext.IsLoggedIn())
+        {
+            Response.StatusCode = 401;
+            return View("NotAuthorized", new NotAuthorizedViewModel()
+            {
+                Message = "Please log in to view this record.", 
+                ShowLoginButton = true
+            });
+        }
+        var auditRecord = await _db.RolePreserveAudit
+            .Include(e => e.AppliedRoles)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id);
+        if (auditRecord == null)
+        {
+            Response.StatusCode = 404;
+            return View("NotFound", new NotFoundViewModel()
+            {
+                Message = "Could not find Role Preserve Audit record"
+            });
+        }
+        var currentMember = await HttpContext.GetCurrentDiscordGuildMember(auditRecord.GetGuildId());
+        if (currentMember == null || !currentMember.GuildPermissions.Has(GuildPermission.ViewAuditLog))
+        {
+            Response.StatusCode = 401;
+            return View("NotAuthorized", new NotAuthorizedViewModel()
+            {
+                Message = "You do not have permission to view this record. You are either not a member of the server this record belongs to, or you're missing the permission \"View Audit Log\" in the server."
+            });
+        }
+
+        var guild = await ExceptionHelper.RetryOnTimedOut(async () => _discord.GetGuild(auditRecord.GetGuildId()));
+        var guildSnapshot = await _db.GuildSnapshots.AsNoTracking()
+            .Where(e => e.GuildId == auditRecord.GuildId)
+            .OrderByDescending(e => e.RecordCreatedAt)
+            .FirstOrDefaultAsync();
+
+        IUser? user = null;
+        UserSnapshotModel? userSnapshot = null;
+
+        IUser? targetUser = null;
+        UserSnapshotModel? targetUserSnapshot = null;
+        
+        var userId = auditRecord.GetUserId();
+        var targetUserId = auditRecord.GetTargetUserId();
+
+        if (userId.HasValue)
+        {
+            user = await ExceptionHelper.RetryOnTimedOut(async () => _discord.GetUser(userId.Value));
+            userSnapshot = await _db.UserSnapshots.AsNoTracking()
+                .Where(e => e.UserId == auditRecord.UserId)
+                .OrderByDescending(e => e.RecordCreatedAt)
+                .FirstOrDefaultAsync();
+        }
+
+        if (targetUserId.HasValue)
+        {
+            targetUser = await ExceptionHelper.RetryOnTimedOut(async () => _discord.GetUser(targetUserId.Value));
+            targetUserSnapshot = await _db.UserSnapshots.AsNoTracking()
+                .Where(e => e.UserId == auditRecord.TargetUserId)
+                .OrderByDescending(e => e.RecordCreatedAt)
+                .FirstOrDefaultAsync();
+        }
+
+
+        var vm = new DetailsViewModel()
+        {
+            Record = auditRecord,
+            Guild = guild,
+            GuildSnapshot = guildSnapshot,
+            User = user,
+            UserSnapshot = userSnapshot,
+            TargetUser = targetUser,
+            TargetUserSnapshot = targetUserSnapshot,
+            GuildId = auditRecord.GetGuildId()
+        };
+
+        return View("Details", vm);
+    }
+}

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/AuditController.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/AuditController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord;
@@ -16,10 +17,11 @@ using XeniaDiscord.Data.Models.Snapshot;
 
 namespace XeniaBot.WebPanel.Areas.RolePreserve.Controllers;
 
-[Area("RolePreserve")]
-[Route("~/[area]/[controller]")]
-[AuthRequired]
 [Authorize]
+[AuthRequired]
+[Area("RolePreserve")]
+[Route("~/Guild/{guildId}/[area]/[controller]")]
+[RestrictToGuild(GuildIdRouteKey = "guildId")]
 public class AuditController : Controller
 {
     private readonly DiscordSocketClient _discord;
@@ -31,7 +33,7 @@ public class AuditController : Controller
         _db = services.GetRequiredService<XeniaDbContext>();
     }
 
-    [HttpGet("Details")]
+    [Route("Details")]
     public async Task<IActionResult> GetDetails(Guid id)
     {
         if (!HttpContext.IsLoggedIn())
@@ -65,7 +67,7 @@ public class AuditController : Controller
             });
         }
 
-        var guild = await ExceptionHelper.RetryOnTimedOut(async () => _discord.GetGuild(auditRecord.GetGuildId()));
+        var guild = ExceptionHelper.RetryOnTimedOut(() => _discord.GetGuild(auditRecord.GetGuildId()));
         var guildSnapshot = await _db.GuildSnapshots.AsNoTracking()
             .Where(e => e.GuildId == auditRecord.GuildId)
             .OrderByDescending(e => e.RecordCreatedAt)
@@ -82,7 +84,7 @@ public class AuditController : Controller
 
         if (userId.HasValue)
         {
-            user = await ExceptionHelper.RetryOnTimedOut(async () => _discord.GetUser(userId.Value));
+            user = ExceptionHelper.RetryOnTimedOut(() => _discord.GetUser(userId.Value));
             userSnapshot = await _db.UserSnapshots.AsNoTracking()
                 .Where(e => e.UserId == auditRecord.UserId)
                 .OrderByDescending(e => e.RecordCreatedAt)
@@ -91,13 +93,27 @@ public class AuditController : Controller
 
         if (targetUserId.HasValue)
         {
-            targetUser = await ExceptionHelper.RetryOnTimedOut(async () => _discord.GetUser(targetUserId.Value));
+            targetUser = ExceptionHelper.RetryOnTimedOut(() => _discord.GetUser(targetUserId.Value));
             targetUserSnapshot = await _db.UserSnapshots.AsNoTracking()
                 .Where(e => e.UserId == auditRecord.TargetUserId)
                 .OrderByDescending(e => e.RecordCreatedAt)
                 .FirstOrDefaultAsync();
         }
 
+        var roleLookup = new Dictionary<string, StrippedRole>();
+        foreach (var roleId in auditRecord.AppliedRoles
+                     .Select(e => e.RoleId).Distinct())
+        {
+            var roleSnapshot = await _db.GuildRoleSnapshots
+                .Include(e => e.Permissions)
+                .Include(e => e.RoleColors)
+                .AsNoTracking()
+                .Where(e => e.RoleId == roleId)
+                .OrderByDescending(e => e.RecordCreatedAt)
+                .FirstOrDefaultAsync();
+            if (roleSnapshot == null) continue;
+            roleLookup[roleId] = StrippedRole.FromRole(roleSnapshot);
+        }
 
         var vm = new DetailsViewModel()
         {
@@ -108,7 +124,8 @@ public class AuditController : Controller
             UserSnapshot = userSnapshot,
             TargetUser = targetUser,
             TargetUserSnapshot = targetUserSnapshot,
-            GuildId = auditRecord.GetGuildId()
+            GuildId = auditRecord.GetGuildId(),
+            RoleLookup = roleLookup
         };
 
         return View("Details", vm);

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/SettingsController.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/SettingsController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+
+namespace XeniaBot.WebPanel.Areas.RolePreserve.Controllers;
+
+[Authorize]
+[AuthRequired]
+[Area("RolePreserve")]
+[Route("~/Guild/{guildId}/[area]/[controller]")]
+[RestrictToGuild(GuildIdRouteKey = "guildId")]
+public class SettingsController : Controller
+{
+    [Route("", Name = "Guild_RolePreserve_Settings_Index")]
+    public async Task<IActionResult> Index(ulong guildId)
+    {
+        // TODO implement logic to add/remove log channel, if to enable role preservation, and blacklisted roles with role preservation
+        throw new NotImplementedException();
+    }
+}

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/SettingsController.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/SettingsController.cs
@@ -9,11 +9,16 @@ using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using XeniaBot.Shared.Helpers;
+using XeniaBot.Shared.Services;
 using XeniaBot.WebPanel.Areas.RolePreserve.Models.Settings;
+using XeniaBot.WebPanel.Extensions;
 using XeniaBot.WebPanel.Models;
 using XeniaDiscord.Common.Helpers;
+using XeniaDiscord.Common.Services;
 using XeniaDiscord.Data;
 using XeniaDiscord.Data.Models.RolePreserve;
+using XeniaDiscord.Data.Models.Snapshot;
+using XeniaDiscord.Data.Repositories;
 
 namespace XeniaBot.WebPanel.Areas.RolePreserve.Controllers;
 
@@ -24,17 +29,31 @@ namespace XeniaBot.WebPanel.Areas.RolePreserve.Controllers;
 [RestrictToGuild(GuildIdRouteKey = "guildId")]
 public class SettingsController : Controller
 {
+    private readonly GuildCacheRepository _guildCacheRepo;
+    private readonly DiscordSnapshotService _discordSnapshotService;
+    private readonly RolePreserveGuildRepository _rolePreserveGuildRepo;
     private readonly DiscordSocketClient _client;
+    private readonly ErrorReportService _err;
     private readonly XeniaDbContext _db;
 
     public SettingsController(IServiceProvider services)
     {
+        _guildCacheRepo = services.GetRequiredService<GuildCacheRepository>();
+        _discordSnapshotService = services.GetRequiredService<DiscordSnapshotService>();
+        _rolePreserveGuildRepo = services.GetRequiredService<RolePreserveGuildRepository>();
         _client = services.GetRequiredService<DiscordSocketClient>();
+        _err = services.GetRequiredService<ErrorReportService>();
         _db = services.GetRequiredService<XeniaDbContext>();
     }
 
     [Route("", Name = "Guild_RolePreserve_Settings_Index")]
     public async Task<IActionResult> Index(ulong guildId)
+    {
+        var vm = await GetViewModel(guildId);
+        return View("Default", vm);
+    }
+
+    private async Task<DetailsViewModel> GetViewModel(ulong guildId)
     {
         var roles = await GetAvailableRoles(guildId);
         var rolePreserveGuild = await GetRolePreserveGuild(guildId);
@@ -53,8 +72,7 @@ public class SettingsController : Controller
             AvailableChannels = availableChannels
             */
         };
-
-        return View("Default", vm);
+        return vm;
     }
 
     [HttpPost("_ComponentSave", Name = "Guild_RolePreserve_Settings_ComponentSave")]
@@ -82,13 +100,40 @@ public class SettingsController : Controller
             logOpt,
             rolePreserveLogChannel.ParseULong());
         var saveResult = await PerformSave(guildId, saveOptions);
-        throw new NotImplementedException();
+
+        var vm = await GetViewModel(guildId);
+        if (saveResult.IsSuccess)
+        {
+            vm.Alert = new AlertComponentViewModel()
+            {
+                MessageType = "success",
+                Message = "Successfully saved settings",
+                ShowClose = true
+            };
+        }
+        else
+        {
+            var content = string.Join("\n",
+                saveResult.Errors
+                    .Select(e => (string.IsNullOrEmpty(e.Name) ? "" : $"- **{e.Name}:** ") + e.Text));
+            vm.Alert = new AlertComponentViewModel()
+            {
+                MessageType = "danger",
+                Message = $"Failed to save settings:\n{content}",
+                RenderMessageAsMarkdown = true
+            };
+        }
+
+        return PartialView("Default", vm);
     }
 
     private async Task<PerformSaveResult> PerformSave(
         ulong guildId, 
         PerformSaveOptions options)
     {
+        var requestingUser = await HttpContext.GetCurrentDiscordUser();
+        var guildIdStr = guildId.ToString();
+        var guild = ExceptionHelper.RetryOnTimedOut(() => _client.GetGuild(guildId));
         var errors = new List<BasicErrorItem>();
         await PerformSaveValidateLogChannel(guildId, options, errors);
 
@@ -99,24 +144,114 @@ public class SettingsController : Controller
                 Errors = errors.ToArray()
             };
         }
-        
-        // remove items in options.RoleBlacklist for ids that don't exist in discord or cache or snapshots.
-        // remove items in options.RoleBlacklist where the associated guild isn't guildId
 
-        // 1. make new db session
-        // 2. start transaction
-        // 3. save guild to cache/snapshot
-        // 4. refresh cache/snapshot for all referenced roles & tables
-        // 5. refresh cache (if needed) for requestor discord user
-        // 6. create or update RolePreserveGuildModel w/ new enable state
-        // 7. find what blacklisted roles need to be added/removed
-        // 8. (in something like RolePreserveService) send log message saying that enable/disable state was changed, and/or blacklisted roles were added/removed
-        throw new NotImplementedException();
+        var availableRoleIdStrs = await _db.GuildRoleSnapshots
+            .Where(e => e.GuildId == guildIdStr)
+            .Select(e => e.RoleId)
+            .Distinct()
+            .ToArrayAsync();
+        ulong[] discordRoleIds = [];
+        if (guild != null)
+            discordRoleIds = guild.Roles.Select(e => e.Id).ToArray();
+        var availableRoleIds = availableRoleIdStrs.Select(e => e.ParseULong(false).GetValueOrDefault(0))
+            .Concat(discordRoleIds)
+            .Where(e => e > 0)
+            .Distinct()
+            .ToArray();
+
+        var existingBlacklistedRoleIdStrs = await _db.RolePreserveBlacklistedRoles
+            .Where(e => e.GuildId == guildIdStr)
+            .Select(e => e.RoleId)
+            .Distinct()
+            .ToArrayAsync();
+        var existingBlacklistedRoleIds = existingBlacklistedRoleIdStrs
+            .Select(e => e.ParseULong(false).GetValueOrDefault(0))
+            .Where(e => e > 0)
+            .Distinct()
+            .ToArray();
+        var blacklistedRoleIds = options.RoleBlacklist
+            .Where(e => e > 0 && availableRoleIds.Contains(e))
+            .ToArray();
+        
+        var blacklistedRoleIdsToRemove = existingBlacklistedRoleIds
+            .Where(e => !blacklistedRoleIds.Contains(e)).Distinct()
+            .ToArray();
+        var blacklistedRoleIdsToAdd = blacklistedRoleIds
+            .Where(e => !existingBlacklistedRoleIds.Contains(e)).Distinct()
+            .ToArray();
+
+
+        await using var db = _db.CreateSession();
+        var guildLastUpdated = await _guildCacheRepo.LastUpdated(db, guildId);
+        var shouldUpdateCache = DateTime.UtcNow - guildLastUpdated.GetValueOrDefault(DateTime.MinValue)
+                           > TimeSpan.FromDays(7);
+        var now = DateTime.UtcNow;
+        await using var trans = await db.Database.BeginTransactionAsync();
+        try
+        {
+            // refresh cache/snapshot for guild + roles
+            if (shouldUpdateCache && guild != null)
+            {
+                await _discordSnapshotService.UpdateGuild(
+                    db, guild, now, DiscordSnapshotSource.Unknown,
+                    skipRoles: false, skipMembers: true);
+            }
+
+            if (blacklistedRoleIdsToRemove.Length > 0)
+            {
+                await _rolePreserveGuildRepo.RoleBlacklistRemoveRange(
+                    db,
+                    guildId,
+                    blacklistedRoleIdsToRemove,
+                    doneByUser: requestingUser,
+                    now: now);
+            }
+
+            if (blacklistedRoleIdsToAdd.Length > 0)
+            {
+                await _rolePreserveGuildRepo.RoleBlacklistAddRange(
+                    db,
+                    guildId,
+                    blacklistedRoleIdsToAdd,
+                    doneByUser: requestingUser,
+                    now: now);
+            }
+
+            await _rolePreserveGuildRepo.EnableAsync(db, guildId, options.Enable, requestingUser);
+            // TODO for role preserve logging - TODO send message in role preserve log channel saying what stuff has changed (it's audited anyways)
+
+            await db.SaveChangesAsync();
+            await trans.CommitAsync();
+        }
+        catch (Exception ex)
+        {
+            await trans.RollbackAsync();
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes(
+                    $"User {requestingUser?.Username} failed to update Role Preserve Settings for Guild {guild?.Name} (userId={requestingUser?.Id}, guildId={guildId})")
+                .AddSerializedAttachment("options.json", options));
+            await trans.RollbackAsync();
+            return new PerformSaveResult
+            {
+                IsSuccess = false,
+                Errors = [
+                    new BasicErrorItem("Fatal", "Failed to save settings")
+                ]
+            };
+        }
+
+        return new PerformSaveResult
+        {
+            IsSuccess = true,
+            Errors = []
+        };
     }
 
     public class PerformSaveResult
     {
-        public BasicErrorItem[] Errors { get; set; } = [];
+        public bool IsSuccess { get; init; } = false;
+        public BasicErrorItem[] Errors { get; init; } = [];
     }
 
     private async Task PerformSaveValidateLogChannel(

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/SettingsController.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Controllers/SettingsController.cs
@@ -1,7 +1,19 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using XeniaBot.Shared.Helpers;
+using XeniaBot.WebPanel.Areas.RolePreserve.Models.Settings;
+using XeniaBot.WebPanel.Models;
+using XeniaDiscord.Common.Helpers;
+using XeniaDiscord.Data;
+using XeniaDiscord.Data.Models.RolePreserve;
 
 namespace XeniaBot.WebPanel.Areas.RolePreserve.Controllers;
 
@@ -12,10 +24,244 @@ namespace XeniaBot.WebPanel.Areas.RolePreserve.Controllers;
 [RestrictToGuild(GuildIdRouteKey = "guildId")]
 public class SettingsController : Controller
 {
+    private readonly DiscordSocketClient _client;
+    private readonly XeniaDbContext _db;
+
+    public SettingsController(IServiceProvider services)
+    {
+        _client = services.GetRequiredService<DiscordSocketClient>();
+        _db = services.GetRequiredService<XeniaDbContext>();
+    }
+
     [Route("", Name = "Guild_RolePreserve_Settings_Index")]
     public async Task<IActionResult> Index(ulong guildId)
     {
-        // TODO implement logic to add/remove log channel, if to enable role preservation, and blacklisted roles with role preservation
+        var roles = await GetAvailableRoles(guildId);
+        var rolePreserveGuild = await GetRolePreserveGuild(guildId);
+        var roleBlacklist = await GetRoleBlacklist(guildId);
+        var strippedGuild = await GetStrippedGuild(guildId);
+        // TODO for role preserve logging - var logChannel = await GetStrippedLogChannel(guildId);
+        // TODO for role preserve logging - var availableChannels = await GetAvailableChannels(guildId);
+        var vm = new DetailsViewModel()
+        {
+            Enable = rolePreserveGuild?.Enabled == true,
+            RoleBlacklist = roleBlacklist,
+            Guild = strippedGuild,
+            AvailableRoles = roles,
+            /* TODO for role preserve logging
+            LogChannel = logChannel,
+            AvailableChannels = availableChannels
+            */
+        };
+
+        return View("Default", vm);
+    }
+
+    [HttpPost("_ComponentSave", Name = "Guild_RolePreserve_Settings_ComponentSave")]
+    public async Task<IActionResult> SaveComponent(
+        ulong guildId,
+        [FromForm] bool rolePreserveEnable,
+        [FromForm] string[] rolePreserveBlacklistedRoles,
+        [FromForm] bool rolePreserveEnableLogging,
+        [FromForm] bool rolePreserveLogChannelFromFallback,
+        [FromForm] string? rolePreserveLogChannel)
+    {
+        var blacklistedRoleIds = rolePreserveBlacklistedRoles
+            .Select(e => e.ParseULong().GetValueOrDefault(0))
+            .Where(e => e > 0)
+            .ToArray();
+        var logOpt = SaveRolePreserveLogCfgKind.Disabled;
+        if (rolePreserveEnableLogging)
+            logOpt = rolePreserveLogChannelFromFallback
+                ? SaveRolePreserveLogCfgKind.Fallback
+                : SaveRolePreserveLogCfgKind.Custom;
+
+        var saveOptions = new PerformSaveOptions(
+            rolePreserveEnable,
+            blacklistedRoleIds,
+            logOpt,
+            rolePreserveLogChannel.ParseULong());
+        var saveResult = await PerformSave(guildId, saveOptions);
         throw new NotImplementedException();
+    }
+
+    private async Task<PerformSaveResult> PerformSave(
+        ulong guildId, 
+        PerformSaveOptions options)
+    {
+        var errors = new List<BasicErrorItem>();
+        await PerformSaveValidateLogChannel(guildId, options, errors);
+
+        if (errors.Count > 0)
+        {
+            return new PerformSaveResult
+            {
+                Errors = errors.ToArray()
+            };
+        }
+        
+        // remove items in options.RoleBlacklist for ids that don't exist in discord or cache or snapshots.
+        // remove items in options.RoleBlacklist where the associated guild isn't guildId
+
+        // 1. make new db session
+        // 2. start transaction
+        // 3. save guild to cache/snapshot
+        // 4. refresh cache/snapshot for all referenced roles & tables
+        // 5. refresh cache (if needed) for requestor discord user
+        // 6. create or update RolePreserveGuildModel w/ new enable state
+        // 7. find what blacklisted roles need to be added/removed
+        // 8. (in something like RolePreserveService) send log message saying that enable/disable state was changed, and/or blacklisted roles were added/removed
+        throw new NotImplementedException();
+    }
+
+    public class PerformSaveResult
+    {
+        public BasicErrorItem[] Errors { get; set; } = [];
+    }
+
+    private async Task PerformSaveValidateLogChannel(
+        ulong guildId,
+        PerformSaveOptions options,
+        List<BasicErrorItem> errors)
+    {
+        if (options.LogOpt == SaveRolePreserveLogCfgKind.Disabled ||
+            options.LogOpt == SaveRolePreserveLogCfgKind.Fallback)
+            return;
+
+        var logChannelValue = options.LogChannel.GetValueOrDefault(0);
+        if (options.LogOpt == SaveRolePreserveLogCfgKind.Custom)
+        {
+            if (logChannelValue == 0)
+            {
+                errors.Add(new BasicErrorItem("Log Channel", "Value is required"));
+                return;
+            }
+
+
+            var guild = ExceptionHelper.RetryOnTimedOut(() => _client.GetGuild(guildId));
+            var channel = guild.Channels.FirstOrDefault(e => e.Id == logChannelValue);
+            if (channel == null)
+            {
+                errors.Add(new BasicErrorItem("Log Channel", "Does not exist"));
+                return;
+            }
+
+            var channelPermissions = DiscordPermissionHelper.CalculateChannel(guild.CurrentUser, channel);
+            var missingPermissions = new HashSet<string>();
+            if (!channelPermissions.CanPerform(ChannelPermission.SendMessages))
+            {
+                missingPermissions.Add("Send Messages");
+            }
+
+            if (missingPermissions.Count > 0)
+            {
+                errors.Add(new BasicErrorItem("Log Channel", "Xenia is missing the following permissions: " + string.Join(", ", missingPermissions)));
+            }
+        }
+    }
+
+    public sealed record BasicErrorItem(
+        string Name,
+        string Text,
+        bool IsFatal = true);
+
+    public sealed record PerformSaveOptions(
+        bool Enable,
+        ulong[] RoleBlacklist,
+        SaveRolePreserveLogCfgKind LogOpt,
+        ulong? LogChannel);
+
+    public enum SaveRolePreserveLogCfgKind
+    {
+        Disabled,
+        Fallback,
+        Custom
+    }
+
+    // TODO implement logic to return _PartialBlacklistedRoles for HTMX
+    // TODO implement logic to return _PartialEnableFlag for HTMX
+    // TODO implement logic to save blacklisted roles, and return _PartialBlacklistedRoles
+    // TODO implement logic to save "Enable" and return _PartialEnableFlag
+
+    // TODO for role preserve logging - implement logic to return _PartialLogChannel for HTMX
+    // TODO for role preserve logging - add logic to fetch StrippedChannel? for current log channel
+    // TODO for role preserve logging - add logic to fetch available channels for selecting new log channel
+    // TODO for role preserve logging - implement logic to save log channel
+
+    private async Task<StrippedGuild> GetStrippedGuild(ulong guildId)
+    {
+        var discordGuild = ExceptionHelper.RetryOnTimedOut(() => _client.GetGuild(guildId));
+        if (discordGuild != null) return StrippedGuild.FromGuild(discordGuild);
+        
+        var guildIdStr = guildId.ToString();
+        var snapshot = await _db.GuildSnapshots
+            .AsNoTracking()
+            .Where(e => e.GuildId == guildIdStr)
+            .OrderByDescending(e => e.RecordCreatedAt)
+            .FirstOrDefaultAsync();
+        return StrippedGuild.FromExisting(null, snapshot, guildId);
+    }
+
+    private async Task<List<StrippedRole>> GetAvailableRoles(ulong guildId)
+    {
+        var guildIdStr = guildId.ToString();
+        var discordGuild = ExceptionHelper.RetryOnTimedOut(() => _client.GetGuild(guildId));
+        if (discordGuild != null)
+        {
+            return discordGuild.Roles
+                .Select(StrippedRole.FromRole)
+                .OrderBy(e => e.Position)
+                .ToList();
+        }
+
+        var records = await _db.GuildRoleCache
+            .Include(e => e.Snapshot)
+            .ThenInclude(e => e.Permissions)
+            .AsNoTracking()
+            .Where(e => e.GuildId == guildIdStr && !e.IsDeleted)
+            .OrderBy(e => e.Position)
+            .Select(e => e.Snapshot)
+            .ToArrayAsync();
+        return records.Select(StrippedRole.FromRole).ToList();
+    }
+
+    private async Task<List<StrippedRole>> GetRoleBlacklist(ulong guildId)
+    {
+        var guildIdStr = guildId.ToString();
+        var roleIds = await _db.RolePreserveBlacklistedRoles.AsNoTracking()
+            .Where(e => e.GuildId == guildIdStr)
+            .OrderBy(e => e.RoleId)
+            .Select(e => e.RoleId)
+            .ToArrayAsync();
+        var roleSnapshots = await _db.GuildRoleCache
+            .AsNoTracking()
+            .Include(e => e.Snapshot)
+            .ThenInclude(e => e.Permissions)
+            .Where(e => ((IEnumerable<string>)roleIds).Contains(e.RoleId))
+            .Select(e => e.Snapshot)
+            .ToListAsync();
+        var result = roleSnapshots.Select(StrippedRole.FromRole).ToList();
+        
+        foreach (var roleId in roleIds.Where(e => roleSnapshots.All(x => x.RoleId != e)))
+        {
+            var id = roleId.ParseULong(false);
+            if (!id.HasValue) continue;
+            result.Add(new StrippedRole()
+            {
+                Id = id.Value,
+                Name = $"{id}"
+            });
+        }
+
+        return result.OrderBy(e => e.Id).ToList();
+    }
+
+    private async Task<RolePreserveGuildModel?> GetRolePreserveGuild(ulong guildId)
+    {
+        var guildIdStr = guildId.ToString();
+        return await _db.RolePreserveGuilds
+            .AsNoTracking()
+            .Include(e => e.BlacklistedRoles)
+            .FirstOrDefaultAsync(e => e.GuildId == guildIdStr);
     }
 }

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Models/Audit/DetailsViewModel.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Models/Audit/DetailsViewModel.cs
@@ -1,0 +1,23 @@
+﻿using Discord;
+using Discord.WebSocket;
+using XeniaBot.WebPanel.Models;
+using XeniaDiscord.Data.Models.RolePreserve;
+using XeniaDiscord.Data.Models.Snapshot;
+
+namespace XeniaBot.WebPanel.Areas.RolePreserve.Models.Audit;
+
+public class DetailsViewModel
+{
+    public SocketGuild? Guild { get; set; }
+    public GuildSnapshotModel? GuildSnapshot { get; set; }
+
+    public IUser? User { get; set; }
+    public UserSnapshotModel? UserSnapshot { get; set; }
+    
+    public IUser? TargetUser { get; set; }
+    public UserSnapshotModel? TargetUserSnapshot { get; set; }
+
+    public AlertComponentViewModel? Alert { get; set; }
+    public ulong GuildId { get; set; }
+    public required RolePreserveAuditModel Record { get; set; }
+}

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Models/Audit/DetailsViewModel.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Models/Audit/DetailsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Discord;
+﻿using System.Collections.Generic;
+using Discord;
 using Discord.WebSocket;
 using XeniaBot.WebPanel.Models;
 using XeniaDiscord.Data.Models.RolePreserve;
@@ -20,4 +21,6 @@ public class DetailsViewModel
     public AlertComponentViewModel? Alert { get; set; }
     public ulong GuildId { get; set; }
     public required RolePreserveAuditModel Record { get; set; }
+
+    public Dictionary<string, StrippedRole> RoleLookup { get; set; } = [];
 }

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Models/Settings/DetailsViewModel.cs
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Models/Settings/DetailsViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using XeniaBot.WebPanel.Models;
+
+namespace XeniaBot.WebPanel.Areas.RolePreserve.Models.Settings;
+
+public class DetailsViewModel
+{
+    public ulong GuildId => Guild.Id;
+    public required StrippedGuild Guild { get; set; }
+    public bool Enable { get; set; }
+    public List<StrippedRole> RoleBlacklist { get; set; } = [];
+    public List<StrippedRole> AvailableRoles { get; set; } = [];
+    // TODO implement this once proper logging has been implemented for role preserve
+    // public StrippedChannel? LogChannel { get; set; }
+    // public List<StrippedChannel> AvailableChannels { get; set; } = [];
+
+    public AlertComponentViewModel? Alert { get; set; }
+}

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/Details.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/Details.cshtml
@@ -1,5 +1,19 @@
-﻿@using XeniaBot.WebPanel.Areas.RolePreserve.Models.Audit
+﻿@using Microsoft.AspNetCore.Http
+@using XeniaBot.WebPanel.Areas.RolePreserve.Models.Audit
+@using XeniaBot.WebPanel.Extensions
+@inject IHttpContextAccessor HttpContextAccessor
 @model DetailsViewModel
+@{
+    if (HttpContextAccessor?.HttpContext?.IsHtmxRequest() == true)
+    {
+        Layout = null;
+    }
+    else
+    {
+        ViewBag.Title = "Role Preserve Audit Log Entry";
+        Layout = "_Layout";
+    }
+}
 @{
     await Html.RenderPartialAsync("_PartialDetails");
 }

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/Details.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/Details.cshtml
@@ -1,0 +1,5 @@
+﻿@using XeniaBot.WebPanel.Areas.RolePreserve.Models.Audit
+@model DetailsViewModel
+@{
+    await Html.RenderPartialAsync("_PartialDetails");
+}

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/_PartialDetails.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/_PartialDetails.cshtml
@@ -1,4 +1,4 @@
-﻿@using kate.shared.Extensions
+﻿@using Humanizer
 @using XeniaBot.Shared
 @using XeniaBot.WebPanel.Areas.RolePreserve.Models.Audit
 @using XeniaBot.WebPanel.Models
@@ -20,24 +20,21 @@
 }
 
 @await Component.InvokeAsync("GuildBanner",
-    new GuildBannerViewModel()
-    {
-        Guild = StrippedGuild.FromExisting(Model.Guild, Model.GuildSnapshot, Model.GuildId),
-        Parameters = new GuildBannerViewParameters(
-            Model.GuildId, true,
-            [
-                new("Servers", "Server", "List"),
-                new(guildName, "Server", "Index", new Dictionary<string, string>()
-                {
-                    {"id", Model.GuildId.ToString()}
-                }),
-                new("Role Preserve"),
-                new("Audit Log")
-            ])
-    })
+    new GuildBannerViewParameters(
+        Model.GuildId, true,
+        [
+            new("Servers", "Server", "List"),
+            new(guildName, "Server", "Index", new Dictionary<string, string>()
+            {
+                {"id", Model.GuildId.ToString()}
+            }),
+            new("Role Preserve"),
+            new("Audit Log")
+        ]))
+
 <table class="table table-fluid">
     <tr>
-        <th>Id</th>
+        <th>Record Id</th>
         <td>
             <code>@Model.Record.Id</code>
         </td>
@@ -47,13 +44,13 @@
         <td>
             @Model.Record.RecordCreatedAt.ToString("yyyy/MM/dd")
             <br/>
-            @Model.Record.RecordCreatedAt.ToString("HH:mm:ss tt")
+            @Model.Record.RecordCreatedAt.ToString("hh:mm:ss tt") <sup>UTC</sup>
         </td>
     </tr>
     <tr>
         <th>Action</th>
         <td>
-            @Model.Record.Action.ToDescriptionString(Model.Record.Action.ToString())
+            @Model.Record.Action.Humanize(LetterCasing.Title)
         </td>
     </tr>
     @if (Model.Record.TargetUserId != null)
@@ -87,22 +84,25 @@
             <h5>Applied Roles</h5>
         </div>
         <div class="card-body">
-            <table class="table table-fluid">
-                <thead>
-                <tr>
-                    <th>Role</th>
-                    <th>Action</th>
-                </tr>
-                </thead>
-                <tbody>
-                @foreach (var appliedRole in Model.Record.AppliedRoles)
+            @foreach (var group in Model.Record.AppliedRoles.GroupBy(e => e.Action))
+            {
+                <h6>@group.Key.Humanize(LetterCasing.Title)</h6>
+                @foreach (var appliedRole in group)
                 {
-                    <tr data-appliedrole-id="@appliedRole.RoleId">
-                        @* TODO: Implement UI for viewing applied roles and utilize GuildRoleCache for role name and position *@
-                    </tr>
+                    @if (Model.RoleLookup.TryGetValue(appliedRole.RoleId, out var strippedRole))
+                    {
+                        @await Component.InvokeAsync("RolePill", new RolePillComponentModel()
+                        {
+                            Role = strippedRole,
+                            TooltipMode = RolePillComponentTooltipMode.RoleIdAndPermissions
+                        })
+                    }
+                    else
+                    {
+                        <span class="badge text-bg-danger" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Could not find role snapshot"><code>@appliedRole.RoleId</code></span>
+                    }
                 }
-                </tbody>
-            </table>
+            }
         </div>
     </div>
 }

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/_PartialDetails.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/_PartialDetails.cshtml
@@ -4,13 +4,9 @@
 @using XeniaBot.WebPanel.Models
 @using XeniaDiscord.Data
 @model DetailsViewModel
-@if (Model.Alert != null)
-{
-    @await Component.InvokeAsync("Alert", Model.Alert)
-}
-
 @{
     var guildName = Model.Guild?.Name ?? Model.GuildSnapshot?.Name ?? Model.GuildId.ToString();
+    var guildIdStr = Model.GuildId.ToString();
 
     var targetUsername = Model.TargetUser?.FormatUsername() ?? Model.TargetUserSnapshot?.FormatUsername() ?? Model.Record.TargetUserId?.ToString() ?? "Unknown User";
     var targetUserAvatar = Model.TargetUser?.GetDisplayAvatarUrl() ?? Model.TargetUserSnapshot?.DisplayAvatarUrl ?? "/DebugEmpty.png";
@@ -26,11 +22,20 @@
             new("Servers", "Server", "List"),
             new(guildName, "Server", "Index", new Dictionary<string, string>()
             {
-                {"id", Model.GuildId.ToString()}
+                {"id", guildIdStr}
             }),
-            new("Role Preserve"),
+            new("Role Preserve", "Settings", "Index", new Dictionary<string, string>()
+            {
+                { "area", "RolePreserve" },
+                { "id", guildIdStr }
+            }),
             new("Audit Log")
         ]))
+
+@if (Model.Alert != null)
+{
+    @await Component.InvokeAsync("Alert", Model.Alert)
+}
 
 <table class="table table-fluid">
     <tr>

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/_PartialDetails.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Audit/_PartialDetails.cshtml
@@ -1,0 +1,108 @@
+﻿@using kate.shared.Extensions
+@using XeniaBot.Shared
+@using XeniaBot.WebPanel.Areas.RolePreserve.Models.Audit
+@using XeniaBot.WebPanel.Models
+@using XeniaDiscord.Data
+@model DetailsViewModel
+@if (Model.Alert != null)
+{
+    @await Component.InvokeAsync("Alert", Model.Alert)
+}
+
+@{
+    var guildName = Model.Guild?.Name ?? Model.GuildSnapshot?.Name ?? Model.GuildId.ToString();
+
+    var targetUsername = Model.TargetUser?.FormatUsername() ?? Model.TargetUserSnapshot?.FormatUsername() ?? Model.Record.TargetUserId?.ToString() ?? "Unknown User";
+    var targetUserAvatar = Model.TargetUser?.GetDisplayAvatarUrl() ?? Model.TargetUserSnapshot?.DisplayAvatarUrl ?? "/DebugEmpty.png";
+
+    var userFormatted = Model.User?.FormatUsername() ?? Model.UserSnapshot?.FormatUsername() ?? Model.Record.UserId;
+    var userAvatar = Model.User?.GetDisplayAvatarUrl() ?? Model.UserSnapshot?.DisplayAvatarUrl ?? "/DebugEmpty.png";
+}
+
+@await Component.InvokeAsync("GuildBanner",
+    new GuildBannerViewModel()
+    {
+        Guild = StrippedGuild.FromExisting(Model.Guild, Model.GuildSnapshot, Model.GuildId),
+        Parameters = new GuildBannerViewParameters(
+            Model.GuildId, true,
+            [
+                new("Servers", "Server", "List"),
+                new(guildName, "Server", "Index", new Dictionary<string, string>()
+                {
+                    {"id", Model.GuildId.ToString()}
+                }),
+                new("Role Preserve"),
+                new("Audit Log")
+            ])
+    })
+<table class="table table-fluid">
+    <tr>
+        <th>Id</th>
+        <td>
+            <code>@Model.Record.Id</code>
+        </td>
+    </tr>
+    <tr>
+        <th>Created At</th>
+        <td>
+            @Model.Record.RecordCreatedAt.ToString("yyyy/MM/dd")
+            <br/>
+            @Model.Record.RecordCreatedAt.ToString("HH:mm:ss tt")
+        </td>
+    </tr>
+    <tr>
+        <th>Action</th>
+        <td>
+            @Model.Record.Action.ToDescriptionString(Model.Record.Action.ToString())
+        </td>
+    </tr>
+    @if (Model.Record.TargetUserId != null)
+    {
+        <tr>
+            <th>Target User</th>
+            <td>
+                <img src="@targetUserAvatar" class="card-img-top smallUserIcon" />
+                @targetUsername<br />
+                <sup><code>@Model.Record.TargetUserId</code></sup>
+            </td>
+        </tr>
+    }
+    @if (Model.Record.UserId != null)
+    {
+        <tr>
+            <th>User</th>
+            <td>
+                <img src="@userAvatar" class="card-img-top smallUserIcon" />
+                @userFormatted<br />
+                <sup><code>@Model.Record.UserId</code></sup>
+            </td>
+        </tr>
+    }
+</table>
+
+@if (Model.Record.AppliedRoles.Count > 0)
+{
+    <div class="card">
+        <div class="card-header">
+            <h5>Applied Roles</h5>
+        </div>
+        <div class="card-body">
+            <table class="table table-fluid">
+                <thead>
+                <tr>
+                    <th>Role</th>
+                    <th>Action</th>
+                </tr>
+                </thead>
+                <tbody>
+                @foreach (var appliedRole in Model.Record.AppliedRoles)
+                {
+                    <tr data-appliedrole-id="@appliedRole.RoleId">
+                        @* TODO: Implement UI for viewing applied roles and utilize GuildRoleCache for role name and position *@
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/Default.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/Default.cshtml
@@ -13,6 +13,8 @@
         Layout = "_Layout";
     }
 }
-@{
-    await Html.RenderPartialAsync("_PartialDefault");
-}
+<div id="guild-rolepreserve-settings">
+    @{
+        await Html.RenderPartialAsync("_PartialDefault");
+    }
+</div>

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/Default.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/Default.cshtml
@@ -1,0 +1,18 @@
+﻿@using Microsoft.AspNetCore.Http
+@using XeniaBot.WebPanel.Extensions
+@inject IHttpContextAccessor HttpContextAccessor
+@model XeniaBot.WebPanel.Areas.RolePreserve.Models.Settings.DetailsViewModel
+@{
+    if (HttpContextAccessor?.HttpContext?.IsHtmxRequest() == true)
+    {
+        Layout = null;
+    }
+    else
+    {
+        ViewBag.Title = $"Role Preserve - {Model.Guild.Name}";
+        Layout = "_Layout";
+    }
+}
+@{
+    await Html.RenderPartialAsync("_PartialDefault");
+}

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/_PartialDefault.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/_PartialDefault.cshtml
@@ -23,6 +23,10 @@
     @await Component.InvokeAsync("Alert", Model.Alert)
 }
 
+@{
+    var serverLogPage = Url.Action("ModerationView", "Server", new { id = Model.GuildId });
+}
+
 @* TODO show warning if Xenia won't be able to give back roles due to hierarchy issues *@
 @* TODO Implement logic to add roles to blacklist *@
 <form enctype="multipart/form-data"
@@ -37,7 +41,9 @@
             If you disable Role Preservation, Xenia will continue to capture "snapshots" of what roles your members have, just in-case if you want to enable it or re-enable it.<br />
             <br />
             You can also tell Xenia to "ignore" specific roles from being given back to users with the <code>/rolepreserve blacklist-add</code> command.
-            At the moment you can only view "ignored" roles in the dashboard, but in the future, you'll be able to add roles to "ignore" in the dashboard.
+            At the moment you can only view "ignored" roles in the dashboard, but in the future, you'll be able to add roles to "ignore" in the dashboard.<br/>
+            <br/>
+            <strong>If you would like to enable logging, please enable the "Role Preserve" server log event in a channel in the <a href="@serverLogPage">Server Log settings</a> page.</strong>
         </div>
     </div>
     @{

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/_PartialDefault.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/_PartialDefault.cshtml
@@ -1,0 +1,33 @@
+﻿@using XeniaBot.WebPanel.Areas.RolePreserve.Models.Settings
+@using XeniaBot.WebPanel.Models
+@model DetailsViewModel
+
+@await Component.InvokeAsync("GuildBanner",
+    new GuildBannerViewParameters(
+        Model.GuildId, true,
+        [
+            new("Servers", "Server", "List"),
+            new(Model.Guild.Name, "Server", "Index", new Dictionary<string, string>()
+            {
+                {"id", Model.GuildId.ToString()}
+            }),
+            new("Role Preserve")
+        ]))
+
+@if (Model.Alert != null)
+{
+    @await Component.InvokeAsync("Alert", Model.Alert)
+}
+
+@* show warning if Xenia won't be able to give back roles due to hierarchy issues *@
+@* TODO send hx-post to /Guild/{guildId}/RolePreserve/Settings/_ComponentSave
+    and also swap outerHTML for #guild-rolepreserve-settings
+    check Kasta or GetPsyched.PartnerApp for a refresher on how to implement
+*@
+<form id="guild-rolepreserve-settings"
+      hx-post="">
+      
+    <button type="submit" class="btn btn-success">
+        Save
+    </button>
+</form>

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/_PartialDefault.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/_PartialDefault.cshtml
@@ -11,6 +11,10 @@
             {
                 {"id", Model.GuildId.ToString()}
             }),
+            new("Moderation")
+            {
+                Href = $"/Server/{Model.GuildId}/Moderation"
+            },
             new("Role Preserve")
         ]))
 

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/_PartialDefault.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/Settings/_PartialDefault.cshtml
@@ -19,14 +19,51 @@
     @await Component.InvokeAsync("Alert", Model.Alert)
 }
 
-@* show warning if Xenia won't be able to give back roles due to hierarchy issues *@
-@* TODO send hx-post to /Guild/{guildId}/RolePreserve/Settings/_ComponentSave
-    and also swap outerHTML for #guild-rolepreserve-settings
-    check Kasta or GetPsyched.PartnerApp for a refresher on how to implement
-*@
-<form id="guild-rolepreserve-settings"
-      hx-post="">
-      
+@* TODO show warning if Xenia won't be able to give back roles due to hierarchy issues *@
+@* TODO Implement logic to add roles to blacklist *@
+<form enctype="multipart/form-data"
+      hx-post="/Guild/@Model.GuildId/RolePreserve/Settings/_ComponentSave"
+      hx-target="#guild-rolepreserve-settings"
+      hx-swap="innerHTML">
+    <div class="form-check mb-3">
+        <input class="form-check-input" name="rolePreserveEnable" type="checkbox" value="true" id="role_preserve-enable" checked="@Model.Enable" />
+        <label class="form-check-label" for="role_preserve-enable">Enable Feature</label>
+        <div id="role_preserve-enable-help" class="form-text">
+            Role Preservation restores a members roles when they re-join. Xenia is only able to grant roles if the automatically generated <code>xenia</code> role is above the ones you want to be restored.<br />
+            If you disable Role Preservation, Xenia will continue to capture "snapshots" of what roles your members have, just in-case if you want to enable it or re-enable it.<br />
+            <br />
+            You can also tell Xenia to "ignore" specific roles from being given back to users with the <code>/rolepreserve blacklist-add</code> command.
+            At the moment you can only view "ignored" roles in the dashboard, but in the future, you'll be able to add roles to "ignore" in the dashboard.
+        </div>
+    </div>
+    @{
+        var anyBlacklistedRolesText = Model.RoleBlacklist.Count == 0 ? "no" : "yes";
+    }
+    <hr/>
+    <div class="mb-3">
+        <label class="form-label">Blacklisted Roles</label>
+        <div id="role_preserve-blacklisted_roles" data-xenia-anyblacklistedroles="@anyBlacklistedRolesText">
+            @if (Model.RoleBlacklist.Count == 0)
+            {
+                <span class="badge text-bg-secondary"><i>No blacklisted roles</i></span>
+            }
+            @foreach (var item in Model.RoleBlacklist)
+            {
+                @await Component.InvokeAsync("RolePill", new RolePillComponentModel
+                {
+                    Role = item,
+                    TooltipMode = RolePillComponentTooltipMode.RoleId,
+                    InputOptions = new RolePillInputOptions
+                    {
+                        Name = "rolePreserveBlacklistedRoles",
+                        Value = item.Id.ToString(),
+                        AllowRemoval = false
+                    }
+                })
+            }
+        </div>
+    </div>
+    <hr />
     <button type="submit" class="btn btn-success">
         Save
     </button>

--- a/XeniaBot.WebPanel/Areas/RolePreserve/Views/_ViewImports.cshtml
+++ b/XeniaBot.WebPanel/Areas/RolePreserve/Views/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+﻿@using XeniaBot.WebPanel
+@using XeniaBot.WebPanel.Areas.ServerSettings.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/XeniaBot.WebPanel/AuthRequiredAttribute.cs
+++ b/XeniaBot.WebPanel/AuthRequiredAttribute.cs
@@ -22,15 +22,16 @@ public class AuthRequiredAttribute : ActionFilterAttribute
     #region Obsolete
     /// <summary>
     /// <para><b>Will be removed in a later update</b></para>
-    /// <para>Optional: Requesting User Id must be in the provided guild and must have the Manage Server permission.</para>
+    /// <para>Optional: Requesting User ID must be in the provided guild and must have the Manage Server permission.</para>
     /// </summary>
     [DefaultValue(null)]
     [Obsolete("Will be removed in a later update.")]
     public ulong? RequireGuildId { get; set; }
+
     /// <summary>
     /// <para><b>Will be removed in a later update. Use <see cref="RestrictToGuildAttribute"/> instead.</b></para>
     /// 
-    /// <para>Route/Parameter name where the Guild Id is set.</para>
+    /// <para>Route/Parameter name where the Guild ID is set.</para>
     ///
     /// <para>Requesting User must have the Manage Server permission</para>
     ///
@@ -39,6 +40,7 @@ public class AuthRequiredAttribute : ActionFilterAttribute
     [DefaultValue(null)]
     [Obsolete("Will be removed in a later update. Use RestrictToGuildAttribute instead.")]
     public string? GuildIdRouteDataName { get; set; }
+    
     /// <summary>
     /// <para><b>Will be removed in a later update. Use <see cref="RequireSuperuserAttribute"/> instead.</b></para>
     /// Require the requesting user to be in <see cref="ConfigData.UserWhitelist"/>. Used for bot owner-only sections.
@@ -47,6 +49,7 @@ public class AuthRequiredAttribute : ActionFilterAttribute
     [Obsolete("Will be removed in a later update. Use RequireSuperuserAttribute instead.")]
     public bool RequireWhitelist { get; set; }
     #endregion
+    
     public override void OnActionExecuting(ActionExecutingContext context)
     {
         // Only allow authenticated users.
@@ -69,7 +72,7 @@ public class AuthRequiredAttribute : ActionFilterAttribute
             return;
         }
 
-        ulong? targetGuildId = RequireGuildId;
+        var targetGuildId = RequireGuildId;
         if (GuildIdRouteDataName != null)
         {
             if (context.RouteData.Values.TryGetValue(GuildIdRouteDataName, out var s))
@@ -77,8 +80,8 @@ public class AuthRequiredAttribute : ActionFilterAttribute
                 try
                 {
                     targetGuildId = ulong.Parse(s?.ToString() ?? "0");
-                    if (targetGuildId == null || targetGuildId < 1)
-                        throw new Exception();
+                    if (targetGuildId is null or < 1)
+                        throw new InvalidOperationException("Invalid TargetGuildId");
                 }
                 catch
                 {
@@ -105,7 +108,7 @@ public class AuthRequiredAttribute : ActionFilterAttribute
         if (targetGuildId != null)
         {
             var userId = AspHelper.GetUserId(context.HttpContext) ?? 0;
-            bool canAccess = AspHelper.CanAccessGuild((ulong)targetGuildId!, userId);
+            var canAccess = AspHelper.CanAccessGuild((ulong)targetGuildId!, userId);
             if (!canAccess)
             {
                 context.Result = new ViewResult

--- a/XeniaBot.WebPanel/Controllers/ReminderController.cs
+++ b/XeniaBot.WebPanel/Controllers/ReminderController.cs
@@ -82,7 +82,7 @@ public class ReminderController : BaseXeniaController
 
         dbResult.MarkAsComplete();
         await db.Set(dbResult);
-        
+        _logger.LogInformation("Deleted reminder {ReminderId}", id);
         return RedirectToAction("Index", new Dictionary<string, object>()
         {
             {"message", "Successfully deleted reminder"},

--- a/XeniaBot.WebPanel/Controllers/ServerController.cs
+++ b/XeniaBot.WebPanel/Controllers/ServerController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions;
 using XeniaBot.MongoData;
 using XeniaBot.Shared.Services;
 using XeniaBot.WebPanel.Helpers;
@@ -71,6 +72,15 @@ public partial class ServerController : BaseXeniaController
     [RestrictToGuild(GuildIdRouteKey = "id")]
     public async Task<IActionResult> ModerationView(ulong id, string? messageType = null, string? message = null)
     {
+        var result = await GetModerationView(id, messageType, message);
+        if (result.IsFailure) return result.Error;
+        return View("Details/ModerationView", result.Value);
+    }
+
+    private async Task<Result<ServerDetailsViewModel, IActionResult>> GetModerationView(
+        ulong id,
+        string? messageType = null, string? message = null)
+    {
         var userId = AspHelper.GetUserId(HttpContext);
         if (userId == null)
             return View("NotFound", "User not found");
@@ -82,15 +92,20 @@ public partial class ServerController : BaseXeniaController
 
         var data = await GetDetails(guild.Id);
         data.User = guildUser;
-        
+
         await PopulateModel(data);
-        if (messageType != null)
-            data.MessageType = messageType;
-        if (message != null)
-            data.Message = message;
-        
-        return View("Details/ModerationView", data);
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            data.Alert = new AlertComponentViewModel
+            {
+                MessageType = messageType ?? "info",
+                Message = message,
+                ShowClose = true
+            };
+        }
+        return data;
     }
+
     [HttpGet("~/Server/{id}/Fun")]
     [AuthRequired]
     [RestrictToGuild(GuildIdRouteKey = "id")]

--- a/XeniaBot.WebPanel/Controllers/ServerController.cs
+++ b/XeniaBot.WebPanel/Controllers/ServerController.cs
@@ -223,11 +223,9 @@ public partial class ServerController : BaseXeniaController
         foreach (var item in _discord.Guilds)
         {
             var guildUser = item.GetUser(user.Id);
-            if (guildUser == null)
+            if (guildUser?.GuildPermissions.ManageGuild != true)
                 continue;
-            if (!guildUser.GuildPermissions.ManageGuild)
-                continue;
-            dataItems.Add(new ServerListViewModelItem()
+            dataItems.Add(new ServerListViewModelItem
             {
                 Guild = item,
                 GuildUser = guildUser

--- a/XeniaBot.WebPanel/Controllers/ServerController_Helper.cs
+++ b/XeniaBot.WebPanel/Controllers/ServerController_Helper.cs
@@ -1,18 +1,59 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using XeniaBot.MongoData.Models;
+using XeniaBot.Shared.Helpers;
 using XeniaBot.WebPanel.Helpers;
 using XeniaBot.WebPanel.Models;
+using XeniaDiscord.Data.Models.BanSync;
+using XeniaDiscord.Data.Models.ServerLog;
+using RolePreserveGuildModel = XeniaDiscord.Data.Models.RolePreserve.RolePreserveGuildModel;
 
 namespace XeniaBot.WebPanel.Controllers;
 
 public partial class ServerController
 {
-    public async Task<ServerDetailsViewModel> GetDetails(ulong serverId)
+    [NonAction]
+    public async Task<ServerDetailsViewModel> GetDetails(ulong guildId)
     {
-        var data = new ServerDetailsViewModel();
-        var guild = _discord.GetGuild(serverId);
-        data.User = guild.GetUser(AspHelper.GetUserId(HttpContext) ?? 0);
+        var guild = ExceptionHelper.RetryOnTimedOut(() => _discord.GetGuild(guildId));
+        var user = ExceptionHelper.RetryOnTimedOut(() => guild.GetUser(AspHelper.GetUserId(HttpContext) ?? 0));
+        var data = new ServerDetailsViewModel
+        {
+            Guild = guild,
+            User = user,
+            CounterConfig = new CounterGuildModel()
+            {
+                GuildId = guildId
+            },
+            BanSyncConfig = new BanSyncGuildModel(guildId),
+            XpConfig = new LevelSystemConfigModel()
+            {
+                GuildId = guildId
+            },
+            LogConfig = new ServerLogGuildModel()
+            {
+                GuildId = guildId.ToString()
+            },
+            GreeterConfig = new GuildGreeterConfigModel()
+            {
+                GuildId = guildId
+            },
+            GreeterGoodbyeConfig = new GuildByeGreeterConfigModel()
+            {
+                GuildId = guildId
+            },
+            RolePreserve = new RolePreserveGuildModel(guildId),
+            WarnStrikeConfig = new GuildConfigWarnStrikeModel()
+            {
+                GuildId = guildId
+            },
+            ConfessionConfig = new ConfessionGuildModel()
+            {
+                GuildId = guildId
+            }
+        };
         
-        await AspHelper.FillServerModel(HttpContext.RequestServices, serverId, data);
+        await AspHelper.FillServerModel(HttpContext.RequestServices, guildId, data);
         
         return data;
     }

--- a/XeniaBot.WebPanel/Controllers/ServerSettingsController.cs
+++ b/XeniaBot.WebPanel/Controllers/ServerSettingsController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Discord;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System;
@@ -23,7 +24,7 @@ public partial class ServerController
 {
     [HttpPost("~/Server/{id}/Settings/Log")]
     [AuthRequired]
-    [RestrictToGuild(GuildIdRouteKey = "id", RequiredPermission = Discord.GuildPermission.ManageChannels)]
+    [RestrictToGuild(GuildIdRouteKey = "id", RequiredPermission = GuildPermission.ManageChannels)]
     public async Task<IActionResult> SaveSettings_LogSystem(
         ulong id,
         [FromForm] bool enable,
@@ -124,10 +125,11 @@ public partial class ServerController
                 messageType: "danger",
                 message: $"Failed to save Server Log settings: {ex.GetType().Name} {ex.Message}");
         }
-        
-        return await ModerationView(id,
-            messageType: "success",
-            message: "Server Log settings saved");
+
+        var result = await GetModerationView(id, "success", "Server Log settings saved");
+        if (result.IsFailure) return result.Error;
+        result.Value.ActiveTab = "serverlog";
+        return View("Details/ModerationView", result.Value);
     }
 
     [HttpPost("~/Server/{id}/Settings/RolePreserve")]
@@ -152,8 +154,10 @@ public partial class ServerController
                 throw;
             }
 
-            return await ModerationView(
-                id, messageType: "success", message: $"Role Preserve " + (enable ? "Enabled" : "Disabled"));
+            var result = await GetModerationView(id, "success", "Role Preserve settings saved");
+            result.Value.ActiveTab = "rolepreserve";
+            if (result.IsFailure) return result.Error;
+            return View("Details/ModerationView", result.Value);
         }
         catch (Exception ex)
         {
@@ -161,9 +165,10 @@ public partial class ServerController
                 .ReportException(ex, $"Failed to save role preserve settings");
             _logger.LogError(ex, "Failed to save role preserve settings for Guild {GuildId}",
                 id);
-            return await ModerationView(id,
-                messageType: "danger",
-                message: $"Failed to save Role Preserve settings. {ex.Message}");
+            var result = await GetModerationView(id, "danger", $"Failed to save role preserve settings: {ex.Message}");
+            result.Value.ActiveTab = "rolepreserve";
+            if (result.IsFailure) return result.Error;
+            return View("Details/ModerationView", result.Value);
         }
     }
 
@@ -172,20 +177,31 @@ public partial class ServerController
     [RestrictToGuild(GuildIdRouteKey = "id")]
     public async Task<IActionResult> SaveSettings_WarnStrike(ulong id, bool enable, int maxStrike, int strikeWindow)
     {
+        var result = await GetModerationView(id);
+        result.Value.ActiveTab = "warnstrike";
+        if (result.IsFailure) return result.Error;
         try
         {
             if (maxStrike < 1)
             {
-                return await ModerationView(id,
-                    messageType: "danger",
-                    message: $"Failed to save Warn Strike settings. Max Strike must be greater than one");
+                result.Value.Alert = new AlertComponentViewModel()
+                {
+                    Message = "Failed to save Warn Strike settings: Max Strike must be greater than one.",
+                    MessageType = "danger",
+                    ShowClose = true
+                };
+                return View("Details/ModerationView", result.Value);
             }
 
             if (strikeWindow < 1)
             {
-                return await ModerationView(id,
-                    messageType: "danger",
-                    message: $"Failed to save Warn Strike settings. Strike Window must be greater than one");
+                result.Value.Alert = new AlertComponentViewModel()
+                {
+                    Message = "Failed to save Warn Strike settings: Strike Window must be greater than one.",
+                    MessageType = "danger",
+                    ShowClose = true
+                };
+                return View("Details/ModerationView", result.Value);
             }
             var warnStrikeService = CoreContext.Instance?.GetRequiredService<WarnStrikeService>()
                 ?? throw new InvalidOperationException($"Could not find service {typeof(WarnStrikeService)}");
@@ -197,17 +213,28 @@ public partial class ServerController
             model.StrikeWindow = TimeSpan.FromDays(strikeWindow).TotalSeconds;
 
             await configRepo.InsertOrUpdate(model);
-            return await ModerationView(
-                id, messageType: "success", message: $"Warn Strike settings saved");
+            result.Value.WarnStrikeConfig = model;
+
+            result.Value.Alert = new AlertComponentViewModel()
+            {
+                Message = "Warn Strike settings saved",
+                MessageType = "success",
+                ShowClose = true
+            };
+            return View("Details/ModerationView", result.Value);
         }
         catch (Exception ex)
         {
             Program.Core.GetRequiredService<ErrorReportService>()?
                 .ReportException(ex, $"Failed to save Warn Strike settings");
             _logger.LogError(ex, "Failed to save Warn Strike settings for Guild {GuildId}", id);
-            return await ModerationView(id,
-                messageType: "danger",
-                message: $"Failed to save Warn Strike settings. {ex.Message}");
+            result.Value.Alert = new AlertComponentViewModel()
+            {
+                Message = $"Failed to save Warn Strike settings: {ex.Message}",
+                MessageType = "danger",
+                ShowClose = true
+            };
+            return View("Details/ModerationView", result.Value);
         }
     }
     

--- a/XeniaBot.WebPanel/Controllers/ServerSettingsController.cs
+++ b/XeniaBot.WebPanel/Controllers/ServerSettingsController.cs
@@ -231,15 +231,13 @@ public partial class ServerController
         string? message = null)
     {
         ulong targetChannelId = 0;
-        if (inputChannelId == null || inputChannelId?.Length < 1)
+        if (string.IsNullOrEmpty(inputChannelId))
             targetChannelId = 0;
         else
         {
             try
             {
                 targetChannelId = ulong.Parse(inputChannelId);
-                if (targetChannelId == null)
-                    throw new Exception("ChannelId is null");
             }
             catch (Exception ex)
             {
@@ -307,15 +305,13 @@ public partial class ServerController
         string? inputColor)
     {
         ulong targetChannelId = 0;
-        if (inputChannelId == null || inputChannelId?.Length < 1)
+        if (string.IsNullOrEmpty(inputChannelId))
             targetChannelId = 0;
         else
         {
             try
             {
                 targetChannelId = ulong.Parse(inputChannelId);
-                if (targetChannelId == null)
-                    throw new Exception("ChannelId is null");
             }
             catch (Exception ex)
             {

--- a/XeniaBot.WebPanel/Extensions/HtmxExtensions.cs
+++ b/XeniaBot.WebPanel/Extensions/HtmxExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace XeniaBot.WebPanel.Extensions;
+
+public static class HtmxExtensions
+{
+    [NonAction]
+    public static bool IsHtmxRequest(this Controller controller)
+    {
+        return controller.Request.Headers.Keys.Any(key => string.Equals(key, "hx-request", StringComparison.OrdinalIgnoreCase));
+    }
+    [NonAction]
+    public static bool IsHtmxRequest(this HttpContext context)
+    {
+        return context.Request.Headers.Keys.Any(key => string.Equals(key, "hx-request", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/XeniaBot.WebPanel/Extensions/HttpContextExtensions.cs
+++ b/XeniaBot.WebPanel/Extensions/HttpContextExtensions.cs
@@ -1,11 +1,11 @@
-﻿ using System;
-using System.Linq;
-using System.Threading.Tasks;
-using Discord;
+﻿using Discord;
 using Discord.WebSocket;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using XeniaBot.Shared.Helpers;
 using XeniaBot.WebPanel.Helpers;
 

--- a/XeniaBot.WebPanel/Extensions/HttpContextExtensions.cs
+++ b/XeniaBot.WebPanel/Extensions/HttpContextExtensions.cs
@@ -50,7 +50,7 @@ public static class HttpContextExtensions
         if (!userId.HasValue) return null;
 
         var discord = context.RequestServices.GetRequiredService<DiscordSocketClient>();
-        var user = await ExceptionHelper.RetryOnTimedOut(async () => discord.GetUser(userId.Value));
+        var user = ExceptionHelper.RetryOnTimedOut(() => discord.GetUser(userId.Value));
         return user;
     }
 
@@ -60,10 +60,10 @@ public static class HttpContextExtensions
         if (user == null) return null;
 
         var discord = context.RequestServices.GetRequiredService<DiscordSocketClient>();
-        var guild = await ExceptionHelper.RetryOnTimedOut(async () => discord.GetGuild(guildId));
+        var guild = ExceptionHelper.RetryOnTimedOut(() => discord.GetGuild(guildId));
         if (guild == null) return null;
 
-        var member = await ExceptionHelper.RetryOnTimedOut(async () => guild.GetUser(user.Id));
+        var member = ExceptionHelper.RetryOnTimedOut(() => guild.GetUser(user.Id));
         return member;
     }
 #pragma warning restore S6966

--- a/XeniaBot.WebPanel/Extensions/HttpContextExtensions.cs
+++ b/XeniaBot.WebPanel/Extensions/HttpContextExtensions.cs
@@ -1,9 +1,13 @@
-﻿using System;
+﻿ using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Discord;
+using Discord.WebSocket;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using XeniaBot.Shared.Helpers;
+using XeniaBot.WebPanel.Helpers;
 
 namespace XeniaBot.WebPanel.Extensions;
 
@@ -34,4 +38,33 @@ public static class HttpContextExtensions
             where string.Equals(scheme.Name, provider, StringComparison.OrdinalIgnoreCase)
             select scheme).Any();
     }
+
+    public static bool IsLoggedIn(this HttpContext context)
+        => context.User?.Identity?.IsAuthenticated == true;
+
+#pragma warning disable S6966
+    public static async Task<IUser?> GetCurrentDiscordUser(this HttpContext context)
+    {
+        if (context.User?.Identity?.IsAuthenticated != true) return null;
+        var userId = AspHelper.GetUserId(context);
+        if (!userId.HasValue) return null;
+
+        var discord = context.RequestServices.GetRequiredService<DiscordSocketClient>();
+        var user = await ExceptionHelper.RetryOnTimedOut(async () => discord.GetUser(userId.Value));
+        return user;
+    }
+
+    public static async Task<IGuildUser?> GetCurrentDiscordGuildMember(this HttpContext context, ulong guildId)
+    {
+        var user = await context.GetCurrentDiscordUser();
+        if (user == null) return null;
+
+        var discord = context.RequestServices.GetRequiredService<DiscordSocketClient>();
+        var guild = await ExceptionHelper.RetryOnTimedOut(async () => discord.GetGuild(guildId));
+        if (guild == null) return null;
+
+        var member = await ExceptionHelper.RetryOnTimedOut(async () => guild.GetUser(user.Id));
+        return member;
+    }
+#pragma warning restore S6966
 }

--- a/XeniaBot.WebPanel/Helpers/AspHelper.cs
+++ b/XeniaBot.WebPanel/Helpers/AspHelper.cs
@@ -26,20 +26,11 @@ public static class AspHelper
 {
     public static ulong? GetUserId(HttpContext context)
     {
-        ulong? target = null;
-        if (context.User?.Identity?.IsAuthenticated ?? false)
-        {
-            foreach (var claim in context.User.Claims)
-            {
-                if (claim.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier")
-                {
-                    target = ulong.Parse(claim.Value);
-                    return target;
-                }
-            }
-        }
-
-        return target;
+        if (!(context.User?.Identity?.IsAuthenticated ?? false)) return null;
+        var claim = context.User.Claims.FirstOrDefault(e =>
+            e.Type == "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
+        if (ulong.TryParse(claim?.Value, out var value)) return value;
+        return null;
     }
     
     public static bool IsCurrentUserAdmin(HttpContext context)

--- a/XeniaBot.WebPanel/Models/Admin/Component/AdminLevelSystemComponentViewModel.cs
+++ b/XeniaBot.WebPanel/Models/Admin/Component/AdminLevelSystemComponentViewModel.cs
@@ -18,8 +18,8 @@ public class AdminLevelSystemComponentViewModel : IGuildViewModel, IAlertViewMod
     public async Task PopulateModel(HttpContext context, ulong guildId)
     {
         var discord = CoreContext.Instance!.GetRequiredService<DiscordSocketClient>();
-        Guild = discord.GetGuild(guildId);
         var xpConfig = CoreContext.Instance!.GetRequiredService<LevelSystemConfigRepository>();
+        Guild = discord.GetGuild(guildId);
         XpConfig = await xpConfig.Get(Guild.Id) ?? new LevelSystemConfigModel()
         {
             GuildId = Guild.Id

--- a/XeniaBot.WebPanel/Models/Component/AlertComponentViewModel.cs
+++ b/XeniaBot.WebPanel/Models/Component/AlertComponentViewModel.cs
@@ -3,6 +3,7 @@
 public class AlertComponentViewModel : IAlertViewModel
 {
     public string? Message { get; set; }
+    public bool? RenderMessageAsMarkdown { get; set; }
     public string? MessageType { get; set; }
     public string MessageClass => MessageType == null ? "alert alert-dismissible " : $"alert alert-dismissible alert-{MessageType}";
     public bool ShowClose { get; set; } = false;

--- a/XeniaBot.WebPanel/Models/Component/RolePillComponentModel.cs
+++ b/XeniaBot.WebPanel/Models/Component/RolePillComponentModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using CSharpFunctionalExtensions;
 using Humanizer;
 using XeniaDiscord.Common;
@@ -7,9 +8,14 @@ namespace XeniaBot.WebPanel.Models;
 
 public class RolePillComponentModel
 {
+    private readonly Guid _id = Guid.NewGuid();
+    public Guid Guid => _id;
+    public string ElementId => $"role_pill_{Role.Id}_{Guid}";
     public required StrippedRole Role { get; set; }
     public RolePillComponentTooltipMode TooltipMode { get; set; } = RolePillComponentTooltipMode.RoleId;
     public string? CustomTooltipText { get; set; }
+
+    public Maybe<RolePillInputOptions> InputOptions { get; set; }
 
     public string GetBadgeStyle()
     {
@@ -46,6 +52,13 @@ public class RolePillComponentModel
 
         return tooltipText;
     }
+}
+
+public class RolePillInputOptions
+{
+    public required string Name { get; set; }
+    public required string Value { get; set; }
+    public bool AllowRemoval { get; set; }
 }
 
 public enum RolePillComponentTooltipMode

--- a/XeniaBot.WebPanel/Models/Component/RolePillComponentModel.cs
+++ b/XeniaBot.WebPanel/Models/Component/RolePillComponentModel.cs
@@ -1,0 +1,57 @@
+﻿using System.Linq;
+using CSharpFunctionalExtensions;
+using Humanizer;
+using XeniaDiscord.Common;
+
+namespace XeniaBot.WebPanel.Models;
+
+public class RolePillComponentModel
+{
+    public required StrippedRole Role { get; set; }
+    public RolePillComponentTooltipMode TooltipMode { get; set; } = RolePillComponentTooltipMode.RoleId;
+    public string? CustomTooltipText { get; set; }
+
+    public string GetBadgeStyle()
+    {
+        var cssColor = Role.RoleUnicolour.ToCss(100.0);
+        if (cssColor == "transparent") return "background-color: RGBA(var(--bs-dark-rgb), var(--bs-bg-opacity, 1)) !important;";
+        return $"background-color: {cssColor} !important;";
+    }
+    public string GetTooltipText()
+    {
+        var tooltipText = string.Empty;
+        switch (TooltipMode)
+        {
+            case RolePillComponentTooltipMode.RoleIdAndPermissions:
+                tooltipText = $"<code>{Role.Id}</code>";
+                Role.Permissions.Tap(gp =>
+                {
+                    if (gp.RawValue == 0)
+                    {
+                        tooltipText += "<br/><strong>No permissions</strong>";
+                        return;
+                    }
+
+                    tooltipText += "<br/><hr/><strong>Permissions:</strong><br/>";
+                    tooltipText += string.Join(", ", gp.ToList().Select(e => e.Humanize(LetterCasing.Title)));
+                });
+                break;
+            case RolePillComponentTooltipMode.RoleId:
+                tooltipText = $"<code>{Role.Id}</code>";
+                break;
+            case RolePillComponentTooltipMode.Custom:
+                if (!string.IsNullOrEmpty(CustomTooltipText?.Trim())) tooltipText = CustomTooltipText;
+                break;
+        }
+
+        return tooltipText;
+    }
+}
+
+public enum RolePillComponentTooltipMode
+{
+    None,
+    RoleId,
+    RoleIdAndPermissions,
+    Custom
+}

--- a/XeniaBot.WebPanel/Models/Server/Component/ServerListComponentViewModel.cs
+++ b/XeniaBot.WebPanel/Models/Server/Component/ServerListComponentViewModel.cs
@@ -14,9 +14,10 @@ public class ServerListComponentViewModel : BaseViewModel
 
     public bool IsGuildLast(ServerListViewModelItem guild)
     {
-        if (Items.Count() < 2)
+        var count = Items.Count();
+        if (count < 2)
             return true;
 
-        return Items.ElementAt(Items.Count() - 1).Guild.Id == guild.Guild.Id;
+        return Items.ElementAt(count - 1).Guild.Id == guild.Guild.Id;
     }
 }

--- a/XeniaBot.WebPanel/Models/Server/ServerDetailsViewModel.cs
+++ b/XeniaBot.WebPanel/Models/Server/ServerDetailsViewModel.cs
@@ -16,30 +16,27 @@ public class ServerDetailsViewModel : BaseViewModel,
     IServerCountingComponentViewModel,
     IServerConfessionComponentViewModel
 {
-    public SocketGuildUser User { get; set; }
-    public SocketGuild Guild { get; set; }
+    public required SocketGuildUser User { get; set; }
+    public required SocketGuild Guild { get; set; }
     public ICollection<SocketGuildUser> UsersWhoCanAccess { get; set; } = [];
-    
-    public CounterGuildModel CounterConfig { get; set; }
-    public BanSyncGuildModel BanSyncConfig { get; set; }
-    public LevelSystemConfigModel XpConfig { get; set; }
+
+    public required CounterGuildModel CounterConfig { get; set; }
+    public required BanSyncGuildModel BanSyncConfig { get; set; }
+    public required LevelSystemConfigModel XpConfig { get; set; }
     public LevelSystemConfigModel LevelSystemConfig
     {
         get => XpConfig;
-        set
-        {
-            XpConfig = value;
-        }
+        set => XpConfig = value;
     }
-    public ServerLogGuildModel LogConfig { get; set; }
+    public required ServerLogGuildModel LogConfig { get; set; }
     public ICollection<BanSyncGuildSnapshotModel> BanSyncStateHistory { get; set; } = [];
-    public GuildGreeterConfigModel GreeterConfig { get; set; }
-    public GuildByeGreeterConfigModel GreeterGoodbyeConfig { get; set; }
+    public required GuildGreeterConfigModel GreeterConfig { get; set; }
+    public required GuildByeGreeterConfigModel GreeterGoodbyeConfig { get; set; }
     public ICollection<GuildWarnItemModel> WarnItems { get; set; } = [];
-    public RolePreserveGuildModel RolePreserve { get; set; }
+    public required RolePreserveGuildModel RolePreserve { get; set; }
     public long BanSyncRecordCount { get; set; }
-    public GuildConfigWarnStrikeModel WarnStrikeConfig { get; set; }
-    public ConfessionGuildModel ConfessionConfig { get; set; }
+    public required GuildConfigWarnStrikeModel WarnStrikeConfig { get; set; }
+    public required ConfessionGuildModel ConfessionConfig { get; set; }
 
     public bool IsWarnActive(GuildWarnItemModel model)
     {

--- a/XeniaBot.WebPanel/Models/Server/ServerDetailsViewModel.cs
+++ b/XeniaBot.WebPanel/Models/Server/ServerDetailsViewModel.cs
@@ -16,6 +16,7 @@ public class ServerDetailsViewModel : BaseViewModel,
     IServerCountingComponentViewModel,
     IServerConfessionComponentViewModel
 {
+    public string ActiveTab { get; set; } = string.Empty;
     public required SocketGuildUser User { get; set; }
     public required SocketGuild Guild { get; set; }
     public ICollection<SocketGuildUser> UsersWhoCanAccess { get; set; } = [];
@@ -37,6 +38,7 @@ public class ServerDetailsViewModel : BaseViewModel,
     public long BanSyncRecordCount { get; set; }
     public required GuildConfigWarnStrikeModel WarnStrikeConfig { get; set; }
     public required ConfessionGuildModel ConfessionConfig { get; set; }
+    public AlertComponentViewModel? Alert { get; set; }
 
     public bool IsWarnActive(GuildWarnItemModel model)
     {

--- a/XeniaBot.WebPanel/Models/Server/ServerListViewModel.cs
+++ b/XeniaBot.WebPanel/Models/Server/ServerListViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Discord.WebSocket;
+﻿using Discord.WebSocket;
 using XeniaBot.MongoData;
 
 namespace XeniaBot.WebPanel.Models;
@@ -8,17 +7,12 @@ public class ServerListViewModel : BaseViewModel
 {
     public ulong? UserId { get; set; }
     public string? UserAvatar { get; set; }
-    public ServerListViewModelItem[] Items { get; set; }
-    public ListViewStyle ListStyle { get; set; }
-    public ServerListViewModel()
-    {
-        Items = Array.Empty<ServerListViewModelItem>();
-        ListStyle = ListViewStyle.List;
-    }
+    public ServerListViewModelItem[] Items { get; set; } = [];
+    public ListViewStyle ListStyle { get; set; } = ListViewStyle.List;
 }
 
 public class ServerListViewModelItem
 {
-    public SocketGuildUser GuildUser { get; set; }
-    public SocketGuild Guild { get; set; }
+    public required SocketGuildUser GuildUser { get; set; }
+    public required SocketGuild Guild { get; set; }
 }

--- a/XeniaBot.WebPanel/Models/Wrappers/StrippedCategory.cs
+++ b/XeniaBot.WebPanel/Models/Wrappers/StrippedCategory.cs
@@ -6,8 +6,8 @@ namespace XeniaBot.WebPanel.Models;
 
 public class StrippedCategory
 {
-    public IEnumerable<ulong> ChannelIds { get; set; }
-    public string Name { get; set; }
+    public IEnumerable<ulong> ChannelIds { get; set; } = [];
+    public string Name { get; set; } = string.Empty;
     public int Position { get; set; }
     public ulong Id { get; set; }
 

--- a/XeniaBot.WebPanel/Models/Wrappers/StrippedChannel.cs
+++ b/XeniaBot.WebPanel/Models/Wrappers/StrippedChannel.cs
@@ -12,14 +12,12 @@ public class StrippedChannel
 
     public static IEnumerable<StrippedChannel> FromGuild(IGuild guild)
     {
-        return guild.GetChannelsAsync().GetAwaiter().GetResult().Select((v) =>
-        {
-            return new StrippedChannel()
+        return guild.GetChannelsAsync().GetAwaiter().GetResult()
+            .Select((v) => new StrippedChannel()
             {
                 Id = v.Id,
                 Name = v.Name,
                 Position = v.Position
-            };
-        });
+            });
     }
 }

--- a/XeniaBot.WebPanel/Models/Wrappers/StrippedGuild.cs
+++ b/XeniaBot.WebPanel/Models/Wrappers/StrippedGuild.cs
@@ -1,19 +1,23 @@
 ﻿using System;
 using Discord.WebSocket;
+using XeniaDiscord.Data.Models.Snapshot;
 
 namespace XeniaBot.WebPanel.Models;
 
-public class StrippedGuild : IEquatable<StrippedGuild>
+public sealed class StrippedGuild
+    : IEquatable<StrippedGuild>
 {
     public bool Equals(StrippedGuild? other)
     {
         return other?.Id == Id;
     }
+    
     public ulong Id { get; set; }
+
     /// <summary>
     /// Name of the guild
     /// </summary>
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
     /// <summary>
     /// Amount of members in guild
     /// </summary>
@@ -25,7 +29,7 @@ public class StrippedGuild : IEquatable<StrippedGuild>
     /// <summary>
     /// Icon Url for this guild. Will default to `/Debugempty.png` when is null.
     /// </summary>
-    public string IconUrl { get; set; }
+    public string? IconUrl { get; set; }
     /// <summary>
     /// Banner Url for this guild
     /// </summary>
@@ -33,7 +37,7 @@ public class StrippedGuild : IEquatable<StrippedGuild>
     /// <summary>
     /// Description of this guild.
     /// </summary>
-    public string Description { get; set; }
+    public string? Description { get; set; }
 
     public static StrippedGuild FromGuild(SocketGuild? guild)
     {
@@ -51,15 +55,42 @@ public class StrippedGuild : IEquatable<StrippedGuild>
         }
         else
         {
-            var instance = new StrippedGuild();
-            instance.Id = guild.Id;
-            instance.Name = guild.Name;
-            instance.MemberCount = guild.MemberCount;
-            instance.OwnerId = guild.OwnerId;
-            instance.IconUrl = guild.IconUrl ?? "/Debugempty.png";
-            instance.BannerUrl = guild.BannerUrl;
-            instance.Description = guild.Description ?? "";
-            return instance;
+            return new StrippedGuild
+            {
+                Id = guild.Id,
+                Name = guild.Name,
+                MemberCount = guild.MemberCount,
+                OwnerId = guild.OwnerId,
+                IconUrl = guild.IconUrl ?? "/Debugempty.png",
+                BannerUrl = guild.BannerUrl,
+                Description = guild.Description ?? ""
+            };
         }
+    }
+
+    public static StrippedGuild FromExisting(
+        SocketGuild? guild,
+        GuildSnapshotModel? model,
+        ulong id)
+    {
+        if (guild != null) return FromGuild(guild);
+        if (model == null)
+            return new StrippedGuild()
+            {
+                Id = id,
+                Name = id.ToString(),
+                MemberCount = -1,
+                OwnerId = 0,
+                IconUrl = "/Debugempty.png",
+            };
+        return new StrippedGuild()
+        {
+            Id = model.GetGuildId(),
+            Name = model.Name,
+            MemberCount = model.ApproximateMemberCount ?? -1,
+            OwnerId = model.GetOwnerUserId(),
+            IconUrl = model.IconUrl ?? "/Debugempty.png",
+            Description = model.Description
+        };
     }
 }

--- a/XeniaBot.WebPanel/Models/Wrappers/StrippedGuild.cs
+++ b/XeniaBot.WebPanel/Models/Wrappers/StrippedGuild.cs
@@ -18,22 +18,27 @@ public sealed class StrippedGuild
     /// Name of the guild
     /// </summary>
     public string Name { get; set; } = string.Empty;
+
     /// <summary>
     /// Amount of members in guild
     /// </summary>
     public int MemberCount { get; set; }
+    
     /// <summary>
     /// UserId of the guild owner
     /// </summary>
     public ulong OwnerId { get; set; }
+
     /// <summary>
-    /// Icon Url for this guild. Will default to `/Debugempty.png` when is null.
+    /// Icon Url for this guild. Will default to <c>/DebugEmpty.png</c> when is null.
     /// </summary>
     public string? IconUrl { get; set; }
+    
     /// <summary>
     /// Banner Url for this guild
     /// </summary>
     public string? BannerUrl { get; set; }
+    
     /// <summary>
     /// Description of this guild.
     /// </summary>
@@ -43,13 +48,13 @@ public sealed class StrippedGuild
     {
         if (guild == null)
         {
-            return new StrippedGuild()
+            return new StrippedGuild
             {
                 Id = 0,
                 Name = "<unknown>",
                 MemberCount = -1,
                 OwnerId = 0,
-                IconUrl = "/Debugempty.png",
+                IconUrl = "/DebugEmpty.png",
                 Description = ""
             };
         }
@@ -61,7 +66,7 @@ public sealed class StrippedGuild
                 Name = guild.Name,
                 MemberCount = guild.MemberCount,
                 OwnerId = guild.OwnerId,
-                IconUrl = guild.IconUrl ?? "/Debugempty.png",
+                IconUrl = guild.IconUrl ?? "/DebugEmpty.png",
                 BannerUrl = guild.BannerUrl,
                 Description = guild.Description ?? ""
             };
@@ -75,21 +80,21 @@ public sealed class StrippedGuild
     {
         if (guild != null) return FromGuild(guild);
         if (model == null)
-            return new StrippedGuild()
+            return new StrippedGuild
             {
                 Id = id,
                 Name = id.ToString(),
                 MemberCount = -1,
                 OwnerId = 0,
-                IconUrl = "/Debugempty.png",
+                IconUrl = "/DebugEmpty.png",
             };
-        return new StrippedGuild()
+        return new StrippedGuild
         {
             Id = model.GetGuildId(),
             Name = model.Name,
             MemberCount = model.ApproximateMemberCount ?? -1,
             OwnerId = model.GetOwnerUserId(),
-            IconUrl = model.IconUrl ?? "/Debugempty.png",
+            IconUrl = model.IconUrl ?? "/DebugEmpty.png",
             Description = model.Description
         };
     }

--- a/XeniaBot.WebPanel/Models/Wrappers/StrippedRole.cs
+++ b/XeniaBot.WebPanel/Models/Wrappers/StrippedRole.cs
@@ -8,25 +8,30 @@ namespace XeniaBot.WebPanel.Models;
 public class StrippedRole
 {
     /// <summary>
-    /// Hex Color of <see cref="SocketRole.Color"/>. Default is `#00000000`
+    /// Hex Color of <see cref="SocketRole.Color"/>. Default is <c>#00000000</c>
     /// </summary>
-    public string HexColor { get; set; }
+    public string HexColor { get; set; } = "#00000000";
+    
     /// <summary>
-    /// Id of role. Cloned from <see cref="SocketRole.Id"/>
+    /// Role ID. Cloned from <see cref="SocketRole.Id"/>
     /// </summary>
     public ulong RoleId { get; set; }
+    
     /// <summary>
     /// When the role was created. <see cref="SocketRole.CreatedAt"/>
     /// </summary>
     public DateTimeOffset CreatedAt { get; set; }
+
     /// <summary>
     /// Name of the role. <see cref="SocketRole.Name"/>
     /// </summary>
-    public string Name { get; set; }
+    public string Name { get; set; } = "unknown";
+    
     /// <summary>
     /// Position of the role. <see cref="SocketRole.Position"/>
     /// </summary>
     public int Position { get; set; }
+    
     /// <summary>
     /// Can the current user grant this role?
     /// </summary>
@@ -36,20 +41,20 @@ public class StrippedRole
     /// <summary>
     /// Generate a list of <see cref="StrippedRole"/> from a guild.
     /// </summary>
-    /// <param name="guild"></param>
-    /// <returns></returns>
     public static IEnumerable<StrippedRole> FromGuild(DiscordSocketClient client, SocketGuild guild)
     {
         var roles = guild.Roles;
         var currentUserRoles = guild.GetUser(client.CurrentUser.Id).Roles.ToList();
-        var ourHighestRolePosition =
-            currentUserRoles.OrderByDescending(v => v.Position).Select(v => v.Position).Concat(new int[]{int.MinValue})
-                .OrderByDescending(v => v)
-                .FirstOrDefault();
+        var ourHighestRolePosition = currentUserRoles
+            .OrderByDescending(v => v.Position)
+            .Select(v => v.Position)
+            .Concat([int.MinValue])
+            .OrderByDescending(v => v)
+            .FirstOrDefault();
         var items = new List<StrippedRole>();
         foreach (var i in roles)
         {
-            var d = StrippedRole.FromRole(client, i);
+            var d = FromRole(client, i);
             d.CanAccess = d.Position < ourHighestRolePosition;
             items.Add(d);
         }
@@ -60,7 +65,7 @@ public class StrippedRole
     public static StrippedRole FromRole(DiscordSocketClient client, SocketRole role)
     {
         var instance = new StrippedRole();
-        instance.HexColor = role.Color.ToString() ?? "#00000000";
+        instance.HexColor = role.Colors.PrimaryColor.ToString() ?? "#00000000";
         instance.RoleId = role.Id;
         instance.CreatedAt = role.CreatedAt;
         instance.Name = role.Name;

--- a/XeniaBot.WebPanel/Models/Wrappers/StrippedRole.cs
+++ b/XeniaBot.WebPanel/Models/Wrappers/StrippedRole.cs
@@ -1,21 +1,39 @@
-﻿using System;
+﻿using CSharpFunctionalExtensions;
+using Discord;
+using Discord.WebSocket;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Discord.WebSocket;
+using Wacton.Unicolour;
+using XeniaDiscord.Common;
+using XeniaDiscord.Data.Models.Snapshot;
 
 namespace XeniaBot.WebPanel.Models;
 
-public class StrippedRole
+public class StrippedRole : IStrippedRole
 {
     /// <summary>
-    /// Hex Color of <see cref="SocketRole.Color"/>. Default is <c>#00000000</c>
+    /// Hex Color of <see cref="SocketRole.Color"/>. Default is <c>#000000</c>
     /// </summary>
-    public string HexColor { get; set; } = "#00000000";
-    
+    public string HexColor { get; set; } = "#000000";
+
+    public Unicolour RoleUnicolour
+        => new(HexColor);
+
+    private static readonly Unicolour Dark = new("404046");
+    private static readonly Unicolour Light = new("e8e8ff");
+    public bool ShouldUseLightText()
+    {
+        var color = RoleUnicolour;
+        if (color.HasConversionError()) return true;
+        var inGamut = color.MapToRgbGamut(GamutMap.RgbClipping);
+        return inGamut.Contrast(Light) > inGamut.Contrast(Dark);
+    }
+
     /// <summary>
     /// Role ID. Cloned from <see cref="SocketRole.Id"/>
     /// </summary>
-    public ulong RoleId { get; set; }
+    public ulong Id { get; set; }
     
     /// <summary>
     /// When the role was created. <see cref="SocketRole.CreatedAt"/>
@@ -36,8 +54,9 @@ public class StrippedRole
     /// Can the current user grant this role?
     /// </summary>
     public bool CanAccess { get; set; }
-    
-    
+
+    public Maybe<GuildPermissions> Permissions { get; set; } = Maybe.None;
+
     /// <summary>
     /// Generate a list of <see cref="StrippedRole"/> from a guild.
     /// </summary>
@@ -51,6 +70,7 @@ public class StrippedRole
             .Concat([int.MinValue])
             .OrderByDescending(v => v)
             .FirstOrDefault();
+        
         var items = new List<StrippedRole>();
         foreach (var i in roles)
         {
@@ -65,11 +85,39 @@ public class StrippedRole
     public static StrippedRole FromRole(DiscordSocketClient client, SocketRole role)
     {
         var instance = new StrippedRole();
-        instance.HexColor = role.Colors.PrimaryColor.ToString() ?? "#00000000";
-        instance.RoleId = role.Id;
+        instance.HexColor = role.Colors.PrimaryColor.ToString() ?? "#000000";
+        instance.Id = role.Id;
         instance.CreatedAt = role.CreatedAt;
         instance.Name = role.Name;
         instance.Position = role.Position;
+        instance.Permissions = role.Permissions;
         return instance;
     }
+
+    public static StrippedRole FromRole(GuildRoleSnapshotModel model)
+    {
+        var instance = new StrippedRole
+        {
+            Id = model.GetRoleId(),
+            CreatedAt = model.CreatedAt,
+            Name = model.Name ?? model.RoleId,
+            Position = model.Position,
+            Permissions = model.ParsePermissions()
+        };
+        instance.HexColor = model.RoleColors == null
+            ? "#000000"
+            : model.RoleColors.GetPrimaryColor().ToString();
+        return instance;
+    }
+}
+
+public interface IStrippedRole
+{
+    string HexColor { get; }
+    ulong Id { get; }
+    DateTimeOffset CreatedAt { get; }
+    string Name { get; }
+    int Position { get; }
+    bool CanAccess { get; }
+    Maybe<GuildPermissions> Permissions { get; }
 }

--- a/XeniaBot.WebPanel/Models/Wrappers/StrippedRole.cs
+++ b/XeniaBot.WebPanel/Models/Wrappers/StrippedRole.cs
@@ -15,7 +15,9 @@ public class StrippedRole : IStrippedRole
     /// <summary>
     /// Hex Color of <see cref="SocketRole.Color"/>. Default is <c>#000000</c>
     /// </summary>
-    public string HexColor { get; set; } = "#000000";
+    public string HexColor { get; set; } = DefaultHexColor;
+
+    public const string DefaultHexColor = "#000000";
 
     public Unicolour RoleUnicolour
         => new(HexColor);
@@ -74,7 +76,7 @@ public class StrippedRole : IStrippedRole
         var items = new List<StrippedRole>();
         foreach (var i in roles)
         {
-            var d = FromRole(client, i);
+            var d = FromRole(i);
             d.CanAccess = d.Position < ourHighestRolePosition;
             items.Add(d);
         }
@@ -82,32 +84,35 @@ public class StrippedRole : IStrippedRole
         return items;
     }
 
-    public static StrippedRole FromRole(DiscordSocketClient client, SocketRole role)
+    public static StrippedRole FromRole(SocketRole role)
     {
-        var instance = new StrippedRole();
-        instance.HexColor = role.Colors.PrimaryColor.ToString() ?? "#000000";
-        instance.Id = role.Id;
-        instance.CreatedAt = role.CreatedAt;
-        instance.Name = role.Name;
-        instance.Position = role.Position;
-        instance.Permissions = role.Permissions;
-        return instance;
+        var color = role.Colors.PrimaryColor.ToString() ?? DefaultHexColor;
+        return new StrippedRole
+        {
+            HexColor = color,
+            Id = role.Id,
+            CreatedAt = role.CreatedAt,
+            Name = role.Name,
+            Position = role.Position,
+            Permissions = role.Permissions
+        };
     }
 
     public static StrippedRole FromRole(GuildRoleSnapshotModel model)
     {
-        var instance = new StrippedRole
+        var roleId = model.GetRoleId();
+        var color = model.RoleColors == null
+            ? DefaultHexColor
+            : model.RoleColors.GetPrimaryColor().ToString();
+        return new StrippedRole
         {
-            Id = model.GetRoleId(),
+            Id = roleId,
             CreatedAt = model.CreatedAt,
             Name = model.Name ?? model.RoleId,
             Position = model.Position,
-            Permissions = model.ParsePermissions()
+            Permissions = model.ParsePermissions(),
+            HexColor = color
         };
-        instance.HexColor = model.RoleColors == null
-            ? "#000000"
-            : model.RoleColors.GetPrimaryColor().ToString();
-        return instance;
     }
 }
 

--- a/XeniaBot.WebPanel/Models/Wrappers/StrippedUser.cs
+++ b/XeniaBot.WebPanel/Models/Wrappers/StrippedUser.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Discord;
 using Discord.WebSocket;
 
@@ -6,23 +7,21 @@ namespace XeniaBot.WebPanel.Models;
 
 public class StrippedUser
 {
-    public string AvatarUrl { get; set; }
-    public string Discriminator { get; set; }
-    public string Username { get; set; }
-    public string DisplayName { get; set; }
+    public string AvatarUrl { get; set; } = string.Empty;
+    public string Discriminator { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
     public bool IsBot { get; set; }
     public bool IsWebhook { get; set; }
     public ulong Id { get; set; }
     
     public static IEnumerable<StrippedUser> FromGuild(DiscordSocketClient client, SocketGuild guild)
     {
-        var users = new List<StrippedUser>();
-        foreach (var i in guild.Users)
-        {
-            users.Add(StrippedUser.FromUser(client, i));
-        }
-        return users;
+        return guild.Users
+            .Select(i => FromUser(client, i))
+            .ToList();
     }
+
     public static StrippedUser FromUser(DiscordSocketClient client, IUser user)
     {
         var i = new StrippedUser();

--- a/XeniaBot.WebPanel/Program.cs
+++ b/XeniaBot.WebPanel/Program.cs
@@ -89,14 +89,8 @@ public static class Program
         LogManager.Setup().LoadConfigurationFromFile(FeatureFlags.NLogFileLocation);
         if (!string.IsNullOrEmpty(FeatureFlags.SentryDSN))
         {
-            SentrySdk.Init(static options =>
-            {
-                Update(options);
-            });
-            LogManager.Configuration?.AddSentry(options =>
-            {
-                Update(options);
-            });
+            SentrySdk.Init(Update);
+            LogManager.Configuration?.AddSentry(Update);
         }
 
         LogManager.GetLogger("Main").Info($"Running version {Details.VersionRaw}");
@@ -121,6 +115,7 @@ public static class Program
         options.Release = Version?.ToString();
         options.SendDefaultPii = true;
         options.AttachStacktrace = true;
+        options.EnableLogs = true;
         options.Environment = Details.Debug ? "production" : "debug";
         options.TracesSampleRate = 1.0;
         options.IsGlobalModeEnabled = false;

--- a/XeniaBot.WebPanel/RequireSuperuserAttribute.cs
+++ b/XeniaBot.WebPanel/RequireSuperuserAttribute.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Services;
 using XeniaBot.WebPanel.Helpers;
-using XeniaBot.WebPanel.Models;
 
 namespace XeniaBot.WebPanel;
 
@@ -24,7 +21,7 @@ public class RequireSuperuserAttribute : ActionFilterAttribute
 
         // Decline access to users that aren't a superuser.
         var userId = AspHelper.GetUserId(context.HttpContext) ?? 0;
-        if (!CoreContext.Instance?.GetRequiredService<ConfigData>().UserWhitelist.Contains((ulong)userId) ?? false)
+        if (CoreContext.Instance?.GetRequiredService<ConfigData>().UserWhitelist.Contains(userId) != true)
         {
             context.Result = new ViewResult
             {

--- a/XeniaBot.WebPanel/RestrictToGuildAttribute.cs
+++ b/XeniaBot.WebPanel/RestrictToGuildAttribute.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using XeniaBot.Shared;
 using XeniaBot.WebPanel.Helpers;
 using XeniaBot.WebPanel.Models;
 
@@ -18,10 +17,11 @@ namespace XeniaBot.WebPanel;
 public class RestrictToGuildAttribute : ActionFilterAttribute
 {
     /// <summary>
-    /// Key for the Route Data that contains the Guild Id this should be restricted to.
+    /// Key for the Route Data that contains the Guild ID this should be restricted to.
     /// </summary>
     [DefaultValue(null)]
     public string? GuildIdRouteKey { get; set; }
+
     /// <summary>
     /// Permission that the Requesting User requires to access the page this Attribute is applied on.
     /// </summary>
@@ -41,9 +41,9 @@ public class RestrictToGuildAttribute : ActionFilterAttribute
         if (!AuthAttributeHelper.HandleAuth(context))
             return;
 
-        ulong? targetGuildId = AuthAttributeHelper.ParseGuildIdFromRouteData(context, GuildIdRouteKey);
+        var targetGuildId = AuthAttributeHelper.ParseGuildIdFromRouteData(context, GuildIdRouteKey);
         
-        if (targetGuildId == null)
+        if (!targetGuildId.HasValue)
         {
             context.Result = new ViewResult
             {
@@ -60,7 +60,7 @@ public class RestrictToGuildAttribute : ActionFilterAttribute
         }
 
 
-        if (!AuthAttributeHelper.HandleUserAccessGuild(context, (ulong)targetGuildId!))
+        if (!AuthAttributeHelper.HandleUserAccessGuild(context, targetGuildId.Value))
         {
             return;
         }

--- a/XeniaBot.WebPanel/ViewComponents/RolePillViewComponent.cs
+++ b/XeniaBot.WebPanel/ViewComponents/RolePillViewComponent.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+using XeniaBot.WebPanel.Models;
+
+namespace XeniaBot.WebPanel.ViewComponents;
+
+public class RolePillViewComponent : ViewComponent
+{
+    public Task<IViewComponentResult> InvokeAsync(RolePillComponentModel data)
+    {
+        try
+        {
+            return Task.FromResult<IViewComponentResult>(View("Default", data));
+        }
+        catch (Exception exception)
+        {
+            return Task.FromException<IViewComponentResult>(exception);
+        }
+    }
+}

--- a/XeniaBot.WebPanel/Views/Server/Details/FunView/CountingView.cshtml
+++ b/XeniaBot.WebPanel/Views/Server/Details/FunView/CountingView.cshtml
@@ -1,6 +1,7 @@
 ﻿@using XeniaBot.Data.Models
 @model XeniaBot.WebPanel.Models.Component.FunView.IServerCountingComponentViewModel
 
+@* TODO: Use htmx *@
 @{
     ViewBag.Title = $"Counting - {@Model.Guild.Name}";
     Layout = "_Layout";

--- a/XeniaBot.WebPanel/Views/Server/Details/FunView/LevelSystemView.cshtml
+++ b/XeniaBot.WebPanel/Views/Server/Details/FunView/LevelSystemView.cshtml
@@ -1,5 +1,4 @@
-﻿@using XeniaBot.Data.Models
-@model XeniaBot.WebPanel.Models.Component.FunView.IServerLevelSystemComponentViewModel
+﻿@model XeniaBot.WebPanel.Models.Component.FunView.IServerLevelSystemComponentViewModel
 
 @{
     ViewBag.Title = $"Level System - {@Model.Guild.Name}";

--- a/XeniaBot.WebPanel/Views/Server/Details/ModerationView.cshtml
+++ b/XeniaBot.WebPanel/Views/Server/Details/ModerationView.cshtml
@@ -13,62 +13,90 @@
             guildId = Model.Guild.Id
         }
     );
+
+    const string navItemClassDefault = "nav-link";
+    const string tabPaneClassDefault = "tab-pane";
+    var navItemClassServerLog = navItemClassDefault;
+    var navItemClassWarnStrike = navItemClassDefault;
+    var navItemClassBanSync = navItemClassDefault;
+    var tabPaneClassServerLog = tabPaneClassDefault;
+    var tabPaneClassWarnStrike = tabPaneClassDefault;
+    var tabPaneClassBanSync = tabPaneClassDefault;
+    switch (Model.ActiveTab)
+    {
+        case "serverlog":
+            navItemClassServerLog += " active";
+            tabPaneClassServerLog += " show active";
+            break;
+        case "warnstrike":
+            navItemClassWarnStrike += " active";
+            tabPaneClassWarnStrike += " show active";
+            break;
+        case "bansync":
+            navItemClassBanSync += " active";
+            tabPaneClassBanSync += " show active";
+            break;
+        default:
+            navItemClassServerLog += " active";
+            tabPaneClassServerLog += " show active";
+            break;
+    }
 }
 
-@await Component.InvokeAsync("GuildBanner", new GuildBannerViewParameters(Model.Guild.Id, true,
-new List<BreadcrumbItem>()
-{
-    new BreadcrumbItem("Servers", "Server", "List"),
-    new BreadcrumbItem(Model.Guild.Name, "Server", "Index", new Dictionary<string, string>()
-    {
-        {"id", Model.Guild.Id.ToString()}
-    }),
-    new BreadcrumbItem("Moderation")
-}))
+@await Component.InvokeAsync("GuildBanner",
+    new GuildBannerViewParameters(
+        Model.Guild.Id, true,
+        [
+            new BreadcrumbItem("Servers", "Server", "List"),
+            new BreadcrumbItem(Model.Guild.Name, "Server", "Index", new Dictionary<string, string>()
+            {
+                {"id", Model.Guild.Id.ToString()}
+            }),
+            new BreadcrumbItem("Moderation")
+        ]))
 
-<div class="row d-flex flex-row">
-    <div class="m-1 col-auto">
-        <div class="card">
-            <div class="card-header card-header-sm" id="bansync">Ban Sync</div>
-            <div class="card-body"
-                 hx-get="@bansyncComponentUrl"
-                 hx-swap="innerHTML"
-                 hx-trigger="load"
-                 hx-target="this"
-                 hx-indicator=".htmx-indicator">
-                <div class="d-flex justify-content-center htmx-indicator">
-                    <div class="spinner-border" role="status">
-                        <span class="visually-hidden">Loading...</span>
-                    </div>
+@if (Model.Alert != null)
+{
+    @await Component.InvokeAsync("Alert", Model.Alert)
+}
+
+<ul class="nav nav-tabs" id="moderation-tabs" role="tablist">
+    <li class="nav-item" role="presentation">
+        <button class="@navItemClassServerLog" id="tab-serverlog" data-bs-toggle="tab" data-bs-target="#serverlog-content" type="button" role="tab" aria-controls="home" aria-selected="true">Server Logging</button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="@navItemClassWarnStrike" id="tab-warnstrike" data-bs-toggle="tab" data-bs-target="#warnstrike-content" type="button" role="tab" aria-controls="profile" aria-selected="false">Warn Strike</button>
+    </li>
+    <li class="nav-item" role="presentation">
+        <a class="nav-link" href="~/Guild/@Model.Guild.Id/RolePreserve/Settings">Role Preserve</a>
+    </li>
+    <li class="nav-item" role="presentation">
+        <button class="@navItemClassBanSync" id="tab-bansync" data-bs-toggle="tab" data-bs-target="#bansync-content" type="button" role="tab" aria-controls="profile" aria-selected="false">BanSync</button>
+    </li>
+</ul>
+<div class="tab-content pt-2 px-3">
+    <div class="@tabPaneClassServerLog" id="serverlog-content" aria-labelledby="tab-serverlog" role="tabpanel" tabindex="0">
+        @{ await Html.RenderPartialAsync("Details/ModerationView/Logging"); }
+    </div>
+    <div class="@tabPaneClassWarnStrike" id="warnstrike-content" role="tabpanel" tabindex="0" aria-labelledby="tab-warnstrike">
+        @{ await Html.RenderPartialAsync("Details/ModerationView/WarnStrike"); }
+    </div>
+    <div class="tab-pane" id="rolepreserve-content" role="tabpanel" tabindex="0" aria-labelledby="tab-rolepreserve"></div>
+    <div class="@tabPaneClassBanSync" id="bansync-content" role="tabpanel" tabindex="0" aria-labelledby="tab-bansync">
+        <div hx-get="@bansyncComponentUrl"
+             hx-swap="innerHTML"
+             hx-trigger="load"
+             hx-target="this"
+             hx-indicator=".htmx-indicator">
+            <div class="d-flex justify-content-center htmx-indicator">
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden">Loading...</span>
                 </div>
             </div>
         </div>
     </div>
-    <div class="m-1 col-auto">
-        <div class="card">
-            <div class="card-header card-header-sm" id="rolePreserve">Role Preserve</div>
-            <div class="card-body">
-                @{ await Html.RenderPartialAsync("Details/ModerationView/RolePreserve"); }
-            </div>
-        </div>
-    </div>
-    <div class="m-1 col-auto">
-        <div class="card">
-            <div class="card-header card-header-sm" id="warnStrike">Warn Strike</div>
-            <div class="card-body">
-                @{ await Html.RenderPartialAsync("Details/ModerationView/WarnStrike"); }
-            </div>
-        </div>
-    </div>
-    <div class="m-1 col-auto">
-        <div class="card">
-            <div class="card-header card-header-sm" id="log">Logging</div>
-            <div class="card-body">
-                @{ await Html.RenderPartialAsync("Details/ModerationView/Logging"); }
-            </div>
-        </div>
-    </div>
 </div>
+
 @section Scripts {
     <script src="~/js/site.serverLog.js" asp-append-version="true"></script>
 }

--- a/XeniaBot.WebPanel/Views/Server/Details/ModerationView/Logging.cshtml
+++ b/XeniaBot.WebPanel/Views/Server/Details/ModerationView/Logging.cshtml
@@ -111,7 +111,7 @@
 
                         </select>
                         <small id="server-log-select-channel-help" class="form-text text-muted">
-                            Channel that the selected event should be used with.<br/>
+                            Chanel that the selected event should be used with.<br/>
                             More than one event can be used per channel, and more than one channel can have the same event.
                         </small>
                     </div>

--- a/XeniaBot.WebPanel/Views/Server/Details/ModerationView/Logging.cshtml
+++ b/XeniaBot.WebPanel/Views/Server/Details/ModerationView/Logging.cshtml
@@ -2,10 +2,9 @@
 @using System.Text.Json
 @using Discord
 @using Discord.WebSocket
-@using Microsoft.AspNetCore.Mvc.TagHelpers
-@using XeniaBot.WebPanel.Models
 @model ServerDetailsViewModel
 
+@* TODO: Use htmx *@
 @{
     var seenChannelIds = new HashSet<ulong>();
     var channelItems = new List<JsTypeServerLogChannelItem>();

--- a/XeniaBot.WebPanel/Views/Server/Details/ModerationView/WarnStrike.cshtml
+++ b/XeniaBot.WebPanel/Views/Server/Details/ModerationView/WarnStrike.cshtml
@@ -1,5 +1,6 @@
 ﻿@model ServerDetailsViewModel
 
+@* TODO: Use htmx *@
 <form id="role_preserve"
       enctype="application/x-www-form-urlencoded"
       method="post"

--- a/XeniaBot.WebPanel/Views/ServerBanSync/Details.cshtml
+++ b/XeniaBot.WebPanel/Views/ServerBanSync/Details.cshtml
@@ -1,5 +1,4 @@
-﻿@using XeniaBot.WebPanel.Helpers
-@model BanSyncRecordViewModel
+﻿@model BanSyncRecordViewModel
 
 @{
     ViewBag.Title = "BanSync Record";

--- a/XeniaBot.WebPanel/Views/Shared/Components/Alert/Default.cshtml
+++ b/XeniaBot.WebPanel/Views/Shared/Components/Alert/Default.cshtml
@@ -1,10 +1,20 @@
-﻿@model AlertComponentViewModel
+﻿@using Markdig
+@model AlertComponentViewModel
 
-
-@if (Model.Message != null)
+@if (!string.IsNullOrEmpty(Model.Message?.Trim()))
 {
     <div class="@(Model.MessageClass) mb-2" role="alert">
-        @Model.Message
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        @if (Model.RenderMessageAsMarkdown == true)
+        {
+            @Html.Raw(Markdown.ToHtml(Model.Message))
+        }
+        else
+        {
+            @Model.Message
+        }
+        @if (Model.ShowClose)
+        {
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        }
     </div>
 }

--- a/XeniaBot.WebPanel/Views/Shared/Components/GuildBanner/Default.cshtml
+++ b/XeniaBot.WebPanel/Views/Shared/Components/GuildBanner/Default.cshtml
@@ -1,6 +1,5 @@
 ﻿@model GuildBannerViewModel
 
-
 @if (Model.Parameters.EnableBreadcrumb)
 {
     <div role="enable-breadcrumb">

--- a/XeniaBot.WebPanel/Views/Shared/Components/RolePill/Default.cshtml
+++ b/XeniaBot.WebPanel/Views/Shared/Components/RolePill/Default.cshtml
@@ -1,0 +1,21 @@
+﻿@model XeniaBot.WebPanel.Models.RolePillComponentModel
+@{
+    var spanClass = "badge ";
+    spanClass += Model.Role.ShouldUseLightText() switch
+    {
+        false => "text-dark",
+        _ => "text-light",
+    };
+
+    var tooltipText = Model.GetTooltipText();
+    var style = Model.GetBadgeStyle();
+}
+
+@if (!string.IsNullOrEmpty(tooltipText))
+{
+    <span class="@spanClass" style="@style" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true" data-bs-title="@tooltipText">@@@Model.Role.Name</span>
+}
+else
+{
+    <span class="@spanClass" style="@style">@@@Model.Role.Name</span>
+}

--- a/XeniaBot.WebPanel/Views/Shared/Components/RolePill/Default.cshtml
+++ b/XeniaBot.WebPanel/Views/Shared/Components/RolePill/Default.cshtml
@@ -11,11 +11,20 @@
     var style = Model.GetBadgeStyle();
 }
 
-@if (!string.IsNullOrEmpty(tooltipText))
-{
-    <span class="@spanClass" style="@style" data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true" data-bs-title="@tooltipText">@@@Model.Role.Name</span>
-}
-else
-{
-    <span class="@spanClass" style="@style">@@@Model.Role.Name</span>
-}
+<span class="@spanClass" style="@style" id="@Model.ElementId" 
+        @{
+            if (!string.IsNullOrEmpty(tooltipText))
+            {
+                <text>data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-html="true" data-bs-title="@tooltipText"</text>
+            }
+        }>
+    @if (Model.InputOptions.HasValue)
+    {
+        <input type="hidden" value="@Model.InputOptions.Value.Value" name="@Model.InputOptions.Value.Name" />
+    }
+    @@@Model.Role.Name
+    @if (Model.InputOptions is { HasValue: true, Value.AllowRemoval: true })
+    {
+        <button type="button" class="btn-close btn-sm ms-1" aria-label="Close" onclick="document.getElementById('@Model.ElementId').remove()"></button>
+    }
+</span>

--- a/XeniaBot.WebPanel/Views/Shared/Components/RoleSelectRaw/Default.cshtml
+++ b/XeniaBot.WebPanel/Views/Shared/Components/RoleSelectRaw/Default.cshtml
@@ -1,5 +1,4 @@
 ﻿@model XeniaBot.WebPanel.Models.RoleSelectRawComponentModel
-@using Discord.WebSocket
 @if ((Model.SelectedRoleId ?? 0) == 0)
 {
     <option value="" selected>None</option>
@@ -11,6 +10,6 @@ else
 <hr/>
 @foreach (var role in Model.Roles.OrderBy(v => v.Position))
 {
-    <option value="@role.RoleId" disabled="@(!role.CanAccess)">@role.Name</option>
+    <option value="@role.Id" disabled="@(!role.CanAccess)">@role.Name</option>
 }
 

--- a/XeniaBot.WebPanel/Views/Shared/NotAuthorizedPartial.cshtml
+++ b/XeniaBot.WebPanel/Views/Shared/NotAuthorizedPartial.cshtml
@@ -1,5 +1,8 @@
 ﻿@model NotAuthorizedViewModel?
 @namespace XeniaBot.WebPanel.Views.Shared
+@{
+    Layout = null;
+}
 
 <h1>Unauthorized</h1>
 <p>You cannot access this page due to you not being logged in or you don't have the right permissions.</p>

--- a/XeniaBot.WebPanel/Views/Shared/NotFoundPartial.cshtml
+++ b/XeniaBot.WebPanel/Views/Shared/NotFoundPartial.cshtml
@@ -1,4 +1,7 @@
 ﻿@model string
+@{
+    Layout = null;
+}
 
 <h1>Not Found</h1>
 <p>The data you requested could not be found. </p>

--- a/XeniaBot.WebPanel/wwwroot/js/site.js
+++ b/XeniaBot.WebPanel/wwwroot/js/site.js
@@ -1,6 +1,9 @@
 ﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
+const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+
 /**
  * @typedef {object} CreateBootstrapToastOptions
  * @property {string|null} [iconUrl] - Url of an icon to display to the left of the title

--- a/XeniaBot.WebPanel/wwwroot/js/site.js
+++ b/XeniaBot.WebPanel/wwwroot/js/site.js
@@ -162,6 +162,34 @@ const xeniaDiscord = {
         $(div).toast(toastOptions);
         $(div).toast('show');
         return div;
+    },
+    createRolePill: function (options) {
+        const span = document.createElement('span');
+        span.style = options.style;
+        span.id = options.id;
+        if (options.tooltipText) {
+            span.setAttribute('data-bs-toggle', 'tooltip');
+            span.setAttribute('data-bs-placement', 'bottom');
+            span.setAttribute('data-bs-title', options.tooltipText);
+        }
+        if (options.inputOptions) {
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = options.inputOptions.name;
+            input.value = options.inputOptions.value;
+            span.appendChild(input);
+        }
+        span.innerText += `@${options.name}`;
+        if (options.inputOptions && options.inputOptions.allowRemoval) {
+            const button = document.createElement('button');
+            button.className = 'btn-close btn-sm ms-1';
+            button.setAttribute('aria-label', 'Remove');
+            button.onclick = () => {
+                document.getElementById(`span#${options.Id}`).remove();
+            };
+            span.appendChild(button);
+        }
+        return span;
     }
 };
 

--- a/XeniaBot.sln
+++ b/XeniaBot.sln
@@ -44,6 +44,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XeniaDiscord.Interactions",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XeniaDiscord.Resources", "XeniaDiscord.Resources\XeniaDiscord.Resources.csproj", "{06506F11-CB9C-419E-A7BE-312045575279}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XeniaDiscord.UnitTest", "XeniaDiscord.UnitTest\XeniaDiscord.UnitTest.csproj", "{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -210,6 +212,18 @@ Global
 		{06506F11-CB9C-419E-A7BE-312045575279}.Release|arm64.Build.0 = Release|Any CPU
 		{06506F11-CB9C-419E-A7BE-312045575279}.Release|x86.ActiveCfg = Release|Any CPU
 		{06506F11-CB9C-419E-A7BE-312045575279}.Release|x86.Build.0 = Release|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Debug|arm64.Build.0 = Debug|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Debug|x86.Build.0 = Debug|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Release|arm64.ActiveCfg = Release|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Release|arm64.Build.0 = Release|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Release|x86.ActiveCfg = Release|Any CPU
+		{4D93DF5A-5F74-47E6-ACCD-0DAEECCCB439}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/XeniaBot.sln.DotSettings
+++ b/XeniaBot.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=will_0020rollback/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/XeniaBot.sln.DotSettings
+++ b/XeniaBot.sln.DotSettings
@@ -1,2 +1,7 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/Environment/AIAssistantOptions/IsAccessToCodeEnabled/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/AIAssistantOptions/IsContextActionsEnabled/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/AIAssistantOptions/IsExplainExceptionEnabled/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/AIInplaceSuggestionHintsOptions/ShowInPlaceSuggestionHints/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/GrayCodeCompletion/IsEnabled/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=will_0020rollback/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/XeniaDiscord.Common/Helpers/DiscordPermissionHelper.cs
+++ b/XeniaDiscord.Common/Helpers/DiscordPermissionHelper.cs
@@ -1,0 +1,147 @@
+﻿using CSharpFunctionalExtensions;
+using Discord;
+using Discord.WebSocket;
+
+namespace XeniaDiscord.Common.Helpers;
+
+public static class DiscordPermissionHelper
+{
+    public static GuildPermission CalculateGuild(
+        SocketGuildUser member)
+        => CalculateGuild(member.Roles, member.GuildPermissions);
+    public static GuildPermission CalculateGuild(
+        IReadOnlyCollection<IRole> memberRoles,
+        GuildPermissions memberPermissions)
+    {
+        var permissions = (GuildPermission)((ulong)0);
+        foreach (var role in memberRoles.OrderBy(e => e.Position))
+        {
+            foreach (var p in role.Permissions.ToList().Where(e => !permissions.HasFlag(e)))
+            {
+                permissions |= p;
+            }
+        }
+
+        foreach (var p in memberPermissions.ToList().Where(e => !permissions.HasFlag(e)))
+        {
+            permissions |= p;
+        }
+
+        return permissions;
+    }
+
+    public static CalculateChannelPermissionsResult CalculateChannel(
+        SocketGuildUser member,
+        IGuildChannel channel)
+        => CalculateChannel(
+            member.Roles,
+            member.GuildPermissions,
+            member.Id,
+            channel.PermissionOverwrites);
+
+    public static CalculateChannelPermissionsResult CalculateChannel(
+        IReadOnlyCollection<IRole> memberRoles,
+        GuildPermissions memberPermissions,
+        ulong memberId,
+        IReadOnlyCollection<Overwrite> permissionOverwrites)
+    {
+        var allow = (ChannelPermission)(0);
+        var deny = (ChannelPermission)(0);
+        foreach (var overwrite in memberRoles
+                     .OrderBy(static e => e.Position)
+                     .Select(r => permissionOverwrites.FirstOrDefault(p => p.TargetId == r.Id && p.TargetType == PermissionTarget.Role)))
+        {
+            ProcessChannelOverwrite(ref allow, ref deny, overwrite);
+        }
+
+        var userOverwrite = permissionOverwrites
+            .Where(e => e.TargetId == memberId && e.TargetType == PermissionTarget.User)
+            .Take(1)
+            .ToArray();
+        if (userOverwrite.Length > 0)
+        {
+            ProcessChannelOverwrite(ref allow, ref deny, userOverwrite[0]);
+        }
+
+        return new CalculateChannelPermissionsResult(allow, deny, CalculateGuild(memberRoles, memberPermissions));
+    }
+
+    public static void ProcessChannelOverwrite(
+        ref ChannelPermission allow,
+        ref ChannelPermission deny,
+        Overwrite overwrite)
+    {
+        var allowValue = (ChannelPermission)overwrite.Permissions.AllowValue;
+        var denyValue = (ChannelPermission)overwrite.Permissions.DenyValue;
+        foreach (var f in Enum.GetValues<ChannelPermission>())
+        {
+            if (allowValue.HasFlag(f) && !allow.HasFlag(f)) allow |= f;
+            if (denyValue.HasFlag(f) && !deny.HasFlag(f)) deny |= f;
+        }
+    }
+
+    public static bool CanPerform(this CalculateChannelPermissionsResult data,
+        ChannelPermission permission)
+    {
+        if (data.Allow.HasFlag(permission)) return true;
+        if (data.Deny.HasFlag(permission)) return true;
+        return permission.ToGuildPermission()
+            .GetValueOrDefault(
+                v => data.GuildPermissions.HasFlag(v),
+                defaultValue: false);
+    }
+
+    public static Maybe<GuildPermission> ToGuildPermission(this ChannelPermission value)
+    {
+        return value switch
+        {
+            ChannelPermission.CreateInstantInvite => GuildPermission.CreateInstantInvite,
+            ChannelPermission.ManageChannels => GuildPermission.ManageChannels,
+            ChannelPermission.AddReactions => GuildPermission.AddReactions,
+            ChannelPermission.ViewChannel => GuildPermission.ViewChannel,
+            ChannelPermission.SendMessages => GuildPermission.SendMessages,
+            ChannelPermission.SendTTSMessages => GuildPermission.SendTTSMessages,
+            ChannelPermission.ManageMessages => GuildPermission.ManageMessages,
+            ChannelPermission.EmbedLinks => GuildPermission.EmbedLinks,
+            ChannelPermission.AttachFiles => GuildPermission.AttachFiles,
+            ChannelPermission.ReadMessageHistory => GuildPermission.ReadMessageHistory,
+            ChannelPermission.MentionEveryone => GuildPermission.MentionEveryone,
+            ChannelPermission.UseExternalEmojis => GuildPermission.UseExternalEmojis,
+            ChannelPermission.Connect => GuildPermission.Connect,
+            ChannelPermission.Speak => GuildPermission.Speak,
+            ChannelPermission.MuteMembers => GuildPermission.MuteMembers,
+            ChannelPermission.DeafenMembers => GuildPermission.DeafenMembers,
+            ChannelPermission.MoveMembers => GuildPermission.MoveMembers,
+            ChannelPermission.UseVAD => GuildPermission.UseVAD,
+            ChannelPermission.PrioritySpeaker => GuildPermission.PrioritySpeaker,
+            ChannelPermission.Stream => GuildPermission.Stream,
+            ChannelPermission.ManageRoles => GuildPermission.ManageRoles,
+            ChannelPermission.ManageWebhooks => GuildPermission.ManageWebhooks,
+            ChannelPermission.ManageEmojis => GuildPermission.ManageEmojisAndStickers,
+            ChannelPermission.UseApplicationCommands => GuildPermission.UseApplicationCommands,
+            ChannelPermission.RequestToSpeak => GuildPermission.RequestToSpeak,
+            ChannelPermission.ManageThreads => GuildPermission.ManageThreads,
+            ChannelPermission.CreatePublicThreads => GuildPermission.CreatePublicThreads,
+            ChannelPermission.CreatePrivateThreads => GuildPermission.CreatePrivateThreads,
+            ChannelPermission.UseExternalStickers => GuildPermission.UseExternalStickers,
+            ChannelPermission.SendMessagesInThreads => GuildPermission.SendMessagesInThreads,
+            ChannelPermission.StartEmbeddedActivities => GuildPermission.StartEmbeddedActivities,
+            ChannelPermission.UseSoundboard => GuildPermission.UseSoundboard,
+            ChannelPermission.CreateEvents => GuildPermission.CreateEvents,
+            ChannelPermission.UseExternalSounds => GuildPermission.UseExternalSounds,
+            ChannelPermission.SendVoiceMessages => GuildPermission.SendVoiceMessages,
+            ChannelPermission.UseClydeAI => GuildPermission.UseClydeAI,
+            ChannelPermission.SetVoiceChannelStatus => GuildPermission.SetVoiceChannelStatus,
+            ChannelPermission.SendPolls => GuildPermission.SendPolls,
+            ChannelPermission.UseExternalApps => GuildPermission.UseExternalApps,
+            ChannelPermission.PinMessages => GuildPermission.PinMessages,
+            ChannelPermission.BypassSlowmode => GuildPermission.BypassSlowmode,
+            _ => Maybe.None
+        };
+    }
+}
+
+public sealed record CalculateChannelPermissionsResult(
+    ChannelPermission Allow,
+    ChannelPermission Deny,
+    GuildPermission GuildPermissions);

--- a/XeniaDiscord.Common/Mappers/DiscordSnapshot/RoleToSnapshotModelMapper.cs
+++ b/XeniaDiscord.Common/Mappers/DiscordSnapshot/RoleToSnapshotModelMapper.cs
@@ -18,12 +18,15 @@ public class RoleToSnapshotModelMapper
     {
         ArgumentNullException.ThrowIfNull(role);
 
+        var recordId = Guid.NewGuid();
+        var roleIdStr = role.Id.ToString();
         var result = new GuildRoleSnapshotModel
         {
+            Id = recordId,
             RecordCreatedAt = DateTime.UtcNow,
 
             GuildId = role.Guild.Id.ToString(),
-            RoleId = role.Id.ToString(),
+            RoleId = roleIdStr,
             Name = role.Name,
             CreatedAt = role.CreatedAt.UtcDateTime,
             Position = role.Position,
@@ -31,6 +34,11 @@ public class RoleToSnapshotModelMapper
             IsManaged = role.IsManaged,
             IsMentionable = role.IsMentionable,
             IsHoisted = role.IsHoisted,
+            RoleColors = new GuildRoleColorSnapshotModel(role.Colors)
+            {
+                GuildRoleSnapshotId = recordId,
+                RoleId = roleIdStr
+            }
         };
 
         foreach (var value in role.Permissions.ToList())
@@ -40,7 +48,7 @@ public class RoleToSnapshotModelMapper
                 GuildRoleSnapshotId = result.Id,
                 RecordCreatedAt = result.RecordCreatedAt,
                 GuildId = result.GuildId,
-                RoleId = result.RoleId,
+                RoleId = roleIdStr,
                 Value = ((ulong)value).ToString(),
             });
         }

--- a/XeniaDiscord.Common/Services/Cache/DiscordCacheService.cs
+++ b/XeniaDiscord.Common/Services/Cache/DiscordCacheService.cs
@@ -1,5 +1,6 @@
 ﻿using Discord;
 using Discord.WebSocket;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
@@ -11,6 +12,7 @@ using XeniaDiscord.Data.Repositories;
 
 namespace XeniaDiscord.Common.Services;
 
+[UsedImplicitly]
 public class DiscordCacheService
 {
     private readonly Logger _log = LogManager.GetCurrentClassLogger();
@@ -120,6 +122,7 @@ public class DiscordCacheService
         try
         {
             member = await ExceptionHelper.RetryOnTimedOut(async () => await guild.GetUserAsync(userId));
+            // ReSharper disable once AsyncMethodWithoutAwait
             member ??= await ExceptionHelper.RetryOnTimedOut(async () => _client.GetUser(userId));
         }
         catch (Exception ex)
@@ -139,7 +142,7 @@ public class DiscordCacheService
         var model = await db.GuildMemberCache
             .AsNoTracking()
             .FirstOrDefaultAsync(e => e.UserId == userIdStr && e.GuildId == guildIdStr)
-            ?? new()
+            ?? new GuildMemberCacheModel
             {
                 GuildId = guildIdStr,
                 UserId = userIdStr,

--- a/XeniaDiscord.Common/Services/Cache/DiscordCacheService.cs
+++ b/XeniaDiscord.Common/Services/Cache/DiscordCacheService.cs
@@ -3,11 +3,10 @@ using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
-using System.Data;
 using XeniaBot.Shared;
+using XeniaBot.Shared.Helpers;
 using XeniaDiscord.Data;
 using XeniaDiscord.Data.Models.Cache;
-using XeniaDiscord.Data.Models.Snapshot;
 using XeniaDiscord.Data.Repositories;
 
 namespace XeniaDiscord.Common.Services;
@@ -25,8 +24,6 @@ public class DiscordCacheService
     private readonly IMapper<IUser, UserCacheModel> _userMapper;
     private readonly IMapperMerger<IUser, GuildMemberCacheModel> _memberMergerMapper;
     private readonly IMapperMerger<IGuild, GuildCacheModel> _guildMergerMapper;
-    private readonly IMapper<IGuildUser, GuildMemberSnapshotModel> _guildMemberSnapshotMapper;
-    private readonly IMapper<IRole, GuildRoleSnapshotModel> _guildRoleSnapshotMapper;
     public DiscordCacheService(IServiceProvider services)
     {
         _db = services.GetRequiredScopedService<XeniaDbContext>(out var _);
@@ -39,14 +36,12 @@ public class DiscordCacheService
         _userMapper = services.GetRequiredService<IMapper<IUser, UserCacheModel>>();
         _memberMergerMapper = services.GetRequiredService<IMapperMerger<IUser, GuildMemberCacheModel>>();
         _guildMergerMapper = services.GetRequiredService<IMapperMerger<IGuild, GuildCacheModel>>();
-        _guildMemberSnapshotMapper = services.GetRequiredService<IMapper<IGuildUser, GuildMemberSnapshotModel>>();
-        _guildRoleSnapshotMapper = services.GetRequiredService<IMapper<IRole, GuildRoleSnapshotModel>>();
     }
 
     #region Guild
     public async Task UpdateGuild(IGuild guild)
     {
-        using var db = _db.CreateSession();
+        await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
@@ -102,7 +97,7 @@ public class DiscordCacheService
     public Task UpdateGuildMember(IGuildUser member) => UpdateGuildMember(member.Guild, member);
     public async Task UpdateGuildMember(IGuild guild, IUser user)
     {
-        using var db = _db.CreateSession();
+        await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
@@ -120,16 +115,18 @@ public class DiscordCacheService
         XeniaDbContext db,
         IGuild guild, ulong userId)
     {
+#pragma warning disable S6966
         IUser? member = null;
         try
         {
-            member = await guild.GetUserAsync(userId);
-            member ??= _client.GetUser(userId);
+            member = await ExceptionHelper.RetryOnTimedOut(async () => await guild.GetUserAsync(userId));
+            member ??= await ExceptionHelper.RetryOnTimedOut(async () => _client.GetUser(userId));
         }
         catch (Exception ex)
         {
             _log.Warn(ex, $"Failed to get Member {userId} in Guild \"{guild.Name}\" ({guild.Id})");
         }
+#pragma warning restore S6966
         await UpdateGuildMember(db, guild, userId, member);
     }
     
@@ -174,7 +171,7 @@ public class DiscordCacheService
 
     public async Task UpdateUser(IUser user)
     {
-        using var db = _db.CreateSession();
+        await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {

--- a/XeniaDiscord.Common/Services/RolePreserveLogService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveLogService.cs
@@ -72,7 +72,7 @@ public class RolePreserveLogService
         
         _log.Info($"Audit ID={auditModel.Id}, Guild ID={user.Guild.Id}, User ID={user.Id}, Username={user.Username} (log channels: {targetLogChannels.Count}, success: {successCountValue}, skip: {skipCountValue}, fail: {failCountValue})");
         
-        foreach (var serverLogChannel in targetLogChannels)
+        foreach (var serverLogChannel in targetLogChannels.DistinctBy(e => e.ChannelId))
         {
             await SendNotificationToChannel(user, embed, attachments, serverLogChannel);
         }
@@ -217,15 +217,13 @@ public class RolePreserveLogService
         var sb = new StringBuilder();
         if (successCountValue > 0 && failCountValue == 0)
         {
-            sb.Append("- ");
             sb.Append(Emotes.Tada);
-            sb.Append("Successfully granted ");
+            sb.Append(" Successfully granted ");
             sb.Append("role".ToQuantity(successCountValue, fmt));
             sb.Append(" to user.");
         }
         else if (successCountValue > 0 && failCountValue > 0)
         {
-            sb.Append("- ");
             sb.Append(Emotes.Warning);
             sb.Append(" Successfully granted user");
             sb.Append("role".ToQuantity(successCountValue, fmt));
@@ -235,7 +233,6 @@ public class RolePreserveLogService
         }
         else if (failCountValue > 0)
         {
-            sb.Append("- ");
             sb.Append(Emotes.Warning);
             sb.Append(" Failed to give user *any* roles. ");
             sb.Append('(');
@@ -489,7 +486,7 @@ public class RolePreserveLogService
                 });
         }
 
-        return targets;
+        return targets.DistinctBy(e => e.ChannelId).ToArray();
     }
     #endregion
 }

--- a/XeniaDiscord.Common/Services/RolePreserveLogService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveLogService.cs
@@ -201,9 +201,18 @@ public class RolePreserveLogService
         EmbedBuilder embed,
         RolePreserveAuditModel auditModel)
     {
+        const string fmt = "N0";
         var successCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSuccess());
         var skipCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSkip());
         var failCountValue = auditModel.AppliedRoles.Count(e => e.IsActionFailure());
+
+        if (successCountValue < 1 && skipCountValue < 1 && failCountValue < 1)
+        {
+            embed.WithDescription(
+                "For some reason nothing happened.\n**Please join the Xenia support server and notify a developer.**\n\n" +
+                $"Please send a screenshot of this embed!\n-# `RolePreserveAuditModel.Id={auditModel.Id}`");
+            return;
+        }
 
         var sb = new StringBuilder();
         if (successCountValue > 0 && failCountValue == 0)
@@ -211,7 +220,7 @@ public class RolePreserveLogService
             sb.Append("- ");
             sb.Append(Emotes.Tada);
             sb.Append("Successfully granted ");
-            sb.Append("role".ToQuantity(successCountValue));
+            sb.Append("role".ToQuantity(successCountValue, fmt));
             sb.Append(" to user.");
         }
         else if (successCountValue > 0 && failCountValue > 0)
@@ -219,9 +228,9 @@ public class RolePreserveLogService
             sb.Append("- ");
             sb.Append(Emotes.Warning);
             sb.Append(" Successfully granted user");
-            sb.Append("role".ToQuantity(successCountValue));
+            sb.Append("role".ToQuantity(successCountValue, fmt));
             sb.Append(", but failed to grant them");
-            sb.Append("role".ToQuantity(failCountValue));
+            sb.Append("role".ToQuantity(failCountValue, fmt));
             sb.Append('.');
         }
         else if (failCountValue > 0)
@@ -229,14 +238,16 @@ public class RolePreserveLogService
             sb.Append("- ");
             sb.Append(Emotes.Warning);
             sb.Append(" Failed to give user *any* roles. ");
-            sb.AppendFormat("({0})", "failure".ToQuantity(failCountValue));
+            sb.Append('(');
+            sb.Append("failure".ToQuantity(failCountValue, fmt));
+            sb.Append(')');
         }
 
         if (sb.Length > 0 && skipCountValue > 0)
         {
             sb.Append('\n');
             sb.Append("-# Skipped ");
-            sb.Append("role".ToQuantity(skipCountValue));
+            sb.Append("role".ToQuantity(skipCountValue, fmt));
         }
 
         if (sb.Length > 0) embed.WithDescription(sb.ToString());
@@ -262,14 +273,14 @@ public class RolePreserveLogService
     {
         const string failFilename = "roles-failure.txt";
         var attachments = new List<FileAttachment>();
-        var count = auditModel.AppliedRoles.Count(e => e.IsActionFailure());
+        var count = auditModel.AppliedRoles.Count(static e => e.IsActionFailure());
         if (count < 1) return [];
         
-        var content = GenerateFailureEmbedContent(auditModel);
+        var content = GenerateRoleListEmbedContent(auditModel, static e => e.IsActionFailure());
         if (content.HasNoValue)
         {
             attachments.Add(new FileAttachment(
-                GenerateFailureAttachmentContent(auditModel).ToMemoryStream(Encoding.UTF8),
+                GenerateRoleListAttachmentContent(auditModel, static e => e.IsActionFailure()).ToMemoryStream(Encoding.UTF8),
                 failFilename,
                 "List of all the roles that Xenia failed to give to a user."));
         }
@@ -359,14 +370,6 @@ public class RolePreserveLogService
         }
     }
 
-    private static string GenerateFailureAttachmentContent(
-        RolePreserveAuditModel auditModel)
-    {
-        return GenerateRoleListAttachmentContent(
-            auditModel,
-            static e => e.IsActionFailure());
-    }
-
     private static string GenerateRoleListAttachmentContent(
         RolePreserveAuditModel auditModel,
         Func<RolePreserveAuditAppliedRoleModel, bool> predicate)
@@ -383,14 +386,6 @@ public class RolePreserveLogService
             sb.AppendLine();
         }
         return sb.ToString();
-    }
-
-    private static Maybe<string> GenerateFailureEmbedContent(
-        RolePreserveAuditModel auditModel)
-    {
-        return GenerateRoleListEmbedContent(
-            auditModel,
-            static e => e.IsActionFailure());
     }
 
     /// <returns>

--- a/XeniaDiscord.Common/Services/RolePreserveLogService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveLogService.cs
@@ -1,10 +1,10 @@
-﻿using System.Text;
-using CSharpFunctionalExtensions;
+﻿using CSharpFunctionalExtensions;
 using Discord;
 using Discord.WebSocket;
 using Humanizer;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
+using System.Text;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Helpers;
 using XeniaBot.Shared.Services;
@@ -36,23 +36,25 @@ public class RolePreserveLogService
         {
             await SendFailureNotification(user, auditModel);
         }
+        else
+        {
+            await SendSuccessNotification(user, auditModel);
+        }
     }
     
-    public async Task SendFailureNotification(
+    private async Task SendFailureNotification(
         SocketGuildUser user,
         RolePreserveAuditModel auditModel)
     {
         // don't run method if there are no failures
-        if (auditModel.AppliedRoles.All(e => e.IsActionSuccess() || e.IsActionSkip()))
+        var successCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSuccess());
+        var skipCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSkip());
+        var failCountValue = auditModel.AppliedRoles.Count(e => e.IsActionFailure());
+        if (failCountValue < 1)
             return;
 
         var targetLogChannels = await GetLogChannelsFor(RolePreserveLogKind.Failure, user);
         if (targetLogChannels.Count < 1) return;
-
-        var successCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSuccess());
-        var skipCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSkip());
-        var failCountValue = auditModel.AppliedRoles.Count(e => e.IsActionFailure());
-        if (skipCountValue < 1 && failCountValue < 1) return;
 
         var embed = new EmbedBuilder()
             .WithDescription(FormatDescriptionText(auditModel))
@@ -76,6 +78,45 @@ public class RolePreserveLogService
         }
     }
 
+    private async Task SendSuccessNotification(
+        SocketGuildUser user,
+        RolePreserveAuditModel auditModel)
+    {
+        // don't run method if there are successes
+        var successCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSuccess());
+        var skipCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSkip());
+        if (successCountValue < 1 && skipCountValue < 1) return;
+        
+        var targetLogChannels = await GetLogChannelsFor(RolePreserveLogKind.Success, user);
+        if (targetLogChannels.Count < 1) return;
+
+        var embed = new EmbedBuilder()
+            .WithDescription(FormatDescriptionText(auditModel))
+            .WithTitle("Role Preserve - Success - " + user.Username)
+            .WithFooter($"User Id: {user.Id}")
+            .WithColor(new Color(255, 255, 255))
+            .WithCurrentTimestamp();
+        if (_config.HasDashboard)
+        {
+            embed.WithUrl($"{_config.DashboardUrl}/RolePreserve/Audit/Details?Id={auditModel.Id}");
+        }
+
+        if (_config.HasDashboard)
+        {
+            embed.WithUrl($"{_config.DashboardUrl}/RolePreserve/Audit/Details?Id={auditModel.Id}");
+        }
+
+        NotificationGetDescription(embed, auditModel);
+        var attachments = GenerateAttachments(embed, RolePreserveLogKind.Success, auditModel);
+
+        _log.Info($"Audit ID={auditModel.Id}, Guild ID={user.Guild.Id}, User ID={user.Id}, Username={user.Username} (log channels: {targetLogChannels.Count}, success: {successCountValue}, skip: {skipCountValue})");
+
+        foreach (var serverLogChannel in targetLogChannels)
+        {
+            await SendNotificationToChannel(user, embed, attachments, serverLogChannel);
+        }
+    }
+
     private async Task SendNotificationToChannel(
         SocketGuildUser user,
         EmbedBuilder embed,
@@ -85,14 +126,15 @@ public class RolePreserveLogService
         SocketTextChannel? textChannel;
         try
         {
-            textChannel = ExceptionHelper.RetryOnTimedOut(() => user.Guild.GetTextChannel(serverLogChannel.GetChannelId()))
-                          ?? throw new InvalidOperationException($"Channel {serverLogChannel.ChannelId} does not exist (GetTextChannel returned null)");
+            textChannel = ExceptionHelper.RetryOnTimedOut(() => user.Guild.GetTextChannel(serverLogChannel.GetChannelId()));
+            if (textChannel == null) return; // just return, since it might've been deleted
         }
         catch (Exception ex)
         {
             _log.Warn(ex, $"Could not get channel {serverLogChannel.ChannelId} in Guild \"{user.Guild}\" ({user.Guild.Id}) from ServerLogChannel with Id={serverLogChannel.Id}");
             return;
         }
+        
         try
         {
             if (attachments.Count > 0)
@@ -209,6 +251,7 @@ public class RolePreserveLogService
         return kind switch
         {
             RolePreserveLogKind.Failure => GenerateAttachmentsForFail(embed, auditModel),
+            RolePreserveLogKind.Success => GenerateAttachmentsForSuccess(embed, auditModel),
             _ => throw new NotImplementedException($"For {nameof(RolePreserveLogKind)}={kind}")
         };
     }
@@ -219,6 +262,9 @@ public class RolePreserveLogService
     {
         const string failFilename = "roles-failure.txt";
         var attachments = new List<FileAttachment>();
+        var count = auditModel.AppliedRoles.Count(e => e.IsActionFailure());
+        if (count < 1) return [];
+        
         var content = GenerateFailureEmbedContent(auditModel);
         if (content.HasNoValue)
         {
@@ -228,30 +274,105 @@ public class RolePreserveLogService
                 "List of all the roles that Xenia failed to give to a user."));
         }
 
-        var text = $"{Emotes.Warning} Unknown error, no attachments generated and no content generated!";
         if (content.HasValue)
         {
             embed.AddField("Failed Roles", content.Value);
         }
         else if (attachments.Count > 0)
         {
-            text = $"{Emotes.Warning} Too many roles for an embed! It has been attached as {failFilename}";
+            var text = $"{Emotes.Warning} Too many roles for an embed! It has been attached as {failFilename}";
             GetAuditEventUrl(auditModel)
                 .Tap(url =>
                 {
                     text += $"\n-# [View audit log entry]({url}).";
                 });
+            embed.AddField("Failed Roles", text);
         }
 
-        embed.AddField("Failed Roles", text);
         return attachments;
+    }
+
+    private List<FileAttachment> GenerateAttachmentsForSuccess(
+        EmbedBuilder embed,
+        RolePreserveAuditModel auditModel)
+    {
+        const string filenameSuccess = "roles-success.txt";
+        const string filenameSkip = "roles-skip.txt";
+        var attachments = new List<FileAttachment>();
+        var countSuccess = auditModel.AppliedRoles.Count(e => e.IsActionSuccess());
+        var countSkip = auditModel.AppliedRoles.Count(e => e.IsActionSkip());
+        if (countSuccess < 1 && countSkip < 1) return [];
+        
+        var contentSuccess = GenerateRoleListEmbedContent(auditModel, static e => e.IsActionSuccess());
+        var contentSkip = GenerateRoleListEmbedContent(auditModel, static e => e.IsActionSkip());
+        if (countSuccess > 0 && contentSuccess.HasNoValue)
+        {
+            attachments.Add(new FileAttachment(
+                GenerateRoleListAttachmentContent(auditModel, static e => e.IsActionSuccess()).ToMemoryStream(Encoding.UTF8),
+                filenameSuccess,
+                "List of all the roles that Xenia successfully gave to a user."));
+        }
+        if (countSkip > 0 && contentSkip.HasNoValue)
+        {
+            attachments.Add(new FileAttachment(
+                GenerateRoleListAttachmentContent(auditModel, static e => e.IsActionSkip()).ToMemoryStream(Encoding.UTF8),
+                filenameSkip,
+                "List of all the roles that Xenia skipped."));
+        }
+
+        AddEmbedFieldForRoleListing(
+            auditModel, embed,
+            "Roles Added",
+            filenameSuccess,
+            contentSuccess,
+            countSuccess);
+        AddEmbedFieldForRoleListing(
+            auditModel, embed,
+            "Roles Skipped",
+            filenameSkip,
+            contentSkip,
+            countSkip);
+        return attachments;
+    }
+
+    private void AddEmbedFieldForRoleListing(
+        RolePreserveAuditModel auditModel,
+        EmbedBuilder embed,
+        string title,
+        string filename,
+        Maybe<string> content,
+        int count)
+    {
+        if (content.HasValue)
+        {
+            embed.AddField(title, content.Value);
+        }
+        else if (count > 0)
+        {
+            var text = $"{Emotes.Warning} Too many roles for an embed! It has been attached as `{filename}`";
+            GetAuditEventUrl(auditModel)
+                .Tap(url =>
+                {
+                    text += $"\n-# [View audit log entry]({url}).";
+                });
+            embed.AddField(title, text);
+        }
     }
 
     private static string GenerateFailureAttachmentContent(
         RolePreserveAuditModel auditModel)
     {
+        return GenerateRoleListAttachmentContent(
+            auditModel,
+            static e => e.IsActionFailure());
+    }
+
+    private static string GenerateRoleListAttachmentContent(
+        RolePreserveAuditModel auditModel,
+        Func<RolePreserveAuditAppliedRoleModel, bool> predicate)
+    {
         var sb = new StringBuilder();
-        foreach (var item in auditModel.AppliedRoles.Where(e => e.IsActionFailure()))
+        foreach (var item in auditModel.AppliedRoles.Where(predicate))
         {
             sb.Append(item.RoleId);
             if (!string.IsNullOrEmpty(item.Role?.Name))
@@ -264,11 +385,20 @@ public class RolePreserveLogService
         return sb.ToString();
     }
 
+    private static Maybe<string> GenerateFailureEmbedContent(
+        RolePreserveAuditModel auditModel)
+    {
+        return GenerateRoleListEmbedContent(
+            auditModel,
+            static e => e.IsActionFailure());
+    }
+
     /// <returns>
     /// <see cref="Maybe.None"/> if the roles should be attached instead of an embed field.
     /// </returns>
-    private static Maybe<string> GenerateFailureEmbedContent(
-        RolePreserveAuditModel auditModel)
+    private static Maybe<string> GenerateRoleListEmbedContent(
+        RolePreserveAuditModel auditModel,
+        Func<RolePreserveAuditAppliedRoleModel, bool> predicate)
     {
         /* determined with the following code:
         const int max = 1024;
@@ -277,10 +407,10 @@ public class RolePreserveLogService
          */
         const int maxCountSafe = 37;
         var items = auditModel.AppliedRoles
-            .Where(e => e.IsActionFailure())
+            .Where(predicate)
             .ToArray();
         var count = items.Length;
-        if (count > maxCountSafe) return Maybe.None;
+        if (count is > maxCountSafe or < 1) return Maybe.None;
 
         var sb = new StringBuilder();
         for (var i = 0; i < count; i++)

--- a/XeniaDiscord.Common/Services/RolePreserveLogService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveLogService.cs
@@ -1,0 +1,376 @@
+﻿using System.Text;
+using CSharpFunctionalExtensions;
+using Discord;
+using Discord.WebSocket;
+using Humanizer;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using XeniaBot.Shared;
+using XeniaBot.Shared.Helpers;
+using XeniaBot.Shared.Services;
+using XeniaDiscord.Data.Models.RolePreserve;
+using XeniaDiscord.Data.Models.ServerLog;
+using XeniaDiscord.Data.Repositories;
+
+namespace XeniaDiscord.Common.Services;
+
+public class RolePreserveLogService
+{
+    private readonly Logger _log = LogManager.GetCurrentClassLogger();
+    private readonly ErrorReportService _err;
+    private readonly ServerLogRepository _serverLogRepo;
+    private readonly ConfigData _config;
+    
+    public RolePreserveLogService(IServiceProvider services)
+    {
+        _err = services.GetRequiredService<ErrorReportService>();
+        _serverLogRepo = services.GetRequiredService<ServerLogRepository>();
+        _config = services.GetRequiredService<ConfigData>();
+    }
+
+    public async Task SendAuditNotification(
+        SocketGuildUser user,
+        RolePreserveAuditModel auditModel)
+    {
+        if (auditModel.AppliedRoles.Any(e => e.IsActionFailure()))
+        {
+            await SendFailureNotification(user, auditModel);
+        }
+    }
+    
+    public async Task SendFailureNotification(
+        SocketGuildUser user,
+        RolePreserveAuditModel auditModel)
+    {
+        // don't run method if there are no failures
+        if (auditModel.AppliedRoles.All(e => e.IsActionSuccess() || e.IsActionSkip()))
+            return;
+
+        var targetLogChannels = await GetLogChannelsFor(RolePreserveLogKind.Failure, user);
+        if (targetLogChannels.Count < 1) return;
+
+        var successCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSuccess());
+        var skipCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSkip());
+        var failCountValue = auditModel.AppliedRoles.Count(e => e.IsActionFailure());
+        if (skipCountValue < 1 && failCountValue < 1) return;
+
+        var embed = new EmbedBuilder()
+            .WithDescription(FormatDescriptionText(auditModel))
+            .WithTitle("Role Preserve - Failure - " + user.Username)
+            .WithFooter($"User Id: {user.Id}")
+            .WithColor(new Color(255, 255, 255))
+            .WithCurrentTimestamp();
+        if (_config.HasDashboard)
+        {
+            embed.WithUrl($"{_config.DashboardUrl}/RolePreserve/Audit/Details?Id={auditModel.Id}");
+        }
+
+        NotificationGetDescription(embed, auditModel);
+        var attachments = GenerateAttachments(embed, RolePreserveLogKind.Failure, auditModel);
+        
+        _log.Info($"Audit ID={auditModel.Id}, Guild ID={user.Guild.Id}, User ID={user.Id}, Username={user.Username} (log channels: {targetLogChannels.Count}, success: {successCountValue}, skip: {skipCountValue}, fail: {failCountValue})");
+        
+        foreach (var serverLogChannel in targetLogChannels)
+        {
+            await SendNotificationToChannel(user, embed, attachments, serverLogChannel);
+        }
+    }
+
+    private async Task SendNotificationToChannel(
+        SocketGuildUser user,
+        EmbedBuilder embed,
+        List<FileAttachment> attachments,
+        ServerLogChannelModel serverLogChannel)
+    {
+        SocketTextChannel? textChannel;
+        try
+        {
+            textChannel = ExceptionHelper.RetryOnTimedOut(() => user.Guild.GetTextChannel(serverLogChannel.GetChannelId()))
+                          ?? throw new InvalidOperationException($"Channel {serverLogChannel.ChannelId} does not exist (GetTextChannel returned null)");
+        }
+        catch (Exception ex)
+        {
+            _log.Warn(ex, $"Could not get channel {serverLogChannel.ChannelId} in Guild \"{user.Guild}\" ({user.Guild.Id}) from ServerLogChannel with Id={serverLogChannel.Id}");
+            return;
+        }
+        try
+        {
+            if (attachments.Count > 0)
+            {
+                await ExceptionHelper.RetryOnTimedOut(async () => await textChannel.SendFilesAsync(attachments, embed: embed.Build()));
+            }
+            else
+            {
+                await ExceptionHelper.RetryOnTimedOut(async () => await textChannel.SendMessageAsync(embed: embed.Build()));
+            }
+        }
+        catch (Exception ex)
+        {
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes($"Failed to send message in channel \"{textChannel.Name}\" ({textChannel.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id}) for user \"{user.Username}#{user.Discriminator}\" ({user.Id})")
+                .WithUser(user)
+                .WithGuild(user.Guild)
+                .WithChannel(textChannel)
+                .AddSerializedAttachment("serverLogChannel.json", serverLogChannel));
+        }
+    }
+
+    private static string FormatDescriptionText(RolePreserveAuditModel auditModel)
+    {
+        const string defaultResult = "No actions applied.";
+        var successCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSuccess());
+        var skipCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSkip());
+        var failCountValue = auditModel.AppliedRoles.Count(e => e.IsActionFailure());
+        if (skipCountValue < 1 && failCountValue < 1) return defaultResult;
+        
+        var descriptionText = new List<string>(3);
+        if (successCountValue > 0)
+            descriptionText.Add("successfully added " + "role".ToQuantity(successCountValue, "N0"));
+        if (skipCountValue > 0)
+            descriptionText.Add("skipped " + "role".ToQuantity(skipCountValue, "N0"));
+        if (failCountValue > 0)
+            descriptionText.Add("failed to add " + "role".ToQuantity(failCountValue, "N0"));
+        
+        var count = descriptionText.Count;
+        
+        if (count < 1) return defaultResult;
+        
+        // make sure first char in first string is uppercase.
+        var fx = descriptionText[0].ToCharArray();
+        fx[0] = char.ToUpper(fx[0]);
+        descriptionText[0] = new string(fx);
+
+        switch (count)
+        {
+            case 1:
+                return descriptionText[0] + ".";
+            case 2:
+                return descriptionText[0] + " and " + descriptionText[1] + ".";
+            default:
+            {
+                var others = string.Join(", ", descriptionText.Take(count - 1));
+                return others + ", and " + descriptionText.Last() + ".";
+            }
+        }
+    }
+    
+    private static void NotificationGetDescription(
+        EmbedBuilder embed,
+        RolePreserveAuditModel auditModel)
+    {
+        var successCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSuccess());
+        var skipCountValue = auditModel.AppliedRoles.Count(e => e.IsActionSkip());
+        var failCountValue = auditModel.AppliedRoles.Count(e => e.IsActionFailure());
+
+        var sb = new StringBuilder();
+        if (successCountValue > 0 && failCountValue == 0)
+        {
+            sb.Append("- ");
+            sb.Append(Emotes.Tada);
+            sb.Append("Successfully granted ");
+            sb.Append("role".ToQuantity(successCountValue));
+            sb.Append(" to user.");
+        }
+        else if (successCountValue > 0 && failCountValue > 0)
+        {
+            sb.Append("- ");
+            sb.Append(Emotes.Warning);
+            sb.Append(" Successfully granted user");
+            sb.Append("role".ToQuantity(successCountValue));
+            sb.Append(", but failed to grant them");
+            sb.Append("role".ToQuantity(failCountValue));
+            sb.Append('.');
+        }
+        else if (failCountValue > 0)
+        {
+            sb.Append("- ");
+            sb.Append(Emotes.Warning);
+            sb.Append(" Failed to give user *any* roles. ");
+            sb.AppendFormat("({0})", "failure".ToQuantity(failCountValue));
+        }
+
+        if (sb.Length > 0 && skipCountValue > 0)
+        {
+            sb.Append('\n');
+            sb.Append("-# Skipped ");
+            sb.Append("role".ToQuantity(skipCountValue));
+        }
+
+        if (sb.Length > 0) embed.WithDescription(sb.ToString());
+    }
+
+    #region Send Notification - Generate Success/Failure Info
+    private List<FileAttachment> GenerateAttachments(
+        EmbedBuilder embed,
+        RolePreserveLogKind kind,
+        RolePreserveAuditModel auditModel)
+    {
+        return kind switch
+        {
+            RolePreserveLogKind.Failure => GenerateAttachmentsForFail(embed, auditModel),
+            _ => throw new NotImplementedException($"For {nameof(RolePreserveLogKind)}={kind}")
+        };
+    }
+
+    private List<FileAttachment> GenerateAttachmentsForFail(
+        EmbedBuilder embed,
+        RolePreserveAuditModel auditModel)
+    {
+        const string failFilename = "roles-failure.txt";
+        var attachments = new List<FileAttachment>();
+        var content = GenerateFailureEmbedContent(auditModel);
+        if (content.HasNoValue)
+        {
+            attachments.Add(new FileAttachment(
+                GenerateFailureAttachmentContent(auditModel).ToMemoryStream(Encoding.UTF8),
+                failFilename,
+                "List of all the roles that Xenia failed to give to a user."));
+        }
+
+        var text = $"{Emotes.Warning} Unknown error, no attachments generated and no content generated!";
+        if (content.HasValue)
+        {
+            embed.AddField("Failed Roles", content.Value);
+        }
+        else if (attachments.Count > 0)
+        {
+            text = $"{Emotes.Warning} Too many roles for an embed! It has been attached as {failFilename}";
+            GetAuditEventUrl(auditModel)
+                .Tap(url =>
+                {
+                    text += $"\n-# [View audit log entry]({url}).";
+                });
+        }
+
+        embed.AddField("Failed Roles", text);
+        return attachments;
+    }
+
+    private static string GenerateFailureAttachmentContent(
+        RolePreserveAuditModel auditModel)
+    {
+        var sb = new StringBuilder();
+        foreach (var item in auditModel.AppliedRoles.Where(e => e.IsActionFailure()))
+        {
+            sb.Append(item.RoleId);
+            if (!string.IsNullOrEmpty(item.Role?.Name))
+            {
+                sb.Append(" - ");
+                sb.Append(item.Role.Name);
+            }
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    /// <returns>
+    /// <see cref="Maybe.None"/> if the roles should be attached instead of an embed field.
+    /// </returns>
+    private static Maybe<string> GenerateFailureEmbedContent(
+        RolePreserveAuditModel auditModel)
+    {
+        /* determined with the following code:
+        const int max = 1024;
+        int lineSize = string.Format("- <@&{0}>\n", ulong.MaxValue).Length; // expected to be 26
+        int iterCount = Convert.ToInt32(Math.Floor(max / (float)(lineSize)));
+         */
+        const int maxCountSafe = 37;
+        var items = auditModel.AppliedRoles
+            .Where(e => e.IsActionFailure())
+            .ToArray();
+        var count = items.Length;
+        if (count > maxCountSafe) return Maybe.None;
+
+        var sb = new StringBuilder();
+        for (var i = 0; i < count; i++)
+        {
+            var item = items.ElementAt(i);
+            sb.Append("- <@&");
+            sb.Append(item.RoleId);
+            sb.Append('>');
+            if (i < count - 1)
+            {
+                sb.AppendLine();
+            }
+        }
+        // added just to be safe
+        if (sb.Length >= 1024) return Maybe.None;
+        return sb.ToString();
+    }
+    #endregion
+
+    public Maybe<string> GetAuditEventUrl(RolePreserveAuditModel auditModel)
+    {
+        if (!_config.HasDashboard) return Maybe.None;
+        return $"{_config.DashboardUrl}/RolePreserve/Audit/Details?Id={auditModel.Id}";
+    }
+    
+    #region Get Log Channels
+    public async Task<IReadOnlyCollection<ServerLogChannelModel>> GetLogChannelsFor(
+        RolePreserveLogKind kind,
+        ulong guildId)
+    {
+        try
+        {
+            return await GetLogChannelsForInternal(kind, guildId);
+        }
+        catch (Exception ex)
+        {
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes($"Failed to get Server Log Channel models with event {ServerLogEvent.MemberJoin} or {ServerLogEvent.RolePreserve} for Guild  {guildId}"));
+            return [];
+        }
+    }
+    public async Task<IReadOnlyCollection<ServerLogChannelModel>> GetLogChannelsFor(
+        RolePreserveLogKind kind,
+        SocketGuildUser user)
+    {
+        try
+        {
+            return await GetLogChannelsForInternal(kind, user.Guild.Id);
+        }
+        catch (Exception ex)
+        {
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes($"Failed to get Server Log Channel models with event {ServerLogEvent.MemberJoin} or {ServerLogEvent.RolePreserve} for Guild \"{user.Guild.Name}\" ({user.Guild.Id})")
+                .WithUser(user)
+                .WithGuild(user.Guild));
+            return [];
+        }
+    }
+
+    private async Task<IReadOnlyCollection<ServerLogChannelModel>> GetLogChannelsForInternal(
+        RolePreserveLogKind kind,
+        ulong guildId)
+    {
+        var targets = await _serverLogRepo.GetChannelsForGuild(
+            guildId,
+            [ServerLogEvent.RolePreserve],
+            new()
+            {
+                IgnoreDisabledGuilds = true
+            });
+        if (kind == RolePreserveLogKind.Failure && targets.Count < 1)
+        {
+            targets = await _serverLogRepo.GetChannelsForGuild(
+                guildId,
+                [ServerLogEvent.MemberJoin],
+                new()
+                {
+                    IgnoreDisabledGuilds = true
+                });
+        }
+
+        return targets;
+    }
+    #endregion
+}
+
+public enum RolePreserveLogKind
+{
+    Success,
+    Failure
+}

--- a/XeniaDiscord.Common/Services/RolePreserveLogService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveLogService.cs
@@ -60,7 +60,7 @@ public class RolePreserveLogService
             .WithDescription(FormatDescriptionText(auditModel))
             .WithTitle("Role Preserve - Failure - " + user.Username)
             .WithFooter($"User Id: {user.Id}")
-            .WithColor(new Color(255, 255, 255))
+            .WithColor(Color.DarkRed)
             .WithCurrentTimestamp();
         if (_config.HasDashboard)
         {
@@ -94,7 +94,7 @@ public class RolePreserveLogService
             .WithDescription(FormatDescriptionText(auditModel))
             .WithTitle("Role Preserve - Success - " + user.Username)
             .WithFooter($"User Id: {user.Id}")
-            .WithColor(new Color(255, 255, 255))
+            .WithColor(Color.Blue)
             .WithCurrentTimestamp();
         if (_config.HasDashboard)
         {

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -4,19 +4,14 @@ using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
-using System.Collections.Frozen;
-using System.Text;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Helpers;
 using XeniaBot.Shared.Services;
 using XeniaDiscord.Data;
 using XeniaDiscord.Data.Models.RolePreserve;
-using XeniaDiscord.Data.Models.ServerLog;
 using XeniaDiscord.Data.Models.Snapshot;
 using XeniaDiscord.Data.Repositories;
 using RolePreserveGuildRepository = XeniaDiscord.Data.Repositories.RolePreserveGuildRepository;
-using ServerLogEvent = XeniaDiscord.Data.Models.ServerLog.ServerLogEvent;
-using ServerLogRepository = XeniaDiscord.Data.Repositories.ServerLogRepository;
 
 namespace XeniaDiscord.Common.Services;
 
@@ -27,9 +22,9 @@ public class RolePreserveService : BaseService
     private readonly XeniaDbContext _db;
     private readonly ErrorReportService _err;
     private readonly DiscordSocketClient _client;
-    private readonly ServerLogRepository _serverLogRepo;
     private readonly RolePreserveUserRepository _userRepository;
     private readonly RolePreserveGuildRepository _guildRepository;
+    private readonly RolePreserveLogService _rolePreserveLogService;
     private readonly ConfigData _configData;
     private readonly ProgramDetails _details;
 
@@ -39,12 +34,12 @@ public class RolePreserveService : BaseService
         _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
         _err = services.GetRequiredService<ErrorReportService>();
         _client = services.GetRequiredService<DiscordSocketClient>();
-        _serverLogRepo = services.GetRequiredService<ServerLogRepository>();
         _configData = services.GetRequiredService<ConfigData>();
         _details = services.GetRequiredService<ProgramDetails>();
         _userRepository = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveUserRepository>();
         _guildRepository = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveGuildRepository>();
         var snapshotService = (scope?.ServiceProvider ?? services).GetRequiredService<DiscordSnapshotService>();
+        _rolePreserveLogService = services.GetRequiredService<RolePreserveLogService>();
         
         if (_details.Platform == XeniaPlatform.Bot)
         {
@@ -151,6 +146,7 @@ public class RolePreserveService : BaseService
     {
         await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
+        var auditId = Guid.NewGuid();
         try
         {
             if (!await _guildRepository.IsEnabled(db, user.Guild.Id))
@@ -173,13 +169,12 @@ public class RolePreserveService : BaseService
 
             var audit = new RolePreserveAuditModel()
             {
+                Id = auditId,
                 GuildId = user.Guild.Id.ToString(),
                 TargetUserId = user.Id.ToString(),
                 Action = RolePreserveAuditAction.AppliedRoles
             };
             
-            var success = new List<ulong>();
-            var fail = new List<ApplyFailure>();
             foreach (var item in roleIds)
             {
                 var roleId = item;
@@ -196,10 +191,6 @@ public class RolePreserveService : BaseService
                 }
                 try
                 {
-                    var snapshot = await db.GuildRoleSnapshots
-                        .AsNoTracking()
-                        .OrderByDescending(e => e.RecordCreatedAt)
-                        .FirstOrDefaultAsync(e => e.RoleId == roleId.ToString());
                     var existingRole = await ExceptionHelper.RetryOnTimedOut(async () => await user.Guild.GetRoleAsync(roleId));
                     // continue, since the role doesn't exist anymore
                     if (existingRole == null)
@@ -220,11 +211,12 @@ public class RolePreserveService : BaseService
                             RoleId = item.ToString(),
                             Action = RolePreserveAuditAppliedRoleAction.FailureMissingPermissionsHierarchy
                         });
-                        fail.Add(new (item, snapshot));
                         continue;
                     }
-                    await user.AddRoleAsync(roleId);
-                    success.Add(roleId);
+                    await user.AddRoleAsync(roleId, new RequestOptions
+                    {
+                        AuditLogReason = $"Role Preserve (Audit ID: {audit.Id})"
+                    });
                     audit.AppliedRoles.Add(new RolePreserveAuditAppliedRoleModel()
                     {
                         RolePreserveAuditId = audit.Id,
@@ -235,7 +227,6 @@ public class RolePreserveService : BaseService
                 catch (Exception ex)
                 {
                     _log.Warn(ex, $"Failed to grant Role {item} to User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})");
-                    fail.Add(new(item, null));
                     audit.AppliedRoles.Add(new RolePreserveAuditAppliedRoleModel()
                     {
                         RolePreserveAuditId = audit.Id,
@@ -246,21 +237,13 @@ public class RolePreserveService : BaseService
                 }
             }
 
-            _log.Trace($"Operation complete (userId={user.Id}, username={user.Username}, success={success.Count}, fail={fail.Count})");
-            if (success.Count < 1)
+            var failCount = audit.AppliedRoles.Count(e => e.IsActionFailure());
+            var successCount = audit.AppliedRoles.Count(e => e.IsActionSuccess());
+            
+            _log.Trace($"Operation complete (userId={user.Id}, username={user.Username}, success={successCount}, fail={failCount})");
+            if (successCount < 1)
             {
                 _log.Trace($"No roles were restored? (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
-            }
-            if (fail.Count > 0)
-            {
-                try
-                {
-                    await SendFailureNotification(user, success.ToFrozenSet(), fail);
-                }
-                catch (Exception ex)
-                {
-                    _log.Error(ex, $"Failed to send failure notification for User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})");
-                }
             }
 
             await db.AddAsync(audit);
@@ -278,220 +261,30 @@ public class RolePreserveService : BaseService
                 .WithUser(user)
                 .WithGuild(user.Guild));
         }
-    }
-    private sealed record ApplyFailure(ulong RoleId, GuildRoleSnapshotModel? Snapshot);
-    
-    #region Send Failure Notification
-    private async Task SendFailureNotification(
-        SocketGuildUser user,
-        IReadOnlyCollection<ulong> success,
-        IReadOnlyCollection<ApplyFailure> fail,
-        RolePreserveAuditModel? auditModel = null)
-    {
-        if (fail.Count < 1) return;
-        
-        var maybeLogChannels = await GetChannelsForFailureNotification(user);
-        if (maybeLogChannels.HasNoValue) return;
-        var targetLogChannels = maybeLogChannels.Value;
-        
-        var successCount = success.Count.ToString("n0");
-        var successPlural = success.Count == 1 ? "" : "s";
-        var embed = new EmbedBuilder()
-            .WithDescription($"Added {successCount} role{successPlural} successfully.")
-            .WithTitle("Role Preserve - User Joined - " + user.Username)
-            .WithFooter($"User Id: {user.Id}")
-            .WithColor(new Color(255, 255, 255))
-            .WithCurrentTimestamp();
-        if (auditModel != null && _configData.HasDashboard)
-        {
-            embed.WithUrl($"{_configData.DashboardUrl}/RolePreserve/Audit/Details?Id={auditModel.Id}");
-        }
 
-        // TODO generate success/fail data from RolePreserveAuditModel
-        FailureNotificationGetFailContent(embed, success, fail);
-
-        const string failFilename = "roles.txt";
-        var attachments = new List<FileAttachment>();
-        var failureFieldContent = GetFailEmbedContent(fail)
-            .TapError(err =>
-            {
-                if (err != GetFailEmbedContentError.AttachFailures) return;
-                var failAttachmentContent = GetFailAttachment(fail);
-                attachments.Add(new FileAttachment(new MemoryStream(Encoding.UTF8.GetBytes(failAttachmentContent)), failFilename));
-            })
-            .Finally(r =>
-            {
-                var sb = new StringBuilder();
-                if (r.IsFailure)
-                {
-                    switch (r.Error)
-                    {
-                        case GetFailEmbedContentError.AttachFailures:
-                            sb.Append(Emotes.Warning);
-                            sb.AppendFormat(" Too many roles failed! It's been attached as `{0}`", failFilename);
-                            break;
-                        default:
-                            sb.Append(Emotes.Warning);
-                            sb.Append(" Unknown error: ");
-                            sb.Append(r.Error);
-                            break;
-                    }
-                }
-                else
-                {
-                    sb.Append(r.Value);
-                }
-                
-                return sb.ToString();
-            });
-        embed.AddField("Failed Roles", failureFieldContent);
-        foreach (var serverLogChannel in targetLogChannels)
-        {
-            await SendFailureNotificationToChannel(user, embed, attachments, serverLogChannel);
-        }
-    }
-    private async Task<Maybe<IReadOnlyCollection<ServerLogChannelModel>>> GetChannelsForFailureNotification(
-        SocketGuildUser user)
-    {
-        IReadOnlyCollection<ServerLogChannelModel> targetLogChannels;
+        RolePreserveAuditModel? tmpAuditModel = null;
         try
         {
-            targetLogChannels = await _serverLogRepo.GetChannelsForGuild(
-                user.Guild.Id,
-                [ServerLogEvent.RolePreserve],
-                new()
-                {
-                    IgnoreDisabledGuilds = true
-                });
-            if (targetLogChannels.Count < 1)
-            {
-                targetLogChannels = await _serverLogRepo.GetChannelsForGuild(
-                    user.Guild.Id,
-                    [ServerLogEvent.MemberJoin],
-                    new()
-                    {
-                        IgnoreDisabledGuilds = true
-                    });
-            }
-            if (targetLogChannels.Count < 1)
-                return Maybe.None;
-            return Maybe<IReadOnlyCollection<ServerLogChannelModel>>.From(targetLogChannels);
+            tmpAuditModel = await db.RolePreserveAudit
+                .AsNoTracking()
+                .Include(e => e.AppliedRoles)
+                .ThenInclude(e => e.Role)
+                .Include(e => e.ReferencedRoles)
+                .ThenInclude(e => e.Role)
+                .FirstAsync(e => e.Id == auditId);
+            await _rolePreserveLogService.SendAuditNotification(user, tmpAuditModel);
         }
         catch (Exception ex)
         {
-            await _err.Submit(new ErrorReportBuilder()
-                .WithException(ex)
-                .WithNotes($"Failed to get Server Log Channel models with event {ServerLogEvent.MemberJoin} or {ServerLogEvent.RolePreserve} for Guild \"{user.Guild.Name}\" ({user.Guild.Id})")
-                .WithUser(user)
-                .WithGuild(user.Guild));
-            return Maybe.None;
+            var msg = $"Failed to send failure notification for RolePreserveAudit.ID={auditId} for User \"{user.Username}#{user.Discriminator}\" in Guild \"{user.Guild.Name}\" (userId: {user.Id}, guildId: {user.Guild.Id})";
+            _log.Error(ex, msg);
+            await _err.Submit(
+                new ErrorReportBuilder()
+                    .WithException(ex)
+                    .WithNotes(msg)
+                    .AddSerializedAttachment("rolePreserveAudit.json", tmpAuditModel));
         }
     }
-    private static void FailureNotificationGetFailContent(
-        EmbedBuilder embed,
-        IReadOnlyCollection<ulong> success,
-        IReadOnlyCollection<ApplyFailure> fail)
-    {
-        var failCount = fail.Count.ToString("n0");
-        if (success.Count == 0)
-        {
-            embed.WithDescription($"- {Emotes.Warning} Failed to give user *any* roles");
-            if (fail.Count > 0)
-            {
-                embed.Description += $" ({failCount})";
-            }
-        }
-        else if (fail.Count > 0)
-        {
-            var failPlural = fail.Count == 1 ? "" : "s";
-            if (fail.Count > 0) embed.Description += $"\n- Failed to add {failCount} role{failPlural}.";
-        }
-    }
-    private enum GetFailEmbedContentError
-    {
-        AttachFailures
-    }
-    private static Result<string, GetFailEmbedContentError> GetFailEmbedContent(
-        IReadOnlyCollection<ApplyFailure> items)
-    {
-        /* determined with the following code:
-        const int max = 1024;
-        int lineSize = string.Format("- <@&{0}>\n", ulong.MaxValue).Length; // expected to be 26
-        int iterCount = Convert.ToInt32(Math.Floor(max / (float)(lineSize)));
-         */
-        const int maxCountSafe = 37;
-        if (items.Count > maxCountSafe) return GetFailEmbedContentError.AttachFailures;
-
-        var sb = new StringBuilder();
-        var count = items.Count;
-        for (var i = 0; i < count; i++)
-        {
-            var item = items.ElementAt(i);
-            sb.Append("- <@&");
-            sb.Append(item.RoleId);
-            sb.Append('>');
-            if (i < count - 1)
-            {
-                sb.AppendLine();
-            }
-        }
-        // added just to be safe
-        if (sb.Length >= 1024) return GetFailEmbedContentError.AttachFailures;
-        return sb.ToString();
-    }
-    private static string GetFailAttachment(
-        IReadOnlyCollection<ApplyFailure> items)
-    {
-        var sb = new StringBuilder();
-        foreach (var item in items)
-        {
-            sb.Append(item.RoleId);
-            sb.Append(" - ");
-            sb.Append(item.Snapshot?.Name);
-            sb.AppendLine();
-        }
-        return sb.ToString();
-    }
-    private async Task SendFailureNotificationToChannel(
-        SocketGuildUser user,
-        EmbedBuilder embed,
-        List<FileAttachment> attachments,
-        ServerLogChannelModel serverLogChannel)
-    {
-        SocketTextChannel? textChannel;
-        try
-        {
-            textChannel = ExceptionHelper.RetryOnTimedOut(() => user.Guild.GetTextChannel(serverLogChannel.GetChannelId()))
-                          ?? throw new InvalidOperationException($"Channel {serverLogChannel.ChannelId} does not exist (GetTextChannel returned null)");
-        }
-        catch (Exception ex)
-        {
-            _log.Warn(ex, $"Could not get channel {serverLogChannel.ChannelId} in Guild \"{user.Guild}\" ({user.Guild.Id}) from ServerLogChannel with Id={serverLogChannel.Id}");
-            return;
-        }
-        try
-        {
-            if (attachments.Count > 0)
-            {
-                await ExceptionHelper.RetryOnTimedOut(async () => await textChannel.SendFilesAsync(attachments, embed: embed.Build()));
-            }
-            else
-            {
-                await ExceptionHelper.RetryOnTimedOut(async () => await textChannel.SendMessageAsync(embed: embed.Build()));
-            }
-        }
-        catch (Exception ex)
-        {
-            await _err.Submit(new ErrorReportBuilder()
-                .WithException(ex)
-                .WithNotes($"Failed to send message in channel \"{textChannel.Name}\" ({textChannel.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id}) for user \"{user.Username}#{user.Discriminator}\" ({user.Id})")
-                .WithUser(user)
-                .WithGuild(user.Guild)
-                .WithChannel(textChannel)
-                .AddSerializedAttachment("serverLogChannel.json", serverLogChannel));
-        }
-    }
-    #endregion
 
     public override Task OnReadyDelay()
     {

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -407,18 +407,22 @@ public class RolePreserveService : BaseService
             _log.Info($"Not going to run {nameof(PreserveAll)} since {nameof(_configData.RefreshRolePreserveOnStart)} is set to false");
             return Task.CompletedTask;
         }
-        new Thread((ThreadStart)delegate
+        new Thread(PreserveAllThread)
         {
-            try
-            {
-                PreserveAll().GetAwaiter().GetResult();
-            }
-            catch (Exception ex)
-            {
-                _log.Error(ex, $"Failed to run {nameof(PreserveAll)}");
-            }
-        }).Start();
+            Name = $"{nameof(RolePreserveService)}.{nameof(PreserveAllThread)}"
+        }.Start();
         return Task.CompletedTask;
+    }
+    private void PreserveAllThread()
+    {
+        try
+        {
+            PreserveAll().GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, $"Failed to run {nameof(PreserveAll)}");
+        }
     }
 
     public async Task PreserveAll(DateTime? startedAt = null)

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using CSharpFunctionalExtensions;
 using Discord;
 using Discord.WebSocket;
@@ -69,26 +70,42 @@ public class RolePreserveService : BaseService
             {
                 _log.Error(ex, $"Failed to call {nameof(ClientOnRoleDeletedThread)}");
             }
-        }).Start(role);
+        })
+        {
+            Name = $"{nameof(RolePreserveService)}.{nameof(ClientOnRoleDeletedThread)} (roleId={role.Id})"
+        }.Start(role);
     }
-    private async Task ClientOnRoleDeletedThread(SocketRole role)
+
+    private async Task ClientOnRoleDeletedThread(SocketRole? role)
     {
         if (role == null) return;
 
+        // remove from blacklist & remove from preserved roles
         await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
             var roleIdStr = role.Id.ToString();
-            var count = await db.RolePreserveUserRoles
+
+            var countUsr = await db.RolePreserveUserRoles
                 .AsNoTracking()
                 .Where(e => e.RoleId == roleIdStr)
                 .ExecuteDeleteAsync();
+            var countBlk = await db.RolePreserveBlacklistedRoles
+                .AsNoTracking()
+                .Where(e => e.RoleId == roleIdStr)
+                .ExecuteDeleteAsync();
+            
             await db.SaveChangesAsync();
             await trans.CommitAsync();
-            if (count > 0)
+            
+            if (countUsr > 0)
             {
-                _log.Trace($"Deleted {count} records in {RolePreserveUserRoleModel.TableName} for RoleId={role.Id}");
+                _log.Trace($"Deleted {countUsr} records in {RolePreserveUserRoleModel.TableName} for RoleId={role.Id}");
+            }
+            if (countBlk > 0)
+            {
+                _log.Trace($"Deleted {countBlk} records in {RolePreserveBlacklistedRoleModel.TableName} for RoleId={role.Id}");
             }
         }
         catch (Exception ex)

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Text;
+﻿using System.Text;
 using CSharpFunctionalExtensions;
 using Discord;
 using Discord.WebSocket;
@@ -31,7 +30,6 @@ public class RolePreserveService : BaseService
     private readonly ServerLogRepository _serverLogConfig;
     private readonly RolePreserveUserRepository _userRepository;
     private readonly RolePreserveGuildRepository _guildRepository;
-    private readonly DiscordSnapshotService _snapshotService;
     private readonly ConfigData _configData;
     private readonly ProgramDetails _details;
 
@@ -46,19 +44,20 @@ public class RolePreserveService : BaseService
         _details = services.GetRequiredService<ProgramDetails>();
         _userRepository = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveUserRepository>();
         _guildRepository = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveGuildRepository>();
-        _snapshotService = (scope?.ServiceProvider ?? services).GetRequiredService<DiscordSnapshotService>();
+        var snapshotService = (scope?.ServiceProvider ?? services).GetRequiredService<DiscordSnapshotService>();
         
         if (_details.Platform == XeniaPlatform.Bot)
         {
             _client.UserJoined += ClientOnUserJoined;
             _client.RoleDeleted += ClientOnRoleDeleted;
-            _snapshotService.GuildMemberUpdated += DiscordSnapshotOnGuildMemberUpdated;
+            snapshotService.GuildMemberUpdated += DiscordSnapshotOnGuildMemberUpdated;
         }
     }
 
-    private async Task ClientOnRoleDeleted(SocketRole role)
+    private Task ClientOnRoleDeleted(
+        SocketRole? role)
     {
-        if (role == null) return;
+        if (role == null) return Task.CompletedTask;
         new Thread((roleArg) =>
         {
             if (roleArg is not SocketRole socketRole) return;
@@ -74,6 +73,7 @@ public class RolePreserveService : BaseService
         {
             Name = $"{nameof(RolePreserveService)}.{nameof(ClientOnRoleDeletedThread)} (roleId={role.Id})"
         }.Start(role);
+        return Task.CompletedTask;
     }
 
     private async Task ClientOnRoleDeletedThread(SocketRole? role)
@@ -143,8 +143,7 @@ public class RolePreserveService : BaseService
         {
             await trans.RollbackAsync();
             _log.Error(ex, $"Failed to handle event for user {model.Username} ({model.UserId}) in guild {model.GuildId}");
-            // TODO error handling
-            throw;
+            // TODO submit to ErrorReportService
         }
     }
 
@@ -471,7 +470,7 @@ public class RolePreserveService : BaseService
             .Select(e => new
             {
                 Key = e.Id,
-                Value = e.Roles.Select(e => e.Id).Distinct().ToArray()
+                Value = e.Roles.Select(r => r.Id).Distinct().ToArray()
             })
             .ToDictionary(e => e.Key, e => e.Value);
         var startValue = start ?? DateTime.UtcNow;

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -265,7 +265,8 @@ public class RolePreserveService : BaseService
                 return;
             }
             var roleIds = await _userRepository.FindRolesForUser(db, user.Guild.Id, user.Id);
-
+            var blacklist = await _guildRepository.GetBlacklistRolesForGuild(db, user.Guild.Id);
+            
             var ourHighestRoleEnumerable = user.Guild.CurrentUser.Roles.OrderByDescending(v => v.Position);
             var ourHighestRolePos = ourHighestRoleEnumerable.FirstOrDefault()?.Position ?? int.MinValue;
 
@@ -275,6 +276,7 @@ public class RolePreserveService : BaseService
             {
                 var roleId = item;
                 if (roleId == user.Guild.EveryoneRole.Id) continue;
+                if (blacklist.Any(e => e.RoleId == item.ToString())) continue;
                 try
                 {
                     var snapshot = await db.GuildRoleSnapshots

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -358,7 +358,7 @@ public class RolePreserveService : BaseService
         {
             targetLogChannels = await _serverLogRepo.GetChannelsForGuild(
                 user.Guild.Id,
-                [ServerLogEvent.RolePerserve],
+                [ServerLogEvent.RolePreserve],
                 new()
                 {
                     IgnoreDisabledGuilds = true
@@ -381,7 +381,7 @@ public class RolePreserveService : BaseService
         {
             await _err.Submit(new ErrorReportBuilder()
                 .WithException(ex)
-                .WithNotes($"Failed to get Server Log Channel models with event {ServerLogEvent.MemberJoin} or {ServerLogEvent.RolePerserve} for Guild \"{user.Guild.Name}\" ({user.Guild.Id})")
+                .WithNotes($"Failed to get Server Log Channel models with event {ServerLogEvent.MemberJoin} or {ServerLogEvent.RolePreserve} for Guild \"{user.Guild.Name}\" ({user.Guild.Id})")
                 .WithUser(user)
                 .WithGuild(user.Guild));
             return Maybe.None;

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Collections.Frozen;
+using System.Text;
 using CSharpFunctionalExtensions;
 using Discord;
 using Discord.WebSocket;
@@ -150,16 +151,19 @@ public class RolePreserveService : BaseService
     private async Task ClientOnUserJoined(SocketGuildUser user)
     {
         await using var db = _db.CreateSession();
+        await using var trans = await db.Database.BeginTransactionAsync();
         try
         {
             if (!await _guildRepository.IsEnabled(db, user.Guild.Id))
             {
                 _log.Trace($"Skipping Role Preserve is disabled (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
+                await trans.RollbackAsync();
                 return;
             }
             if (!await _userRepository.HasAny(db, user.Guild.Id, user.Id))
             {
                 _log.Trace($"Skipping since there are no records in {RolePreserveUserModel.TableName} (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
+                await trans.RollbackAsync();
                 return;
             }
             var roleIds = await _userRepository.FindRolesForUser(db, user.Guild.Id, user.Id);
@@ -168,13 +172,29 @@ public class RolePreserveService : BaseService
             var ourHighestRoleEnumerable = user.Guild.CurrentUser.Roles.OrderByDescending(v => v.Position);
             var ourHighestRolePos = ourHighestRoleEnumerable.FirstOrDefault()?.Position ?? int.MinValue;
 
+            var audit = new RolePreserveAuditModel()
+            {
+                GuildId = user.Guild.Id.ToString(),
+                TargetUserId = user.Id.ToString(),
+                Action = RolePreserveAuditAction.AppliedRoles
+            };
+            
             var success = new List<ulong>();
             var fail = new List<ApplyFailure>();
             foreach (var item in roleIds)
             {
                 var roleId = item;
                 if (roleId == user.Guild.EveryoneRole.Id) continue;
-                if (blacklist.Any(e => e.RoleId == item.ToString())) continue;
+                if (blacklist.Any(e => e.RoleId == item.ToString()))
+                {
+                    audit.AppliedRoles.Add(new RolePreserveAuditAppliedRoleModel()
+                    {
+                        RolePreserveAuditId = audit.Id,
+                        RoleId = item.ToString(),
+                        Action = RolePreserveAuditAppliedRoleAction.SkippedBlacklisted
+                    });
+                    continue;
+                }
                 try
                 {
                     var snapshot = await db.GuildRoleSnapshots
@@ -183,19 +203,47 @@ public class RolePreserveService : BaseService
                         .FirstOrDefaultAsync(e => e.RoleId == roleId.ToString());
                     var existingRole = await ExceptionHelper.RetryOnTimedOut(async () => await user.Guild.GetRoleAsync(roleId));
                     // continue, since the role doesn't exist anymore
-                    if (existingRole == null) continue;
+                    if (existingRole == null)
+                    {
+                        audit.AppliedRoles.Add(new RolePreserveAuditAppliedRoleModel()
+                        {
+                            RolePreserveAuditId = audit.Id,
+                            RoleId = item.ToString(),
+                            Action = RolePreserveAuditAppliedRoleAction.SkippedRoleDoesNotExist
+                        });
+                        continue;
+                    }
                     if (existingRole.Position > ourHighestRolePos)
                     {
+                        audit.AppliedRoles.Add(new RolePreserveAuditAppliedRoleModel()
+                        {
+                            RolePreserveAuditId = audit.Id,
+                            RoleId = item.ToString(),
+                            Action = RolePreserveAuditAppliedRoleAction.FailureMissingPermissionsHierarchy
+                        });
                         fail.Add(new (item, snapshot));
                         continue;
                     }
                     await user.AddRoleAsync(roleId);
                     success.Add(roleId);
+                    audit.AppliedRoles.Add(new RolePreserveAuditAppliedRoleModel()
+                    {
+                        RolePreserveAuditId = audit.Id,
+                        RoleId = item.ToString(),
+                        Action = RolePreserveAuditAppliedRoleAction.SuccessGrant
+                    });
                 }
                 catch (Exception ex)
                 {
                     _log.Warn(ex, $"Failed to grant Role {item} to User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})");
                     fail.Add(new(item, null));
+                    audit.AppliedRoles.Add(new RolePreserveAuditAppliedRoleModel()
+                    {
+                        RolePreserveAuditId = audit.Id,
+                        RoleId = item.ToString(),
+                        Action = RolePreserveAuditAppliedRoleAction.FailureUnknown,
+                        ExceptionText = ex.ToString()
+                    });
                 }
             }
 
@@ -206,11 +254,23 @@ public class RolePreserveService : BaseService
             }
             if (fail.Count > 0)
             {
-                await SendFailureNotification(user, success, fail);
+                try
+                {
+                    await SendFailureNotification(user, success.ToFrozenSet(), fail);
+                }
+                catch (Exception ex)
+                {
+                    _log.Error(ex, $"Failed to send failure notification for User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})");
+                }
             }
+
+            await db.AddAsync(audit);
+            await db.SaveChangesAsync();
+            await trans.CommitAsync();
         }
         catch (Exception ex)
         {
+            await trans.RollbackAsync();
             var msg = $"Failed to restore roles for User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})";
             _log.Error(ex, msg);
             await _err.Submit(new ErrorReportBuilder()
@@ -257,6 +317,10 @@ public class RolePreserveService : BaseService
             .WithFooter($"User Id: {user.Id}")
             .WithColor(new Color(255, 255, 255))
             .WithCurrentTimestamp();
+        if (auditModel != null && _configData.HasDashboard)
+        {
+            embed.WithUrl($"{_configData.DashboardUrl}/RolePreserve/Audit/Details?Id={auditModel.Id}");
+        }
         var failCount = fail.Count.ToString("n0");
         if (success.Count == 0)
         {

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -196,28 +196,104 @@ public class RolePreserveService : BaseService
             if (fail.Count > 0) embed.Description += $"\n- Failed to add {failCount} role{failPlural}.";
         }
 
-        var failField = string.Join("\n", fail.Select(v => $"- <@&{v.RoleId}>"));
-        var failAttachment = string.Join("\n", fail.Select(v => $"{v.RoleId} - {v.Snapshot?.Name}"));
-
+        const string failFilename = "roles.txt";
         var attachments = new List<FileAttachment>();
-        switch (failField.Length)
-        {
-            case > 1024:
-                attachments.Add(new FileAttachment(new MemoryStream(Encoding.UTF8.GetBytes(failAttachment)), "roles.txt"));
-                embed.AddField("Failed Roles", "Too many roles failed! It's been attached as `roles.txt`");
-                break;
-            case > 0:
-                embed.AddField("Failed Roles", failField);
-                break;
-        }
+        var failAttachmentMessage = new StringBuilder();
+        var failureFieldContent = GetFailEmbedContent(fail)
+            .TapError(err =>
+            {
+                if (err != GetFailEmbedContentError.AttachFailures) return;
+                var failAttachmentContent = GetFailAttachment(fail);
+                attachments.Add(new FileAttachment(new MemoryStream(Encoding.UTF8.GetBytes(failAttachmentContent)), failFilename));
+            })
+            .Finally(r =>
+            {
+                var sb = new StringBuilder();
+                if (r.IsFailure)
+                {
+                    switch (r.Error)
+                    {
+                        case GetFailEmbedContentError.AttachFailures:
+                            sb.Append(Emotes.Warning);
+                            sb.AppendFormat(" Too many roles failed! It's been attached as `{0}`", failFilename);
+                            break;
+                        default:
+                            sb.Append(Emotes.Warning);
+                            sb.Append(" Unknown error: ");
+                            sb.Append(r.Error);
+                            break;
+                    }
+                }
+                else
+                {
+                    sb.Append(r.Value);
+                }
+                
+                return sb.ToString();
+            });
+        embed.AddField("Failed Roles", failureFieldContent);
+        await SendFailureNotificationToChannels(
+            user,
+            embed,
+            attachments,
+            targetLogChannels);
+    }
+    private enum GetFailEmbedContentError
+    {
+        AttachFailures
+    }
+    private static Result<string, GetFailEmbedContentError> GetFailEmbedContent(
+        IReadOnlyCollection<ApplyFailure> items)
+    {
+        /* determined with the following code:
+        const int max = 1024;
+        int lineSize = string.Format("- <@&{0}>\n", ulong.MaxValue).Length; // expected to be 26
+        int iterCount = Convert.ToInt32(Math.Floor(max / (float)(lineSize)));
+         */
+        const int maxCountSafe = 37;
+        if (items.Count > maxCountSafe) return GetFailEmbedContentError.AttachFailures;
 
+        var sb = new StringBuilder();
+        var count = items.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var item = items.ElementAt(i);
+            sb.Append("- <@&");
+            sb.Append(item.RoleId);
+            sb.Append('>');
+            if (i < count - 1)
+            {
+                sb.AppendLine();
+            }
+        }
+        // added just to be safe
+        if (sb.Length >= 1024) return GetFailEmbedContentError.AttachFailures;
+        return sb.ToString();
+    }
+    private static string GetFailAttachment(
+        IReadOnlyCollection<ApplyFailure> items)
+    {
+        var sb = new StringBuilder();
+        foreach (var item in items)
+        {
+            sb.AppendFormat("{0} - {1}", item.RoleId, item.Snapshot?.Name);
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+    private async Task SendFailureNotificationToChannels(
+        SocketGuildUser user,
+        EmbedBuilder embed,
+        List<FileAttachment> attachments,
+        IReadOnlyCollection<ServerLogChannelModel> targetLogChannels)
+    {
         foreach (var serverLogChannel in targetLogChannels)
         {
             SocketTextChannel? textChannel;
             try
             {
                 textChannel = user.Guild.GetTextChannel(serverLogChannel.GetChannelId())
-                    ?? throw new InvalidOperationException($"Channel {serverLogChannel.ChannelId} does not exist (GetTextChannel returned null)");
+                              ?? throw new InvalidOperationException($"Channel {serverLogChannel.ChannelId} does not exist (GetTextChannel returned null)");
             }
             catch (Exception ex)
             {

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -226,7 +226,8 @@ public class RolePreserveService : BaseService
     private async Task SendFailureNotification(
         SocketGuildUser user,
         IReadOnlyCollection<ulong> success,
-        IReadOnlyCollection<ApplyFailure> fail)
+        IReadOnlyCollection<ApplyFailure> fail,
+        RolePreserveAuditModel? auditModel = null)
     {
         if (fail.Count < 1) return;
         IReadOnlyCollection<ServerLogChannelModel> targetLogChannels;
@@ -273,7 +274,6 @@ public class RolePreserveService : BaseService
 
         const string failFilename = "roles.txt";
         var attachments = new List<FileAttachment>();
-        var failAttachmentMessage = new StringBuilder();
         var failureFieldContent = GetFailEmbedContent(fail)
             .TapError(err =>
             {

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -1,23 +1,22 @@
-﻿using System.Collections.Frozen;
-using System.Text;
-using CSharpFunctionalExtensions;
+﻿using CSharpFunctionalExtensions;
 using Discord;
 using Discord.WebSocket;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using NLog;
+using System.Collections.Frozen;
+using System.Text;
 using XeniaBot.Shared;
-using XeniaBot.Shared.Services;
 using XeniaBot.Shared.Helpers;
+using XeniaBot.Shared.Services;
 using XeniaDiscord.Data;
+using XeniaDiscord.Data.Models.RolePreserve;
 using XeniaDiscord.Data.Models.ServerLog;
 using XeniaDiscord.Data.Models.Snapshot;
 using XeniaDiscord.Data.Repositories;
-using XeniaDiscord.Data.Models.RolePreserve;
-
+using RolePreserveGuildRepository = XeniaDiscord.Data.Repositories.RolePreserveGuildRepository;
 using ServerLogEvent = XeniaDiscord.Data.Models.ServerLog.ServerLogEvent;
 using ServerLogRepository = XeniaDiscord.Data.Repositories.ServerLogRepository;
-using RolePreserveGuildRepository = XeniaDiscord.Data.Repositories.RolePreserveGuildRepository;
 
 namespace XeniaDiscord.Common.Services;
 
@@ -28,7 +27,7 @@ public class RolePreserveService : BaseService
     private readonly XeniaDbContext _db;
     private readonly ErrorReportService _err;
     private readonly DiscordSocketClient _client;
-    private readonly ServerLogRepository _serverLogConfig;
+    private readonly ServerLogRepository _serverLogRepo;
     private readonly RolePreserveUserRepository _userRepository;
     private readonly RolePreserveGuildRepository _guildRepository;
     private readonly ConfigData _configData;
@@ -40,7 +39,7 @@ public class RolePreserveService : BaseService
         _db = services.GetRequiredScopedService<XeniaDbContext>(out var scope);
         _err = services.GetRequiredService<ErrorReportService>();
         _client = services.GetRequiredService<DiscordSocketClient>();
-        _serverLogConfig = services.GetRequiredService<ServerLogRepository>();
+        _serverLogRepo = services.GetRequiredService<ServerLogRepository>();
         _configData = services.GetRequiredService<ConfigData>();
         _details = services.GetRequiredService<ProgramDetails>();
         _userRepository = (scope?.ServiceProvider ?? services).GetRequiredService<RolePreserveUserRepository>();
@@ -290,25 +289,11 @@ public class RolePreserveService : BaseService
         RolePreserveAuditModel? auditModel = null)
     {
         if (fail.Count < 1) return;
-        IReadOnlyCollection<ServerLogChannelModel> targetLogChannels;
-        try
-        {
-            targetLogChannels = await _serverLogConfig.GetChannelsForGuild(user.Guild.Id, [ServerLogEvent.MemberJoin], new()
-            {
-                IgnoreDisabledGuilds = true
-            });
-            if (targetLogChannels.Count < 1) return;
-        }
-        catch (Exception ex)
-        {
-            await _err.Submit(new ErrorReportBuilder()
-                .WithException(ex)
-                .WithNotes($"Failed to get Server Log Channel models with event {ServerLogEvent.MemberJoin} for Guild \"{user.Guild.Name}\" ({user.Guild.Id})")
-                .WithUser(user)
-                .WithGuild(user.Guild));
-            return;
-        }
-
+        
+        var maybeLogChannels = await GetChannelsForFailureNotification(user);
+        if (maybeLogChannels.HasNoValue) return;
+        var targetLogChannels = maybeLogChannels.Value;
+        
         var successCount = success.Count.ToString("n0");
         var successPlural = success.Count == 1 ? "" : "s";
         var embed = new EmbedBuilder()
@@ -321,20 +306,9 @@ public class RolePreserveService : BaseService
         {
             embed.WithUrl($"{_configData.DashboardUrl}/RolePreserve/Audit/Details?Id={auditModel.Id}");
         }
-        var failCount = fail.Count.ToString("n0");
-        if (success.Count == 0)
-        {
-            embed.WithDescription($"- {Emotes.Warning} Failed to give user *any* roles");
-            if (fail.Count > 0)
-            {
-                embed.Description += $" ({failCount})";
-            }
-        }
-        else if (fail.Count > 0)
-        {
-            var failPlural = fail.Count == 1 ? "" : "s";
-            if (fail.Count > 0) embed.Description += $"\n- Failed to add {failCount} role{failPlural}.";
-        }
+
+        // TODO generate success/fail data from RolePreserveAuditModel
+        FailureNotificationGetFailContent(embed, success, fail);
 
         const string failFilename = "roles.txt";
         var attachments = new List<FileAttachment>();
@@ -374,6 +348,63 @@ public class RolePreserveService : BaseService
         foreach (var serverLogChannel in targetLogChannels)
         {
             await SendFailureNotificationToChannel(user, embed, attachments, serverLogChannel);
+        }
+    }
+    private async Task<Maybe<IReadOnlyCollection<ServerLogChannelModel>>> GetChannelsForFailureNotification(
+        SocketGuildUser user)
+    {
+        IReadOnlyCollection<ServerLogChannelModel> targetLogChannels;
+        try
+        {
+            targetLogChannels = await _serverLogRepo.GetChannelsForGuild(
+                user.Guild.Id,
+                [ServerLogEvent.RolePerserve],
+                new()
+                {
+                    IgnoreDisabledGuilds = true
+                });
+            if (targetLogChannels.Count < 1)
+            {
+                targetLogChannels = await _serverLogRepo.GetChannelsForGuild(
+                    user.Guild.Id,
+                    [ServerLogEvent.MemberJoin],
+                    new()
+                    {
+                        IgnoreDisabledGuilds = true
+                    });
+            }
+            if (targetLogChannels.Count < 1)
+                return Maybe.None;
+            return Maybe<IReadOnlyCollection<ServerLogChannelModel>>.From(targetLogChannels);
+        }
+        catch (Exception ex)
+        {
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes($"Failed to get Server Log Channel models with event {ServerLogEvent.MemberJoin} or {ServerLogEvent.RolePerserve} for Guild \"{user.Guild.Name}\" ({user.Guild.Id})")
+                .WithUser(user)
+                .WithGuild(user.Guild));
+            return Maybe.None;
+        }
+    }
+    private static void FailureNotificationGetFailContent(
+        EmbedBuilder embed,
+        IReadOnlyCollection<ulong> success,
+        IReadOnlyCollection<ApplyFailure> fail)
+    {
+        var failCount = fail.Count.ToString("n0");
+        if (success.Count == 0)
+        {
+            embed.WithDescription($"- {Emotes.Warning} Failed to give user *any* roles");
+            if (fail.Count > 0)
+            {
+                embed.Description += $" ({failCount})";
+            }
+        }
+        else if (fail.Count > 0)
+        {
+            var failPlural = fail.Count == 1 ? "" : "s";
+            if (fail.Count > 0) embed.Description += $"\n- Failed to add {failCount} role{failPlural}.";
         }
     }
     private enum GetFailEmbedContentError
@@ -430,7 +461,7 @@ public class RolePreserveService : BaseService
         SocketTextChannel? textChannel;
         try
         {
-            textChannel = user.Guild.GetTextChannel(serverLogChannel.GetChannelId())
+            textChannel = ExceptionHelper.RetryOnTimedOut(() => user.Guild.GetTextChannel(serverLogChannel.GetChannelId()))
                           ?? throw new InvalidOperationException($"Channel {serverLogChannel.ChannelId} does not exist (GetTextChannel returned null)");
         }
         catch (Exception ex)
@@ -442,11 +473,11 @@ public class RolePreserveService : BaseService
         {
             if (attachments.Count > 0)
             {
-                await textChannel.SendFilesAsync(attachments, embed: embed.Build());
+                await ExceptionHelper.RetryOnTimedOut(async () => await textChannel.SendFilesAsync(attachments, embed: embed.Build()));
             }
             else
             {
-                await textChannel.SendMessageAsync(embed: embed.Build());
+                await ExceptionHelper.RetryOnTimedOut(async () => await textChannel.SendMessageAsync(embed: embed.Build()));
             }
         }
         catch (Exception ex)

--- a/XeniaDiscord.Common/Services/RolePreserveService.cs
+++ b/XeniaDiscord.Common/Services/RolePreserveService.cs
@@ -146,8 +146,83 @@ public class RolePreserveService : BaseService
             // TODO submit to ErrorReportService
         }
     }
+    
+    private async Task ClientOnUserJoined(SocketGuildUser user)
+    {
+        await using var db = _db.CreateSession();
+        try
+        {
+            if (!await _guildRepository.IsEnabled(db, user.Guild.Id))
+            {
+                _log.Trace($"Skipping Role Preserve is disabled (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
+                return;
+            }
+            if (!await _userRepository.HasAny(db, user.Guild.Id, user.Id))
+            {
+                _log.Trace($"Skipping since there are no records in {RolePreserveUserModel.TableName} (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
+                return;
+            }
+            var roleIds = await _userRepository.FindRolesForUser(db, user.Guild.Id, user.Id);
+            var blacklist = await _guildRepository.GetBlacklistRolesForGuild(db, user.Guild.Id);
+            
+            var ourHighestRoleEnumerable = user.Guild.CurrentUser.Roles.OrderByDescending(v => v.Position);
+            var ourHighestRolePos = ourHighestRoleEnumerable.FirstOrDefault()?.Position ?? int.MinValue;
 
+            var success = new List<ulong>();
+            var fail = new List<ApplyFailure>();
+            foreach (var item in roleIds)
+            {
+                var roleId = item;
+                if (roleId == user.Guild.EveryoneRole.Id) continue;
+                if (blacklist.Any(e => e.RoleId == item.ToString())) continue;
+                try
+                {
+                    var snapshot = await db.GuildRoleSnapshots
+                        .AsNoTracking()
+                        .OrderByDescending(e => e.RecordCreatedAt)
+                        .FirstOrDefaultAsync(e => e.RoleId == roleId.ToString());
+                    var existingRole = await ExceptionHelper.RetryOnTimedOut(async () => await user.Guild.GetRoleAsync(roleId));
+                    // continue, since the role doesn't exist anymore
+                    if (existingRole == null) continue;
+                    if (existingRole.Position > ourHighestRolePos)
+                    {
+                        fail.Add(new (item, snapshot));
+                        continue;
+                    }
+                    await user.AddRoleAsync(roleId);
+                    success.Add(roleId);
+                }
+                catch (Exception ex)
+                {
+                    _log.Warn(ex, $"Failed to grant Role {item} to User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})");
+                    fail.Add(new(item, null));
+                }
+            }
 
+            _log.Trace($"Operation complete (userId={user.Id}, username={user.Username}, success={success.Count}, fail={fail.Count})");
+            if (success.Count < 1)
+            {
+                _log.Trace($"No roles were restored? (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
+            }
+            if (fail.Count > 0)
+            {
+                await SendFailureNotification(user, success, fail);
+            }
+        }
+        catch (Exception ex)
+        {
+            var msg = $"Failed to restore roles for User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})";
+            _log.Error(ex, msg);
+            await _err.Submit(new ErrorReportBuilder()
+                .WithException(ex)
+                .WithNotes(msg)
+                .WithUser(user)
+                .WithGuild(user.Guild));
+        }
+    }
+    private sealed record ApplyFailure(ulong RoleId, GuildRoleSnapshotModel? Snapshot);
+    
+    #region Send Failure Notification
     private async Task SendFailureNotification(
         SocketGuildUser user,
         IReadOnlyCollection<ulong> success,
@@ -232,11 +307,10 @@ public class RolePreserveService : BaseService
                 return sb.ToString();
             });
         embed.AddField("Failed Roles", failureFieldContent);
-        await SendFailureNotificationToChannels(
-            user,
-            embed,
-            attachments,
-            targetLogChannels);
+        foreach (var serverLogChannel in targetLogChannels)
+        {
+            await SendFailureNotificationToChannel(user, embed, attachments, serverLogChannel);
+        }
     }
     private enum GetFailEmbedContentError
     {
@@ -276,132 +350,57 @@ public class RolePreserveService : BaseService
         var sb = new StringBuilder();
         foreach (var item in items)
         {
-            sb.AppendFormat("{0} - {1}", item.RoleId, item.Snapshot?.Name);
+            sb.Append(item.RoleId);
+            sb.Append(" - ");
+            sb.Append(item.Snapshot?.Name);
             sb.AppendLine();
         }
         return sb.ToString();
     }
-    private async Task SendFailureNotificationToChannels(
+    private async Task SendFailureNotificationToChannel(
         SocketGuildUser user,
         EmbedBuilder embed,
         List<FileAttachment> attachments,
-        IReadOnlyCollection<ServerLogChannelModel> targetLogChannels)
+        ServerLogChannelModel serverLogChannel)
     {
-        foreach (var serverLogChannel in targetLogChannels)
-        {
-            SocketTextChannel? textChannel;
-            try
-            {
-                textChannel = user.Guild.GetTextChannel(serverLogChannel.GetChannelId())
-                              ?? throw new InvalidOperationException($"Channel {serverLogChannel.ChannelId} does not exist (GetTextChannel returned null)");
-            }
-            catch (Exception ex)
-            {
-                _log.Warn(ex, $"Could not get channel {serverLogChannel.ChannelId} in Guild \"{user.Guild}\" ({user.Guild.Id}) from ServerLogChannel with Id={serverLogChannel.Id}");
-                continue;
-            }
-            try
-            {
-                if (attachments.Count > 0)
-                {
-                    await textChannel.SendFilesAsync(attachments, embed: embed.Build());
-                }
-                else
-                {
-                    await textChannel.SendMessageAsync(embed: embed.Build());
-                }
-            }
-            catch (Exception ex)
-            {
-                await _err.Submit(new ErrorReportBuilder()
-                    .WithException(ex)
-                    .WithNotes($"Failed to send message in channel \"{textChannel.Name}\" ({textChannel.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id}) for user \"{user.Username}#{user.Discriminator}\" ({user.Id})")
-                    .WithUser(user)
-                    .WithGuild(user.Guild)
-                    .WithChannel(textChannel)
-                    .AddSerializedAttachment("serverLogChannel.json", serverLogChannel));
-            }
-        }
-    }
-    
-    private async Task ClientOnUserJoined(SocketGuildUser user)
-    {
-        await using var db = _db.CreateSession();
+        SocketTextChannel? textChannel;
         try
         {
-            if (!await _guildRepository.IsEnabled(db, user.Guild.Id))
+            textChannel = user.Guild.GetTextChannel(serverLogChannel.GetChannelId())
+                          ?? throw new InvalidOperationException($"Channel {serverLogChannel.ChannelId} does not exist (GetTextChannel returned null)");
+        }
+        catch (Exception ex)
+        {
+            _log.Warn(ex, $"Could not get channel {serverLogChannel.ChannelId} in Guild \"{user.Guild}\" ({user.Guild.Id}) from ServerLogChannel with Id={serverLogChannel.Id}");
+            return;
+        }
+        try
+        {
+            if (attachments.Count > 0)
             {
-                _log.Trace($"Skipping Role Preserve is disabled (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
-                return;
+                await textChannel.SendFilesAsync(attachments, embed: embed.Build());
             }
-            if (!await _userRepository.HasAny(db, user.Guild.Id, user.Id))
+            else
             {
-                _log.Trace($"Skipping since there are no records in {RolePreserveUserModel.TableName} (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
-                return;
-            }
-            var roleIds = await _userRepository.FindRolesForUser(db, user.Guild.Id, user.Id);
-            var blacklist = await _guildRepository.GetBlacklistRolesForGuild(db, user.Guild.Id);
-            
-            var ourHighestRoleEnumerable = user.Guild.CurrentUser.Roles.OrderByDescending(v => v.Position);
-            var ourHighestRolePos = ourHighestRoleEnumerable.FirstOrDefault()?.Position ?? int.MinValue;
-
-            var success = new List<ulong>();
-            var fail = new List<ApplyFailure>();
-            foreach (var item in roleIds)
-            {
-                var roleId = item;
-                if (roleId == user.Guild.EveryoneRole.Id) continue;
-                if (blacklist.Any(e => e.RoleId == item.ToString())) continue;
-                try
-                {
-                    var snapshot = await db.GuildRoleSnapshots
-                        .AsNoTracking()
-                        .OrderByDescending(e => e.RecordCreatedAt)
-                        .FirstOrDefaultAsync(e => e.RoleId == roleId.ToString());
-                    var existingRole = await ExceptionHelper.RetryOnTimedOut(async () => await user.Guild.GetRoleAsync(roleId));
-                    // continue, since the role doesn't exist anymore
-                    if (existingRole == null) continue;
-                    if (existingRole.Position > ourHighestRolePos)
-                    {
-                        fail.Add(new (item, snapshot));
-                        continue;
-                    }
-                    await user.AddRoleAsync(roleId);
-                    success.Add(roleId);
-                }
-                catch (Exception ex)
-                {
-                    _log.Warn(ex, $"Failed to grant Role {item} to User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})");
-                    fail.Add(new(item, null));
-                }
-            }
-
-            _log.Trace($"Operation complete (userId={user.Id}, username={user.Username}, success={success.Count}, fail={fail.Count})");
-            if (success.Count < 1)
-            {
-                _log.Trace($"No roles were restored? (guildId={user.Guild.Id}, userId={user.Id}, username={user.Username})");
-            }
-            if (fail.Count > 0)
-            {
-                await SendFailureNotification(user, success, fail);
+                await textChannel.SendMessageAsync(embed: embed.Build());
             }
         }
         catch (Exception ex)
         {
-            var msg = $"Failed to restore roles for User \"{user.Username}#{user.Discriminator}\" ({user.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id})";
-            _log.Error(ex, msg);
             await _err.Submit(new ErrorReportBuilder()
                 .WithException(ex)
-                .WithNotes(msg)
+                .WithNotes($"Failed to send message in channel \"{textChannel.Name}\" ({textChannel.Id}) in Guild \"{user.Guild.Name}\" ({user.Guild.Id}) for user \"{user.Username}#{user.Discriminator}\" ({user.Id})")
                 .WithUser(user)
-                .WithGuild(user.Guild));
+                .WithGuild(user.Guild)
+                .WithChannel(textChannel)
+                .AddSerializedAttachment("serverLogChannel.json", serverLogChannel));
         }
     }
-    private sealed record ApplyFailure(ulong RoleId, GuildRoleSnapshotModel? Snapshot);
+    #endregion
 
     public override Task OnReadyDelay()
     {
-        // skip on webpanel
+        // skip on web panel
         if (_details.Platform != XeniaPlatform.Bot) return Task.CompletedTask;
         if (!_configData.RefreshRolePreserveOnStart)
         {

--- a/XeniaDiscord.Common/Services/ServerLogEventHandler.cs
+++ b/XeniaDiscord.Common/Services/ServerLogEventHandler.cs
@@ -57,17 +57,17 @@ public class ServerLogEventHandler
             else if (before != null)
             {
                 permissionsAddedList.AddRange(model.Permissions
-                    .Where(a => !before.Permissions.Any(b => b.Value == a.Value))
+                    .Where(a => before.Permissions.All(b => b.Value != a.Value))
                     .Select(e => e.GetValue()));
                 permissionsRemovedList.AddRange(before.Permissions
-                    .Where(b => !model.Permissions.Any(a => a.Value == b.Value))
+                    .Where(b => model.Permissions.All(a => a.Value != b.Value))
                     .Select(e => e.GetValue()));
             }
             else
             {
                 permissionsAddedList.AddRange(model.Permissions.Select(e => e.GetValue()));
             }
-            info = new()
+            info = new DiscordSnapshotRoleUpdateInfo
             {
                 PermissionsAdded = permissionsAddedList,
                 PermissionsRemoved = permissionsRemovedList,

--- a/XeniaDiscord.Common/Services/ServerLogService.cs
+++ b/XeniaDiscord.Common/Services/ServerLogService.cs
@@ -84,9 +84,11 @@ public class ServerLogService : BaseService
                 _log.Error(ex, $"Failed to send event (GuildId={options.GuildId}, ChannelEvent={channel.Event}, Event={options.Event})");
             }
         }
+
+        return;
         async Task<bool> ProcessForModel(ServerLogChannelModel channelModel)
         {
-            var logChannel = await ExceptionHelper.RetryOnTimedOut(async () => guild.GetTextChannel(channelModel.GetChannelId()));
+            var logChannel = ExceptionHelper.RetryOnTimedOut(() => guild.GetTextChannel(channelModel.GetChannelId()));
             if (logChannel == null) return false;
 
             return await ExceptionHelper.RetryOnTimedOut(async () => await EventHandleProcessInner(logChannel, options));

--- a/XeniaDiscord.Common/Services/ServerLogService.cs
+++ b/XeniaDiscord.Common/Services/ServerLogService.cs
@@ -31,16 +31,21 @@ public class ServerLogService : BaseService
     {
         var options = new EventHandleOptions(guildId, @event)
             .AddEmbeds(embeds)
-            .AddAttachments(attachments?.Select(e => new FileAttachment(new MemoryStream(Encoding.UTF8.GetBytes(e.Value)), e.Key)) ?? []);
+            .WithAttachments(attachments?.Select(e => new FileAttachment(new MemoryStream(Encoding.UTF8.GetBytes(e.Value)), e.Key)) ?? []);
 
         await EventHandle(options);
     }
+
+    public Task EventHandle(IGuild guild, ServerLogEvent @event, EmbedBuilder embed, List<FileAttachment>? attachments = null)
+        => EventHandle(guild.Id, @event, [embed], attachments);
+    public Task EventHandle(IGuild guild, ServerLogEvent @event, EmbedBuilder[] embeds, List<FileAttachment>? attachments = null)
+        => EventHandle(guild.Id, @event, embeds, attachments);
 
     public async Task EventHandle(ulong guildId, ServerLogEvent @event, EmbedBuilder[] embeds, List<FileAttachment>? attachments = null)
     {
         var options = new EventHandleOptions(guildId, @event)
             .AddEmbeds(embeds)
-            .AddAttachments(attachments ?? []);
+            .WithAttachments(attachments ?? []);
         await EventHandle(options);
     }
 
@@ -177,10 +182,14 @@ public class ServerLogService : BaseService
             Attachments = new List<FileAttachment>(10);
         }
 
+        public EventHandleOptions(IGuild guild, ServerLogEvent @event)
+            : this(guild.Id, @event)
+        { }
+
         public ulong GuildId { get; }
         public ServerLogEvent Event { get; }
         public ICollection<EmbedBuilder> Embeds { get; }
-        public ICollection<FileAttachment> Attachments { get; }
+        public ICollection<FileAttachment> Attachments { get; private set; }
 
         public EventHandleOptions AddEmbeds(params IEnumerable<EmbedBuilder> embeds)
         {
@@ -188,13 +197,23 @@ public class ServerLogService : BaseService
             return this;
         }
 
+        public EventHandleOptions WithAttachments(params IEnumerable<FileAttachment> attachments)
+        {
+            if (attachments is ICollection<FileAttachment> attachmentsCollection)
+                Attachments = attachmentsCollection;
+            else
+                Attachments = new List<FileAttachment>(attachments);
+            return this;
+        }
         public EventHandleOptions AddAttachments(params IEnumerable<FileAttachment> attachments)
         {
             foreach (var embed in attachments) Attachments.Add(embed);
             return this;
         }
 
-        public EventHandleOptions AddAttachment(string filename, string content,
+        public EventHandleOptions AddAttachment(
+            string filename,
+            string content,
             string? description = null,
             bool spoiler = false)
         {

--- a/XeniaDiscord.Common/Services/Snapshot/DiscordSnapshotService.cs
+++ b/XeniaDiscord.Common/Services/Snapshot/DiscordSnapshotService.cs
@@ -8,6 +8,7 @@ using XeniaBot.Shared;
 using XeniaBot.Shared.Services;
 using XeniaDiscord.Data;
 using XeniaDiscord.Data.Models.Snapshot;
+using XeniaDiscord.Data.Repositories;
 
 namespace XeniaDiscord.Common.Services;
 
@@ -17,6 +18,7 @@ public class DiscordSnapshotService : BaseService
     private readonly XeniaDbContext _db;
     private readonly DiscordSocketClient _client;
     private readonly DiscordCacheService _cacheService;
+    private readonly GuildCacheRepository _guildCacheRepository;
     private readonly IMapper<IRole, GuildRoleSnapshotModel> _roleMapper;
     private readonly IMapper<IGuildUser, GuildMemberSnapshotModel> _guildMemberMapper;
 
@@ -26,6 +28,7 @@ public class DiscordSnapshotService : BaseService
         _db = services.GetRequiredScopedService<XeniaDbContext>(out var _);
         _client = services.GetRequiredService<DiscordSocketClient>();
         _cacheService = services.GetRequiredService<DiscordCacheService>();
+        _guildCacheRepository = services.GetRequiredService<GuildCacheRepository>();
 
         _roleMapper = services.GetRequiredService<IMapper<IRole, GuildRoleSnapshotModel>>();
         _guildMemberMapper = services.GetRequiredService<IMapper<IGuildUser, GuildMemberSnapshotModel>>();
@@ -365,6 +368,7 @@ public class DiscordSnapshotService : BaseService
         try
         {
             await db.AddAsync(model);
+            await _guildCacheRepository.UpdateRoleCache(db, model);
             await db.SaveChangesAsync();
             await trans.CommitAsync();
         }
@@ -482,6 +486,10 @@ public class DiscordSnapshotService : BaseService
         try
         {
             await db.AddRangeAsync(roles);
+            foreach (var role in roles)
+            {
+                await _guildCacheRepository.UpdateRoleCache(db, role);
+            }
         }
         catch (Exception ex)
         {

--- a/XeniaDiscord.Common/Services/Snapshot/DiscordSnapshotService.cs
+++ b/XeniaDiscord.Common/Services/Snapshot/DiscordSnapshotService.cs
@@ -3,7 +3,7 @@ using Discord.WebSocket;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
-using System.Data;
+using JetBrains.Annotations;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Services;
 using XeniaDiscord.Data;
@@ -12,11 +12,11 @@ using XeniaDiscord.Data.Repositories;
 
 namespace XeniaDiscord.Common.Services;
 
+[UsedImplicitly]
 public class DiscordSnapshotService : BaseService
 {
     private readonly Logger _log = LogManager.GetCurrentClassLogger();
     private readonly XeniaDbContext _db;
-    private readonly DiscordSocketClient _client;
     private readonly DiscordCacheService _cacheService;
     private readonly GuildCacheRepository _guildCacheRepository;
     private readonly IMapper<IRole, GuildRoleSnapshotModel> _roleMapper;
@@ -26,7 +26,7 @@ public class DiscordSnapshotService : BaseService
     public DiscordSnapshotService(IServiceProvider services) : base(services)
     {
         _db = services.GetRequiredScopedService<XeniaDbContext>(out var _);
-        _client = services.GetRequiredService<DiscordSocketClient>();
+        var client = services.GetRequiredService<DiscordSocketClient>();
         _cacheService = services.GetRequiredService<DiscordCacheService>();
         _guildCacheRepository = services.GetRequiredService<GuildCacheRepository>();
 
@@ -38,36 +38,40 @@ public class DiscordSnapshotService : BaseService
         var programDetails = services.GetRequiredService<ProgramDetails>();
         if (programDetails.Platform == XeniaPlatform.Bot)
         {
-            _client.JoinedGuild += OnGuildJoined;
-            _client.GuildUpdated += OnGuildUpdated;
-            _client.LeftGuild += OnGuildLeft;
+            client.JoinedGuild += OnGuildJoined;
+            client.GuildUpdated += OnGuildUpdated;
+            client.LeftGuild += OnGuildLeft;
 
-            _client.UserJoined += OnGuildMemberJoined;
-            _client.GuildMemberUpdated += OnGuildMemberUpdated;
-            _client.RoleCreated += OnGuildRoleCreated;
-            _client.RoleUpdated += OnGuildRoleUpdated;
-            _client.RoleDeleted += OnGuildRoleDeleted;
+            client.UserJoined += OnGuildMemberJoined;
+            client.GuildMemberUpdated += OnGuildMemberUpdated;
+            client.RoleCreated += OnGuildRoleCreated;
+            client.RoleUpdated += OnGuildRoleUpdated;
+            client.RoleDeleted += OnGuildRoleDeleted;
         }
     }
 
     /// <summary>
     /// Invoked when a member has been updated.
     /// </summary>
+    [UsedImplicitly]
     public event DiscordSnapshotComparisonDelegate<GuildMemberSnapshotModel>? GuildMemberUpdated;
 
     /// <summary>
     /// Invoked when a role has been updated, created, or deleted.
     /// </summary>
+    [UsedImplicitly]
     public event DiscordSnapshotComparisonDelegate<GuildRoleSnapshotModel>? GuildRoleUpdated;
 
     /// <summary>
     /// Invoked when a role has been deleted.
     /// </summary>
+    [UsedImplicitly]
     public event DiscordSnapshotComparisonDelegate<GuildRoleSnapshotModel>? GuildRoleDeleted;
 
     /// <summary>
     /// Invoked when the bot joins a guild, or when it's been updated.
     /// </summary>
+    [UsedImplicitly]
     public event DiscordSnapshotComparisonDelegate<GuildSnapshotModel>? GuildUpdated;
 
     private Task OnGuildJoined(SocketGuild guild)
@@ -422,7 +426,6 @@ public class DiscordSnapshotService : BaseService
             await UpdateGuildMembers(db, guild, now, source);
         }
 
-        GuildSnapshotModel? guildSnapshotBefore = null;
         GuildSnapshotModel guildSnapshot;
         try
         {
@@ -432,7 +435,7 @@ public class DiscordSnapshotService : BaseService
                 SnapshotSource = source
             };
             guildSnapshot.Update(guild);
-            guildSnapshotBefore = await db.GuildSnapshots
+            var guildSnapshotBefore = await db.GuildSnapshots
                 .AsNoTracking()
                 .OrderByDescending(e => e.RecordCreatedAt)
                 .Where(e => e.GuildId == guildSnapshot.GuildId)

--- a/XeniaDiscord.Common/Services/Snapshot/DiscordSnapshotService.cs
+++ b/XeniaDiscord.Common/Services/Snapshot/DiscordSnapshotService.cs
@@ -312,6 +312,7 @@ public class DiscordSnapshotService : BaseService
     {
         var roleIdStr = role.Id.ToString();
         var guildIdStr = role.Guild.Id.ToString();
+        var now = DateTime.UtcNow;
         GuildRoleSnapshotModel? modelBefore = null;
         await using var db = _db.CreateSession();
         await using var trans = await db.Database.BeginTransactionAsync();
@@ -356,6 +357,7 @@ public class DiscordSnapshotService : BaseService
         {
             model = _roleMapper.Map(role);
             model.SnapshotSource = source;
+            model.RecordCreatedAt = now;
         }
         catch (Exception ex)
         {
@@ -371,8 +373,15 @@ public class DiscordSnapshotService : BaseService
         }
         try
         {
+            bool? isDeletedValue = source switch
+            {
+                GuildRoleSnapshotSource.RoleDelete => true,
+                GuildRoleSnapshotSource.RoleCreate => false,
+                GuildRoleSnapshotSource.RoleEdit => false,
+                _ => null
+            };
             await db.AddAsync(model);
-            await _guildCacheRepository.UpdateRoleCache(db, model);
+            await _guildCacheRepository.UpdateRoleCache(db, model, isDeleted: isDeletedValue, now: now);
             await db.SaveChangesAsync();
             await trans.CommitAsync();
         }
@@ -489,9 +498,16 @@ public class DiscordSnapshotService : BaseService
         try
         {
             await db.AddRangeAsync(roles);
+            bool? isDeletedValue = source switch
+            {
+                DiscordSnapshotSource.RoleDeleted => true,
+                DiscordSnapshotSource.RoleCreated => false,
+                DiscordSnapshotSource.RoleUpdated => false,
+                _ => null
+            };
             foreach (var role in roles)
             {
-                await _guildCacheRepository.UpdateRoleCache(db, role);
+                await _guildCacheRepository.UpdateRoleCache(db, role, isDeleted: isDeletedValue);
             }
         }
         catch (Exception ex)

--- a/XeniaDiscord.Common/StartupExtensions.cs
+++ b/XeniaDiscord.Common/StartupExtensions.cs
@@ -13,21 +13,25 @@ public static class StartupExtensions
     public static void WithDatabaseServices(this IServiceCollection services, DatabaseServicesOptions options)
     {
         // Add services to the container.
-        services.AddDbContextPool<XeniaDbContext>(
-            o =>
-            {
-                var connectionString = CoreContext.Instance!.Config.Data.Postgres.ToConnectionString();
-                LogManager.GetCurrentClassLogger().Info(connectionString);
-                o.UseNpgsql(connectionString);
-
-                o.EnableSensitiveDataLogging();
-            });
+        services.AddDbContextPool<XeniaDbContext>(ConfigureDbContextOptionsBuilder);
+        services.AddPooledDbContextFactory<XeniaDbContext>(ConfigureDbContextOptionsBuilder);
         // TODO for asp.net
         // if (options.DatabaseDeveloperPageExceptionFilter)
         // {
         //     services.AddDatabaseDeveloperPageExceptionFilter();
         // }
     }
+
+    private static void ConfigureDbContextOptionsBuilder(
+        DbContextOptionsBuilder optionsBuilder)
+    {
+        var connectionString = CoreContext.Instance!.Config.Data.Postgres.ToConnectionString();
+        Log.Debug(connectionString);
+        optionsBuilder.UseNpgsql(connectionString);
+        optionsBuilder.EnableSensitiveDataLogging();
+    }
+
+    private static readonly Logger Log = LogManager.GetCurrentClassLogger();
 
     public class DatabaseServicesOptions
     {

--- a/XeniaDiscord.Common/UnicolourExtensions.cs
+++ b/XeniaDiscord.Common/UnicolourExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Wacton.Unicolour;
+
+namespace XeniaDiscord.Common;
+
+public static class UnicolourExtensions
+{
+    public static bool HasConversionError(this Unicolour colour)
+    {
+        // if the clipped RGB has no hex value, RGB is invalid (likely a NaN during conversion)
+        return colour.Rgb.Byte255.Clipped.Hex == "-";
+    }
+    public static string ToCss(this Unicolour colour, double alpha)
+    {
+        if (colour.HasConversionError())
+        {
+            return "transparent";
+        }
+
+        var (r, g, b) = colour.Rgb.Clipped;
+        return $"rgb({r * 100}% {g * 100}% {b * 100}% / {alpha}%)";
+    }
+}

--- a/XeniaDiscord.Common/XeniaDiscord.Common.csproj
+++ b/XeniaDiscord.Common/XeniaDiscord.Common.csproj
@@ -19,6 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Wacton.Unicolour" />
   </ItemGroup>
 
   <ItemGroup>

--- a/XeniaDiscord.Common/XeniaDiscord.Common.csproj
+++ b/XeniaDiscord.Common/XeniaDiscord.Common.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="NLog" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/XeniaDiscord.Common/XeniaDiscord.Common.csproj.DotSettings
+++ b/XeniaDiscord.Common/XeniaDiscord.Common.csproj.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Ccache/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cguildapproval/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Csnapshot/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/XeniaDiscord.Common/XeniaDiscordCommon.cs
+++ b/XeniaDiscord.Common/XeniaDiscordCommon.cs
@@ -38,6 +38,7 @@ public static class XeniaDiscordCommon
 
             typeof(GuildApprovalService),
             typeof(RolePreserveService),
+            typeof(RolePreserveLogService),
         };
         foreach (var t in types)
         {

--- a/XeniaDiscord.Common/XeniaDiscordCommon.cs
+++ b/XeniaDiscord.Common/XeniaDiscordCommon.cs
@@ -4,6 +4,8 @@ using XeniaDiscord.Common.Handlers;
 using XeniaDiscord.Common.Mappers.DiscordCache;
 using XeniaDiscord.Common.Mappers.DiscordSnapshot;
 using XeniaDiscord.Common.Services;
+#pragma warning disable S1186
+#pragma warning disable IDE0130
 
 namespace XeniaDiscord;
 
@@ -49,6 +51,7 @@ public static class XeniaDiscordCommon
             }
         }
     }
+
     private static void RegisterMappers(IServiceCollection services)
     {
         DiscordUserToUserCacheModelMapper.RegisterService(services);

--- a/XeniaDiscord.Data/Extensions.cs
+++ b/XeniaDiscord.Data/Extensions.cs
@@ -51,6 +51,13 @@ public static class DataExtensions
         return null;
     }
 
+    public static uint? ParseUInt(this string? value, bool allowZero = true)
+    {
+        if (uint.TryParse(value?.Trim(), out var result) &&
+            (allowZero || result > 0)) return result;
+        return null;
+    }
+
     public static TService GetRequiredScopedService<TService>(
         this IServiceProvider services,
         IServiceScopeCallbackDelegate initializeScope,
@@ -120,19 +127,14 @@ public class PaginationOptions
 {
     public int Page
     {
-        get => field;
-        set
-        {
-            field = Math.Max(1, value);
-        }
+        get;
+        set => field = Math.Max(1, value);
     } = 1;
+
     public int PageSize
     {
-        get => field;
-        set
-        {
-            field = Math.Max(1, value);
-        }
+        get;
+        set => field = Math.Max(1, value);
     } = 15;
 
     public int Skip => Page > 1 ? (Page - 1) * PageSize : 0;

--- a/XeniaDiscord.Data/Extensions.cs
+++ b/XeniaDiscord.Data/Extensions.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 using XeniaBot.Shared;
 using XeniaDiscord.Data.Models.Cache;
+using XeniaDiscord.Data.Models.PartialSnapshot;
+using XeniaDiscord.Data.Models.Snapshot;
 
 namespace XeniaDiscord.Data;
 
@@ -22,6 +24,19 @@ public static class DataExtensions
         };
         return b.ConnectionString;
     }
+
+    public static string FormatUsername(this UserSnapshotModel user)
+    {
+        if (string.IsNullOrEmpty(user.Discriminator?.Trim()?.Trim('0'))) return user.Username;
+        return $"{user.Username}#{user.Discriminator}";
+    }
+
+    public static string FormatUsername(this UserPartialSnapshotModel user)
+    {
+        if (string.IsNullOrEmpty(user.Discriminator?.Trim()?.Trim('0'))) return user.Username;
+        return $"{user.Username}#{user.Discriminator}";
+    }
+
     public static ulong ParseRequiredULong(this string? value, string propertyName, bool allowZero = true)
     {
         if (string.IsNullOrEmpty(value?.Trim())) throw new InvalidOperationException($"Property {propertyName} is null or empty");

--- a/XeniaDiscord.Data/Migrations/20260508074350_Create_RolePreserveBlacklist.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260508074350_Create_RolePreserveBlacklist.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508074350_Create_RolePreserveBlacklist")]
+    partial class Create_RolePreserveBlacklist
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260508074350_Create_RolePreserveBlacklist.cs
+++ b/XeniaDiscord.Data/Migrations/20260508074350_Create_RolePreserveBlacklist.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Create_RolePreserveBlacklist : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RolePreserveAudit",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    RecordCreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    GuildId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    Action = table.Column<int>(type: "integer", nullable: false),
+                    UserId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    TargetUserId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    TargetRoleId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RolePreserveAudit", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RolePreserveAudit_RolePreserveGuilds_GuildId",
+                        column: x => x.GuildId,
+                        principalTable: "RolePreserveGuilds",
+                        principalColumn: "GuildId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RolePreserveBlacklistedRoles",
+                columns: table => new
+                {
+                    GuildId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    RoleId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    CreatedByUserId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RolePreserveBlacklistedRoles", x => new { x.GuildId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_RolePreserveBlacklistedRoles_RolePreserveGuilds_GuildId",
+                        column: x => x.GuildId,
+                        principalTable: "RolePreserveGuilds",
+                        principalColumn: "GuildId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RolePreserveAudit_GuildId",
+                table: "RolePreserveAudit",
+                column: "GuildId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RolePreserveAudit_RecordCreatedAt_GuildId",
+                table: "RolePreserveAudit",
+                columns: new[] { "RecordCreatedAt", "GuildId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RolePreserveAudit_RecordCreatedAt_GuildId_UserId_TargetUser~",
+                table: "RolePreserveAudit",
+                columns: new[] { "RecordCreatedAt", "GuildId", "UserId", "TargetUserId", "TargetRoleId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RolePreserveAudit");
+
+            migrationBuilder.DropTable(
+                name: "RolePreserveBlacklistedRoles");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Migrations/20260516075834_RolePreserveBlacklist-20260516_1554.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260516075834_RolePreserveBlacklist-20260516_1554.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516075834_RolePreserveBlacklist-20260516_1554")]
+    partial class RolePreserveBlacklist20260516_1554
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260516075834_RolePreserveBlacklist-20260516_1554.cs
+++ b/XeniaDiscord.Data/Migrations/20260516075834_RolePreserveBlacklist-20260516_1554.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RolePreserveBlacklist20260516_1554 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unballed,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
+                .Annotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
+                .Annotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy")
+                .OldAnnotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unballed,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated");
+
+            migrationBuilder.CreateTable(
+                name: "Cache_GuildRole",
+                columns: table => new
+                {
+                    RoleId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    GuildId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Position = table.Column<int>(type: "integer", nullable: false),
+                    RecordCreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    RecordUpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SnapshotId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Cache_GuildRole", x => x.RoleId);
+                    table.ForeignKey(
+                        name: "FK_Cache_GuildRole_Snapshot_GuildRole_SnapshotId",
+                        column: x => x.SnapshotId,
+                        principalTable: "Snapshot_GuildRole",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "RolePreserveAudit_AppliedRoles",
+                columns: table => new
+                {
+                    RolePreserveAuditId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RoleId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    Action = table.Column<int>(type: "integer", nullable: false),
+                    ExceptionText = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RolePreserveAudit_AppliedRoles", x => new { x.RolePreserveAuditId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_RolePreserveAudit_AppliedRoles_RolePreserveAudit_RolePreser~",
+                        column: x => x.RolePreserveAuditId,
+                        principalTable: "RolePreserveAudit",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Cache_GuildRole_GuildId",
+                table: "Cache_GuildRole",
+                column: "GuildId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Cache_GuildRole_Position",
+                table: "Cache_GuildRole",
+                column: "Position");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Cache_GuildRole_SnapshotId",
+                table: "Cache_GuildRole",
+                column: "SnapshotId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Cache_GuildRole");
+
+            migrationBuilder.DropTable(
+                name: "RolePreserveAudit_AppliedRoles");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unballed,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
+                .OldAnnotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unballed,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
+                .OldAnnotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
+                .OldAnnotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Migrations/20260519095707_Create-GuildRoleColorSnapshot.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260519095707_Create-GuildRoleColorSnapshot.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519095707_Create-GuildRoleColorSnapshot")]
+    partial class CreateGuildRoleColorSnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1589,7 +1592,7 @@ namespace XeniaDiscord.Data.Migrations
                     b.HasOne("XeniaDiscord.Data.Models.Snapshot.GuildRoleSnapshotModel", null)
                         .WithOne("RoleColors")
                         .HasForeignKey("XeniaDiscord.Data.Models.Snapshot.GuildRoleColorSnapshotModel", "GuildRoleSnapshotId")
-                        .OnDelete(DeleteBehavior.SetNull)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 

--- a/XeniaDiscord.Data/Migrations/20260519095707_Create-GuildRoleColorSnapshot.cs
+++ b/XeniaDiscord.Data/Migrations/20260519095707_Create-GuildRoleColorSnapshot.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class CreateGuildRoleColorSnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Snapshot_GuildRole_Color",
+                columns: table => new
+                {
+                    GuildRoleSnapshotId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RoleId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    R = table.Column<byte>(type: "smallint", nullable: false),
+                    G = table.Column<byte>(type: "smallint", nullable: false),
+                    B = table.Column<byte>(type: "smallint", nullable: false),
+                    SecondaryRed = table.Column<byte>(type: "smallint", nullable: true),
+                    SecondaryGreen = table.Column<byte>(type: "smallint", nullable: true),
+                    SecondaryBlue = table.Column<byte>(type: "smallint", nullable: true),
+                    TertiaryRed = table.Column<byte>(type: "smallint", nullable: true),
+                    TertiaryGreen = table.Column<byte>(type: "smallint", nullable: true),
+                    TertiaryBlue = table.Column<byte>(type: "smallint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Snapshot_GuildRole_Color", x => x.GuildRoleSnapshotId);
+                    table.ForeignKey(
+                        name: "FK_Snapshot_GuildRole_Color_Snapshot_GuildRole_GuildRoleSnapsh~",
+                        column: x => x.GuildRoleSnapshotId,
+                        principalTable: "Snapshot_GuildRole",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Snapshot_GuildRole_Color");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Migrations/20260519095836_GuildRoleColorSnapshot-OnDelete_SetNull.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260519095836_GuildRoleColorSnapshot-OnDelete_SetNull.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519095836_GuildRoleColorSnapshot-OnDelete_SetNull")]
+    partial class GuildRoleColorSnapshotOnDelete_SetNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260519095836_GuildRoleColorSnapshot-OnDelete_SetNull.cs
+++ b/XeniaDiscord.Data/Migrations/20260519095836_GuildRoleColorSnapshot-OnDelete_SetNull.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class GuildRoleColorSnapshotOnDelete_SetNull : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Snapshot_GuildRole_Color_Snapshot_GuildRole_GuildRoleSnapsh~",
+                table: "Snapshot_GuildRole_Color");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Snapshot_GuildRole_Color_Snapshot_GuildRole_GuildRoleSnapsh~",
+                table: "Snapshot_GuildRole_Color",
+                column: "GuildRoleSnapshotId",
+                principalTable: "Snapshot_GuildRole",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Snapshot_GuildRole_Color_Snapshot_GuildRole_GuildRoleSnapsh~",
+                table: "Snapshot_GuildRole_Color");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Snapshot_GuildRole_Color_Snapshot_GuildRole_GuildRoleSnapsh~",
+                table: "Snapshot_GuildRole_Color",
+                column: "GuildRoleSnapshotId",
+                principalTable: "Snapshot_GuildRole",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/XeniaDiscord.Data/Migrations/20260523104511_GuildRoleCache_Add_IsDeleted.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260523104511_GuildRoleCache_Add_IsDeleted.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260523104511_GuildRoleCache_Add_IsDeleted")]
+    partial class GuildRoleCache_Add_IsDeleted
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260523104511_GuildRoleCache_Add_IsDeleted.cs
+++ b/XeniaDiscord.Data/Migrations/20260523104511_GuildRoleCache_Add_IsDeleted.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class GuildRoleCache_Add_IsDeleted : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unbanned,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
+                .Annotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
+                .Annotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy")
+                .OldAnnotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unballed,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
+                .OldAnnotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
+                .OldAnnotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Cache_GuildRole",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Cache_GuildRole",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Cache_GuildRole");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Cache_GuildRole");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unballed,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
+                .Annotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
+                .Annotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy")
+                .OldAnnotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unbanned,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
+                .OldAnnotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
+                .OldAnnotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Migrations/20260523104511_GuildRoleCache_Add_IsDeleted.cs
+++ b/XeniaDiscord.Data/Migrations/20260523104511_GuildRoleCache_Add_IsDeleted.cs
@@ -11,14 +11,8 @@ namespace XeniaDiscord.Data.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AlterDatabase()
-                .Annotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unbanned,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
-                .Annotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
-                .Annotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy")
-                .OldAnnotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unballed,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
-                .OldAnnotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
-                .OldAnnotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy");
-
+            migrationBuilder.Sql("ALTER TYPE discord_snapshot_source RENAME VALUE 'user_unballed' TO 'user_unbanned';");
+         
             migrationBuilder.AddColumn<DateTime>(
                 name: "DeletedAt",
                 table: "Cache_GuildRole",
@@ -36,6 +30,8 @@ namespace XeniaDiscord.Data.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql("ALTER TYPE discord_snapshot_source RENAME VALUE 'user_unbanned' TO 'user_unballed';");
+
             migrationBuilder.DropColumn(
                 name: "DeletedAt",
                 table: "Cache_GuildRole");
@@ -43,14 +39,6 @@ namespace XeniaDiscord.Data.Migrations
             migrationBuilder.DropColumn(
                 name: "IsDeleted",
                 table: "Cache_GuildRole");
-
-            migrationBuilder.AlterDatabase()
-                .Annotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unballed,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
-                .Annotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
-                .Annotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy")
-                .OldAnnotation("Npgsql:Enum:discord_snapshot_source", "unknown,member_joined,member_updated,user_updated,user_left,user_banned,user_unbanned,role_created,role_updated,role_deleted,joined_guild,left_guild,guild_updated")
-                .OldAnnotation("Npgsql:Enum:role_preserve_audit_action", "unknown,blacklist_add,blacklist_remove,enable,disable,applied_roles")
-                .OldAnnotation("Npgsql:Enum:role_preserve_audit_applied_role_action", "failure_unknown,success_grant,skipped_role_does_not_exist,skipped_blacklisted,failure_missing_permissions,failure_missing_permissions_hierarchy");
         }
     }
 }

--- a/XeniaDiscord.Data/Migrations/20260524114112_Add-RolePreserveAuditReferencedRoles.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260524114112_Add-RolePreserveAuditReferencedRoles.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524114112_Add-RolePreserveAuditReferencedRoles")]
+    partial class AddRolePreserveAuditReferencedRoles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260524114112_Add-RolePreserveAuditReferencedRoles.cs
+++ b/XeniaDiscord.Data/Migrations/20260524114112_Add-RolePreserveAuditReferencedRoles.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRolePreserveAuditReferencedRoles : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "RolePreserveAudit_ReferencedRoles",
+                columns: table => new
+                {
+                    RolePreserveAuditId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RoleId = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RolePreserveAudit_ReferencedRoles", x => new { x.RolePreserveAuditId, x.RoleId });
+                    table.ForeignKey(
+                        name: "FK_RolePreserveAudit_ReferencedRoles_RolePreserveAudit_RolePre~",
+                        column: x => x.RolePreserveAuditId,
+                        principalTable: "RolePreserveAudit",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RolePreserveAudit_ReferencedRoles");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Migrations/20260616113716_RolePreserveAudit-Role-Reference-GuildRoleCache.Designer.cs
+++ b/XeniaDiscord.Data/Migrations/20260616113716_RolePreserveAudit-Role-Reference-GuildRoleCache.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using XeniaDiscord.Data;
@@ -11,9 +12,11 @@ using XeniaDiscord.Data;
 namespace XeniaDiscord.Data.Migrations
 {
     [DbContext(typeof(XeniaDbContext))]
-    partial class XeniaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260616113716_RolePreserveAudit-Role-Reference-GuildRoleCache")]
+    partial class RolePreserveAuditRoleReferenceGuildRoleCache
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/XeniaDiscord.Data/Migrations/20260616113716_RolePreserveAudit-Role-Reference-GuildRoleCache.cs
+++ b/XeniaDiscord.Data/Migrations/20260616113716_RolePreserveAudit-Role-Reference-GuildRoleCache.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace XeniaDiscord.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RolePreserveAuditRoleReferenceGuildRoleCache : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_RolePreserveAudit_ReferencedRoles_RoleId",
+                table: "RolePreserveAudit_ReferencedRoles",
+                column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RolePreserveAudit_AppliedRoles_RoleId",
+                table: "RolePreserveAudit_AppliedRoles",
+                column: "RoleId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RolePreserveAudit_AppliedRoles_Cache_GuildRole_RoleId",
+                table: "RolePreserveAudit_AppliedRoles",
+                column: "RoleId",
+                principalTable: "Cache_GuildRole",
+                principalColumn: "RoleId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RolePreserveAudit_ReferencedRoles_Cache_GuildRole_RoleId",
+                table: "RolePreserveAudit_ReferencedRoles",
+                column: "RoleId",
+                principalTable: "Cache_GuildRole",
+                principalColumn: "RoleId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_RolePreserveAudit_AppliedRoles_Cache_GuildRole_RoleId",
+                table: "RolePreserveAudit_AppliedRoles");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RolePreserveAudit_ReferencedRoles_Cache_GuildRole_RoleId",
+                table: "RolePreserveAudit_ReferencedRoles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RolePreserveAudit_ReferencedRoles_RoleId",
+                table: "RolePreserveAudit_ReferencedRoles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RolePreserveAudit_AppliedRoles_RoleId",
+                table: "RolePreserveAudit_AppliedRoles");
+        }
+    }
+}

--- a/XeniaDiscord.Data/Models/Cache/GuildRoleCacheModel.cs
+++ b/XeniaDiscord.Data/Models/Cache/GuildRoleCacheModel.cs
@@ -11,6 +11,7 @@ public class GuildRoleCacheModel
     {
         GuildId = "0";
         RoleId = "0";
+        Name = "";
         RecordCreatedAt = DateTime.UtcNow;
         RecordUpdatedAt = RecordCreatedAt;
         SnapshotId = Guid.Empty;
@@ -28,6 +29,12 @@ public class GuildRoleCacheModel
     /// </summary>
     [MaxLength(DbGlobals.ulongMaxLength)]
     public string RoleId { get; set; }
+    
+    /// <summary>
+    /// Role Name
+    /// </summary>
+    [MaxLength(200)]
+    public string Name { get; set; }
 
     /// <summary>
     /// UTC Date Time of when this record was created.

--- a/XeniaDiscord.Data/Models/Cache/GuildRoleCacheModel.cs
+++ b/XeniaDiscord.Data/Models/Cache/GuildRoleCacheModel.cs
@@ -3,7 +3,6 @@ using XeniaDiscord.Data.Models.Snapshot;
 
 namespace XeniaDiscord.Data.Models.Cache;
 
-// TODO add in XeniaDbContext
 public class GuildRoleCacheModel
 {
     public const string TableName = "Cache_GuildRole";
@@ -50,6 +49,16 @@ public class GuildRoleCacheModel
     /// UTC Date Time of when this record was last updated.
     /// </summary>
     public DateTime RecordUpdatedAt { get; set; }
+
+    /// <summary>
+    /// Is this role deleted? Should not be shown in UI selections if it is deleted.
+    /// </summary>
+    public bool IsDeleted { get; set; }
+    
+    /// <summary>
+    /// Time when this role was deleted
+    /// </summary>
+    public DateTime? DeletedAt { get; set; }
 
     /// <summary>
     /// Foreign Key to <see cref="GuildRoleSnapshotModel.Id"/>

--- a/XeniaDiscord.Data/Models/Cache/GuildRoleCacheModel.cs
+++ b/XeniaDiscord.Data/Models/Cache/GuildRoleCacheModel.cs
@@ -35,6 +35,11 @@ public class GuildRoleCacheModel
     /// </summary>
     [MaxLength(200)]
     public string Name { get; set; }
+    
+    /// <summary>
+    /// From: <see cref="Discord.IRole.Position"/>
+    /// </summary>
+    public int Position { get; set; }
 
     /// <summary>
     /// UTC Date Time of when this record was created.

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditAppliedRoleModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditAppliedRoleModel.cs
@@ -1,0 +1,54 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace XeniaDiscord.Data.Models.RolePreserve;
+
+public class RolePreserveAuditAppliedRoleModel
+{
+    public const string TableName = "RolePreserveAudit_AppliedRoles";
+    public RolePreserveAuditAppliedRoleModel()
+    {
+        RolePreserveAuditId = Guid.Empty;
+        RoleId = "0";
+        Action = RolePreserveAuditAppliedRoleAction.FailureUnknown;
+    }
+
+    /// <summary>
+    /// Foreign Key to <see cref="RolePreserveAuditModel.Id"/>
+    /// </summary>
+    public Guid RolePreserveAuditId { get; set; }
+
+    /// <summary>
+    /// Role Id that was applied, or Xenia tried to (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string RoleId { get; set; }
+    
+    /// <summary>
+    /// Action in relation to the role
+    /// </summary>
+    public RolePreserveAuditAppliedRoleAction Action { get; set; }
+
+    /// <summary>
+    /// Only used if <see cref="Action"/> is <see cref="RolePreserveAuditAppliedRoleAction.FailureUnknown"/>
+    /// </summary>
+    public string? ExceptionText { get; set; }
+
+    public ulong GetRoleId() => RoleId.ParseRequiredULong(nameof(RoleId), false);
+}
+
+public enum RolePreserveAuditAppliedRoleAction
+{
+    [Description("Failure - Unknown")]
+    FailureUnknown = 0,
+    [Description("Success - Granted")]
+    SuccessGrant,
+    [Description("Skipped - Role does not exist")]
+    SkippedRoleDoesNotExist,
+    [Description("Skipped - Blacklisted")]
+    SkippedBlacklisted,
+    [Description("Failed to apply - Missing permissions")]
+    FailureMissingPermissions,
+    [Description("Failed to apply - Missing permissions (hierarchy issue)")]
+    FailureMissingPermissionsHierarchy
+}

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditAppliedRoleModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditAppliedRoleModel.cs
@@ -35,6 +35,18 @@ public class RolePreserveAuditAppliedRoleModel
     public string? ExceptionText { get; set; }
 
     public ulong GetRoleId() => RoleId.ParseRequiredULong(nameof(RoleId), false);
+
+    public bool IsActionFailure()
+        => Action == RolePreserveAuditAppliedRoleAction.FailureUnknown
+        || Action == RolePreserveAuditAppliedRoleAction.FailureMissingPermissions
+        || Action == RolePreserveAuditAppliedRoleAction.FailureMissingPermissionsHierarchy;
+    
+    public bool IsActionSkip()
+        => Action == RolePreserveAuditAppliedRoleAction.SkippedRoleDoesNotExist
+        || Action == RolePreserveAuditAppliedRoleAction.SkippedBlacklisted;
+    
+    public bool IsActionSuccess()
+        => Action == RolePreserveAuditAppliedRoleAction.SuccessGrant;
 }
 
 public enum RolePreserveAuditAppliedRoleAction

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditAppliedRoleModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditAppliedRoleModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using XeniaDiscord.Data.Models.Cache;
 
 namespace XeniaDiscord.Data.Models.RolePreserve;
 
@@ -20,6 +21,7 @@ public class RolePreserveAuditAppliedRoleModel
 
     /// <summary>
     /// Role Id that was applied, or Xenia tried to (ulong as string)
+    /// Optional foreign key to <see cref="GuildRoleCacheModel.RoleId"/>
     /// </summary>
     [MaxLength(DbGlobals.ulongMaxLength)]
     public string RoleId { get; set; }
@@ -47,6 +49,12 @@ public class RolePreserveAuditAppliedRoleModel
     
     public bool IsActionSuccess()
         => Action == RolePreserveAuditAppliedRoleAction.SuccessGrant;
+    
+    
+    /// <summary>
+    /// Property Accessor
+    /// </summary>
+    public GuildRoleCacheModel? Role { get; set; }
 }
 
 public enum RolePreserveAuditAppliedRoleAction

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditModel.cs
@@ -12,6 +12,7 @@ public class RolePreserveAuditModel
         RecordCreatedAt = DateTime.UtcNow;
         GuildId = "0";
         Action = RolePreserveAuditAction.Unknown;
+        AppliedRoles = new();
     }
     
     /// <summary>
@@ -53,6 +54,16 @@ public class RolePreserveAuditModel
     /// </summary>
     [MaxLength(DbGlobals.ulongMaxLength)]
     public string? TargetRoleId { get; set; }
+    
+    /// <summary>
+    /// Property Accessor
+    /// </summary>
+    public List<RolePreserveAuditAppliedRoleModel> AppliedRoles { get; set; }
+
+    public ulong GetGuildId() => GuildId.ParseRequiredULong(nameof(GuildId), false);
+    public ulong? GetUserId() => UserId.ParseULong(false);
+    public ulong? GetTargetUserId() => TargetUserId.ParseULong(false);
+    public ulong? GetTargetRoleId() => TargetRoleId.ParseULong(false);
 }
 
 public enum RolePreserveAuditAction
@@ -61,5 +72,6 @@ public enum RolePreserveAuditAction
     BlacklistAdd,
     BlacklistRemove,
     Enable,
-    Disable
+    Disable,
+    AppliedRoles
 }

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditModel.cs
@@ -13,6 +13,7 @@ public class RolePreserveAuditModel
         GuildId = "0";
         Action = RolePreserveAuditAction.Unknown;
         AppliedRoles = new();
+        ReferencedRoles = new();
     }
     
     /// <summary>
@@ -59,6 +60,11 @@ public class RolePreserveAuditModel
     /// Property Accessor
     /// </summary>
     public List<RolePreserveAuditAppliedRoleModel> AppliedRoles { get; set; }
+
+    /// <summary>
+    /// Property Accessor - Referenced roles for moderation actions, and should not be used when applying roles.
+    /// </summary>
+    public List<RolePreserveAuditReferencedRoleModel> ReferencedRoles { get; set; }
 
     public ulong GetGuildId() => GuildId.ParseRequiredULong(nameof(GuildId), false);
     public ulong? GetUserId() => UserId.ParseULong(false);

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditModel.cs
@@ -14,21 +14,43 @@ public class RolePreserveAuditModel
         Action = RolePreserveAuditAction.Unknown;
     }
     
+    /// <summary>
+    /// Record ID, primary key
+    /// </summary>
     public Guid Id { get; set; }
     
+    /// <summary>
+    /// UTC Date Time of when this record was created
+    /// </summary>
     public DateTime RecordCreatedAt { get; set; }
     
+    /// <summary>
+    /// Guild Id (ulong as string)
+    /// Also a foreign key to <see cref="RolePreserveGuildModel.GuildId"/>
+    /// </summary>
     [MaxLength(DbGlobals.ulongMaxLength)]
     public string GuildId { get; set; }
     
+    /// <summary>
+    /// Action that was done
+    /// </summary>
     public RolePreserveAuditAction Action { get; set; }
     
+    /// <summary>
+    /// User Id (ulong as string)
+    /// </summary>
     [MaxLength(DbGlobals.ulongMaxLength)]
     public string? UserId { get; set; }
     
+    /// <summary>
+    /// User Id that the action was performed on (ulong as string, currently not used)
+    /// </summary>
     [MaxLength(DbGlobals.ulongMaxLength)]
     public string? TargetUserId { get; set; }
     
+    /// <summary>
+    /// Role Id that the action was performed on (ulong as string)
+    /// </summary>
     [MaxLength(DbGlobals.ulongMaxLength)]
     public string? TargetRoleId { get; set; }
 }

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditModel.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace XeniaDiscord.Data.Models.RolePreserve;
+
+public class RolePreserveAuditModel
+{
+    public const string TableName = "RolePreserveAudit";
+    
+    public RolePreserveAuditModel()
+    {
+        Id = Guid.NewGuid();
+        RecordCreatedAt = DateTime.UtcNow;
+        GuildId = "0";
+        Action = RolePreserveAuditAction.Unknown;
+    }
+    
+    public Guid Id { get; set; }
+    
+    public DateTime RecordCreatedAt { get; set; }
+    
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string GuildId { get; set; }
+    
+    public RolePreserveAuditAction Action { get; set; }
+    
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? UserId { get; set; }
+    
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? TargetUserId { get; set; }
+    
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? TargetRoleId { get; set; }
+}
+
+public enum RolePreserveAuditAction
+{
+    Unknown,
+    BlacklistAdd,
+    BlacklistRemove,
+    Enable,
+    Disable
+}

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditReferencedRoleModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditReferencedRoleModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using XeniaDiscord.Data.Models.Cache;
 
 namespace XeniaDiscord.Data.Models.RolePreserve;
 
@@ -16,7 +17,13 @@ public class RolePreserveAuditReferencedRoleModel
 
     /// <summary>
     /// Role Id that was applied, or Xenia tried to (ulong as string)
+    /// Optional foreign key to <see cref="GuildRoleCacheModel.RoleId"/>
     /// </summary>
     [MaxLength(DbGlobals.ulongMaxLength)]
     public string RoleId { get; set; } = "0";
+    
+    /// <summary>
+    /// Property Accessor
+    /// </summary>
+    public GuildRoleCacheModel? Role { get; set; }
 }

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditReferencedRoleModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveAuditReferencedRoleModel.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace XeniaDiscord.Data.Models.RolePreserve;
+
+/// <summary>
+/// Used as a reference to a role when adding/removing from blacklist
+/// </summary>
+public class RolePreserveAuditReferencedRoleModel
+{
+    public const string TableName = "RolePreserveAudit_ReferencedRoles";
+
+    /// <summary>
+    /// Foreign Key to <see cref="RolePreserveAuditModel.Id"/>
+    /// </summary>
+    public Guid RolePreserveAuditId { get; set; } = Guid.Empty;
+
+    /// <summary>
+    /// Role Id that was applied, or Xenia tried to (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string RoleId { get; set; } = "0";
+}

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveBlacklistedRoleModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveBlacklistedRoleModel.cs
@@ -1,0 +1,42 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace XeniaDiscord.Data.Models.RolePreserve;
+
+public class RolePreserveBlacklistedRoleModel
+{
+    public const string TableName = "RolePreserveBlacklistedRoles";
+
+    public RolePreserveBlacklistedRoleModel()
+    {
+        GuildId = "0";
+        RoleId = "0";
+        CreatedAt = DateTime.UtcNow;
+    }
+    
+    /// <summary>
+    /// Guild Id (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string GuildId { get; set; }
+    
+    /// <summary>
+    /// Role Id (ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string RoleId { get; set; }
+    
+    /// <summary>
+    /// Discord User Id that added the role to the blacklist. (optional, ulong as string)
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string? CreatedByUserId { get; set; }
+    
+    /// <summary>
+    /// UTC Time of when this blacklist was created.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+    
+    public ulong GetGuildId() => GuildId.ParseRequiredULong(nameof(GuildId), false);
+    public ulong GetRoleId() => RoleId.ParseRequiredULong(nameof(RoleId), false);
+    public ulong? GetCreatedByUserId() => CreatedByUserId.ParseULong(false);
+}

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveGuildModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveGuildModel.cs
@@ -11,6 +11,7 @@ public class RolePreserveGuildModel
         GuildId = "0";
         Enabled = false;
         Users = [];
+        BlacklistedRoles = [];
     }
 
     public RolePreserveGuildModel(
@@ -34,6 +35,11 @@ public class RolePreserveGuildModel
     /// Property Accessor
     /// </summary>
     public List<RolePreserveUserModel> Users { get; set; }
+    
+    /// <summary>
+    /// Property Accessor
+    /// </summary>
+    public List<RolePreserveBlacklistedRoleModel> BlacklistedRoles { get; set; }
     
     public ulong GetGuildId() => GuildId.ParseRequiredULong(nameof(GuildId), false);
 }

--- a/XeniaDiscord.Data/Models/RolePreserve/RolePreserveGuildModel.cs
+++ b/XeniaDiscord.Data/Models/RolePreserve/RolePreserveGuildModel.cs
@@ -12,6 +12,7 @@ public class RolePreserveGuildModel
         Enabled = false;
         Users = [];
         BlacklistedRoles = [];
+        AuditEntries = [];
     }
 
     public RolePreserveGuildModel(
@@ -40,6 +41,8 @@ public class RolePreserveGuildModel
     /// Property Accessor
     /// </summary>
     public List<RolePreserveBlacklistedRoleModel> BlacklistedRoles { get; set; }
+    
+    public List<RolePreserveAuditModel> AuditEntries { get; set; }
     
     public ulong GetGuildId() => GuildId.ParseRequiredULong(nameof(GuildId), false);
 }

--- a/XeniaDiscord.Data/Models/ServerLog/ServerLogEvent.cs
+++ b/XeniaDiscord.Data/Models/ServerLog/ServerLogEvent.cs
@@ -24,5 +24,8 @@ public enum ServerLogEvent
 
     RoleCreate,
     RoleEdit,
-    RoleDelete
+    RoleDelete,
+
+    // start custom stuff below
+    RolePerserve = 300
 }

--- a/XeniaDiscord.Data/Models/ServerLog/ServerLogEvent.cs
+++ b/XeniaDiscord.Data/Models/ServerLog/ServerLogEvent.cs
@@ -27,5 +27,5 @@ public enum ServerLogEvent
     RoleDelete,
 
     // start custom stuff below
-    RolePerserve = 300
+    RolePreserve = 300
 }

--- a/XeniaDiscord.Data/Models/Snapshot/DiscordSnapshotSource.cs
+++ b/XeniaDiscord.Data/Models/Snapshot/DiscordSnapshotSource.cs
@@ -9,7 +9,7 @@ public enum DiscordSnapshotSource
     UserUpdated,
     UserLeft,
     UserBanned,
-    UserUnballed,
+    UserUnbanned,
 
     RoleCreated,
     RoleUpdated,

--- a/XeniaDiscord.Data/Models/Snapshot/GuildRoleColorSnapshotModel.cs
+++ b/XeniaDiscord.Data/Models/Snapshot/GuildRoleColorSnapshotModel.cs
@@ -1,0 +1,92 @@
+﻿using Discord;
+using System.ComponentModel.DataAnnotations;
+
+namespace XeniaDiscord.Data.Models.Snapshot;
+
+public class GuildRoleColorSnapshotModel
+{
+    public const string TableName = "Snapshot_GuildRole_Color";
+
+    public GuildRoleColorSnapshotModel()
+    {
+        GuildRoleSnapshotId = Guid.Empty;
+        RoleId = "0";
+        R = 0;
+        G = 0;
+        B = 0;
+    }
+
+    public GuildRoleColorSnapshotModel(RoleColors colors) : this()
+    {
+        R = colors.PrimaryColor.R;
+        G = colors.PrimaryColor.G;
+        B = colors.PrimaryColor.B;
+        if (colors.SecondaryColor.HasValue)
+        {
+            SecondaryRed = colors.SecondaryColor.Value.R;
+            SecondaryGreen = colors.SecondaryColor.Value.G;
+            SecondaryBlue = colors.SecondaryColor.Value.B;
+        }
+        if (colors.TertiaryColor.HasValue)
+        {
+            TertiaryRed = colors.TertiaryColor.Value.R;
+            TertiaryGreen = colors.TertiaryColor.Value.G;
+            TertiaryBlue = colors.TertiaryColor.Value.B;
+        }
+    }
+
+    /// <summary>
+    /// Primary Key and Foreign Key to <see cref="GuildRoleSnapshotModel.Id"/>
+    /// </summary>
+    public Guid GuildRoleSnapshotId { get; set; }
+
+    /// <summary>
+    /// (assumed to be) Foreign Key to <see cref="Cache.GuildRoleCacheModel.RoleId"/>
+    /// Also ulong as string.
+    /// </summary>
+    [MaxLength(DbGlobals.ulongMaxLength)]
+    public string RoleId { get; set; }
+
+    public byte R { get; set; }
+    public byte G { get; set; }
+    public byte B { get; set; }
+
+    public bool IsHolographic => ToRoleColors().IsHolographic;
+    public bool IsGradient => HasSecondary && !HasTertiary;
+    public bool IsSolid => !HasSecondary && !HasTertiary;
+
+    public bool HasSecondary => SecondaryRed.HasValue && SecondaryGreen.HasValue && SecondaryBlue.HasValue;
+    public bool HasTertiary => TertiaryRed.HasValue && TertiaryGreen.HasValue && TertiaryBlue.HasValue;
+
+    public byte? SecondaryRed { get; set; }
+    public byte? SecondaryGreen { get; set; }
+    public byte? SecondaryBlue { get; set; }
+    public byte? TertiaryRed { get; set; }
+    public byte? TertiaryGreen { get; set; }
+    public byte? TertiaryBlue { get; set; }
+
+    public RoleColors ToRoleColors()
+        => new(GetPrimaryColor(), GetSecondaryColor(), GetTertiaryColor());
+
+    public Color GetPrimaryColor()
+        => new(R, G, B);
+
+    public Color? GetSecondaryColor()
+    {
+        if (HasSecondary)
+        {
+            return new Color(SecondaryRed!.Value, SecondaryGreen!.Value, SecondaryBlue!.Value);
+        }
+        return null;
+    }
+
+    public Color? GetTertiaryColor()
+    {
+        if (HasTertiary)
+        {
+            return new Color(TertiaryRed!.Value, TertiaryGreen!.Value, TertiaryBlue!.Value);
+        }
+
+        return null;
+    }
+}

--- a/XeniaDiscord.Data/Models/Snapshot/GuildRoleSnapshotModel.cs
+++ b/XeniaDiscord.Data/Models/Snapshot/GuildRoleSnapshotModel.cs
@@ -106,9 +106,27 @@ public class GuildRoleSnapshotModel
     /// Property Accessor
     /// </summary>
     public List<GuildRolePermissionSnapshotModel> Permissions { get; set; }
+    
+    /// <summary>
+    /// Property Accessor
+    /// </summary>
+    public GuildRoleColorSnapshotModel? RoleColors { get; set; }
 
     public ulong GetGuildId() => GuildId.ParseRequiredULong(nameof(GuildId), false);
     public ulong GetRoleId() => RoleId.ParseRequiredULong(nameof(RoleId), false);
+
+    public GuildPermissions ParsePermissions()
+    {
+        if (Permissions == null)
+            throw new InvalidOperationException($"{nameof(Permissions)} was not included when querying database");
+        var value = (GuildPermission)0;
+        foreach (var item in Permissions)
+        {
+            value |= item.GetValue();
+        }
+
+        return new GuildPermissions((ulong)value);
+    }
 }
 
 public enum GuildRoleSnapshotSource

--- a/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
+++ b/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
@@ -57,22 +57,31 @@ public class GuildCacheRepository
 
     public async Task UpdateRoleCache(
         XeniaDbContext db,
-        GuildRoleSnapshotModel snapshot)
+        GuildRoleSnapshotModel snapshot,
+        DateTime? now = null,
+        bool? isDeleted = null)
     {
-        var now = DateTime.UtcNow;
+        var nowValue = now.GetValueOrDefault(DateTime.UtcNow);
         var model = await db.GuildRoleCache.FindAsync(snapshot.RoleId);
         if (model == null)
         {
-            await db.GuildRoleCache.AddAsync(new GuildRoleCacheModel()
+            var cacheModel = new GuildRoleCacheModel()
             {
                 GuildId = snapshot.GuildId,
                 RoleId = snapshot.RoleId,
                 Name = snapshot.Name ?? string.Empty,
                 Position = snapshot.Position,
-                RecordCreatedAt = now,
-                RecordUpdatedAt = now,
+                RecordCreatedAt = nowValue,
+                RecordUpdatedAt = nowValue,
                 SnapshotId = snapshot.Id,
-            });
+            };
+            if (isDeleted.HasValue)
+            {
+                cacheModel.IsDeleted = isDeleted.Value;
+                if (cacheModel.IsDeleted) cacheModel.DeletedAt = nowValue;
+                else cacheModel.DeletedAt = null;
+            }
+            await db.GuildRoleCache.AddAsync(cacheModel);
             _log.Debug($"Created record (GuildId={snapshot.GuildId}, RoleId={snapshot.RoleId}, Name={snapshot.Name})");
         }
         else
@@ -81,9 +90,43 @@ public class GuildCacheRepository
                 .ExecuteUpdateAsync(e => e
                     .SetProperty(p => p.Name, snapshot.Name ?? string.Empty)
                     .SetProperty(p => p.Position, snapshot.Position)
-                    .SetProperty(p => p.RecordUpdatedAt, now)
+                    .SetProperty(p => p.RecordUpdatedAt, nowValue)
                     .SetProperty(p => p.SnapshotId, snapshot.Id));
             _log.Debug($"Updated record (GuildId={snapshot.GuildId}, RoleId={snapshot.RoleId}, Name={snapshot.Name})");
+            if (isDeleted.HasValue)
+            {
+                DateTime? deletedAtValue = isDeleted.Value ? nowValue : null;
+                await db.GuildRoleCache.Where(e => e.RoleId == snapshot.RoleId)
+                    .ExecuteUpdateAsync(e => e
+                        .SetProperty(p => p.IsDeleted, isDeleted.Value)
+                        .SetProperty(p => p.DeletedAt, deletedAtValue));
+                _log.Debug($"Marked record as deleted (GuildId={snapshot.GuildId}, RoleId={snapshot.RoleId}, Name={snapshot.Name})");
+            }
         }
+    }
+
+    public async Task<MarkRoleAsDeletedResult> MarkRoleAsDeleted(
+        XeniaDbContext db,
+        ulong roleId,
+        DateTime? deletedAt = null)
+    {
+        var roleIdStr = roleId.ToString();
+        var existing = await db.GuildRoleCache.FirstOrDefaultAsync(e => e.RoleId == roleIdStr);
+        if (existing == null) return MarkRoleAsDeletedResult.RoleNotFound; // role does not exist in cache
+        if (existing.IsDeleted) return MarkRoleAsDeletedResult.RoleAlreadyDeleted;
+        var deletedAtValue = deletedAt.GetValueOrDefault(DateTime.UtcNow);
+        await db.GuildRoleCache.Where(e => e.RoleId == roleIdStr)
+            .ExecuteUpdateAsync(e => e
+                .SetProperty(p => p.IsDeleted, true)
+                .SetProperty(p => p.DeletedAt, deletedAtValue));
+        _log.Debug($"Marked record as deleted (GuildId={existing.GuildId}, RoleId={existing.RoleId}, Name={existing.Name})");
+        return MarkRoleAsDeletedResult.Success;
+    }
+
+    public enum MarkRoleAsDeletedResult
+    {
+        Success,
+        RoleNotFound,
+        RoleAlreadyDeleted
     }
 }

--- a/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
+++ b/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
@@ -1,4 +1,5 @@
-﻿using Discord;
+﻿using CSharpFunctionalExtensions;
+using Discord;
 using Microsoft.EntityFrameworkCore;
 using NLog;
 using XeniaDiscord.Data.Models.Cache;
@@ -26,15 +27,19 @@ public class GuildCacheRepository
         };
         await InsertOrUpdate(db, model);
     }
-    
+
     
     public async Task InsertOrUpdate(
         XeniaDbContext db,
         GuildCacheModel model)
     {
-        model.RecordUpdatedAt = DateTime.UtcNow;
-        if (await db.GuildCache.AnyAsync(e => e.Id == model.Id))
+        if (await db.GuildCache.FindAsync(model.Id) != null)
         {
+            if (model.RecordCreatedAt == model.RecordUpdatedAt)
+            {
+                model.RecordUpdatedAt = DateTime.UtcNow;
+            }
+
             await db.GuildCache.Where(e => e.Id == model.Id)
                 .ExecuteUpdateAsync(e => e
                 .SetProperty(p => p.Name, model.Name)
@@ -46,13 +51,30 @@ public class GuildCacheRepository
                 .SetProperty(p => p.SplashUrl, model.SplashUrl)
                 .SetProperty(p => p.DiscoverySplashUrl, model.DiscoverySplashUrl)
                 .SetProperty(p => p.RecordUpdatedAt, model.RecordUpdatedAt));
-            _log.Debug($"Created record (Id={model.Id}, Name={model.Name})");
+            _log.Debug($"Updated record (Id={model.Id}, Name={model.Name})");
         }
         else
         {
             await db.GuildCache.AddAsync(model);
             _log.Debug($"Created record (Id={model.Id}, Name={model.Name})");
         }
+    }
+
+    public async Task Update(XeniaDbContext db, GuildCacheModel model)
+    {
+        if (await db.GuildCache.FindAsync(model.Id) == null) return;
+        await db.GuildCache.Where(e => e.Id == model.Id)
+            .ExecuteUpdateAsync(e => e
+                .SetProperty(p => p.Name, model.Name)
+                .SetProperty(p => p.OwnerUserId, model.OwnerUserId)
+                .SetProperty(p => p.CreatedAt, model.CreatedAt)
+                .SetProperty(p => p.JoinedAt, model.JoinedAt)
+                .SetProperty(p => p.IconUrl, model.IconUrl)
+                .SetProperty(p => p.BannerUrl, model.BannerUrl)
+                .SetProperty(p => p.SplashUrl, model.SplashUrl)
+                .SetProperty(p => p.DiscoverySplashUrl, model.DiscoverySplashUrl)
+                .SetProperty(p => p.RecordUpdatedAt, model.RecordUpdatedAt));
+        _log.Trace($"Updated record (Id={model.Id}, Name={model.Name})");
     }
 
     public async Task UpdateRoleCache(
@@ -103,6 +125,21 @@ public class GuildCacheRepository
                 _log.Debug($"Marked record as deleted (GuildId={snapshot.GuildId}, RoleId={snapshot.RoleId}, Name={snapshot.Name})");
             }
         }
+    }
+
+    public async Task Update(
+        XeniaDbContext db,
+        GuildRoleCacheModel model)
+    {
+        if (await db.GuildRoleCache.FindAsync(model.RoleId) == null) return;
+
+        await db.GuildRoleCache.Where(e => e.RoleId == model.RoleId)
+            .ExecuteUpdateAsync(e => e
+                .SetProperty(p => p.Name, model.Name)
+                .SetProperty(p => p.Position, model.Position)
+                .SetProperty(p => p.RecordUpdatedAt, model.RecordUpdatedAt)
+                .SetProperty(p => p.SnapshotId, model.SnapshotId));
+        _log.Debug($"Updated record (GuildId={model.GuildId}, RoleId={model.RoleId}, Name={model.Name})");
     }
 
     public async Task<MarkRoleAsDeletedResult> MarkRoleAsDeleted(

--- a/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
+++ b/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
@@ -1,7 +1,6 @@
 using CSharpFunctionalExtensions;
 using Discord;
 using Microsoft.EntityFrameworkCore;
-using MongoDB.Driver.Linq;
 using NLog;
 using XeniaDiscord.Data.Models.Cache;
 using XeniaDiscord.Data.Models.Snapshot;

--- a/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
+++ b/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
@@ -33,7 +33,7 @@ public class GuildCacheRepository
         var guildIdStr = guildId.ToString();
         var records = await db.GuildCache.AsNoTracking()
             .Where(e => e.Id == guildIdStr)
-            .Select(e => e.RecordCreatedAt)
+            .Select(e => e.RecordUpdatedAt)
             .Take(1)
             .ToArrayAsync();
         if (records.Length == 0) return Maybe.None;

--- a/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
+++ b/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
@@ -28,6 +28,17 @@ public class GuildCacheRepository
         await InsertOrUpdate(db, model);
     }
 
+    public async Task<Maybe<DateTime>> LastUpdated(XeniaDbContext db, ulong guildId)
+    {
+        var guildIdStr = guildId.ToString();
+        var records = await db.GuildCache.AsNoTracking()
+            .Where(e => e.Id == guildIdStr)
+            .Select(e => e.RecordCreatedAt)
+            .Take(1)
+            .ToArrayAsync();
+        if (records.Length == 0) return Maybe.None;
+        return records[0];
+    }
     
     public async Task InsertOrUpdate(
         XeniaDbContext db,

--- a/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
+++ b/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using NLog;
 using XeniaDiscord.Data.Models.Cache;
+using XeniaDiscord.Data.Models.Snapshot;
 
 namespace XeniaDiscord.Data.Repositories;
 
@@ -51,6 +52,38 @@ public class GuildCacheRepository
         {
             await db.GuildCache.AddAsync(model);
             _log.Debug($"Created record (Id={model.Id}, Name={model.Name})");
+        }
+    }
+
+    public async Task UpdateRoleCache(
+        XeniaDbContext db,
+        GuildRoleSnapshotModel snapshot)
+    {
+        var now = DateTime.UtcNow;
+        var model = await db.GuildRoleCache.FindAsync(snapshot.GuildId, snapshot.RoleId);
+        if (model == null)
+        {
+            await db.GuildRoleCache.AddAsync(new GuildRoleCacheModel()
+            {
+                GuildId = snapshot.GuildId,
+                RoleId = snapshot.RoleId,
+                Name = snapshot.Name ?? string.Empty,
+                Position = snapshot.Position,
+                RecordCreatedAt = now,
+                RecordUpdatedAt = now,
+                SnapshotId = snapshot.Id,
+            });
+            _log.Debug($"Created record (GuildId={snapshot.GuildId}, RoleId={snapshot.RoleId}, Name={snapshot.Name})");
+        }
+        else
+        {
+            await db.GuildRoleCache.Where(e => e.GuildId == snapshot.GuildId && e.RoleId == snapshot.RoleId)
+                .ExecuteUpdateAsync(e => e
+                    .SetProperty(p => p.Name, snapshot.Name ?? string.Empty)
+                    .SetProperty(p => p.Position, snapshot.Position)
+                    .SetProperty(p => p.RecordUpdatedAt, now)
+                    .SetProperty(p => p.SnapshotId, snapshot.Id));
+            _log.Debug($"Updated record (GuildId={snapshot.GuildId}, RoleId={snapshot.RoleId}, Name={snapshot.Name})");
         }
     }
 }

--- a/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
+++ b/XeniaDiscord.Data/Repositories/GuildCacheRepository.cs
@@ -60,7 +60,7 @@ public class GuildCacheRepository
         GuildRoleSnapshotModel snapshot)
     {
         var now = DateTime.UtcNow;
-        var model = await db.GuildRoleCache.FindAsync(snapshot.GuildId, snapshot.RoleId);
+        var model = await db.GuildRoleCache.FindAsync(snapshot.RoleId);
         if (model == null)
         {
             await db.GuildRoleCache.AddAsync(new GuildRoleCacheModel()
@@ -77,7 +77,7 @@ public class GuildCacheRepository
         }
         else
         {
-            await db.GuildRoleCache.Where(e => e.GuildId == snapshot.GuildId && e.RoleId == snapshot.RoleId)
+            await db.GuildRoleCache.Where(e => e.RoleId == snapshot.RoleId)
                 .ExecuteUpdateAsync(e => e
                     .SetProperty(p => p.Name, snapshot.Name ?? string.Empty)
                     .SetProperty(p => p.Position, snapshot.Position)

--- a/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
+++ b/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
@@ -66,6 +66,11 @@ public class RolePreserveGuildRepository
     public async Task EnableAsync(XeniaDbContext db, ulong guildId, bool enable, IUser? doneByUser = null)
     {
         var guildIdStr = guildId.ToString();
+        // return if we're not really updating anything
+        if (await db.RolePreserveGuilds.AnyAsync(e => e.GuildId == guildIdStr && e.Enabled == enable))
+        {
+            return;
+        }
         if (await db.RolePreserveGuilds.AnyAsync(e => e.GuildId == guildIdStr))
         {
             await db.RolePreserveGuilds

--- a/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
+++ b/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
@@ -71,7 +71,7 @@ public class RolePreserveGuildRepository
             await db.RolePreserveGuilds
                 .Where(e => e.GuildId == guildIdStr)
                 .ExecuteUpdateAsync(e => e
-                .SetProperty(p => p.Enabled, enable));
+                    .SetProperty(p => p.Enabled, enable));
             _log.Trace($"Updated Record (GuildId={guildIdStr}, Enabled={enable}");
         }
         else
@@ -185,7 +185,148 @@ public class RolePreserveGuildRepository
             TargetRoleId = roleIdStr
         });
         return RoleBlacklistRemoveResult.Ok;
+    }
 
+    public async Task<RoleBlacklistRemoveResult> RoleBlacklistAddRange(
+        XeniaDbContext db,
+        ulong guildId,
+        ulong[] roleIds,
+        IUser? doneByUser = null,
+        DateTime? now = null)
+    {
+        roleIds = [.. roleIds.Distinct().Where(e => e > 0)];
+        
+        if (roleIds.Length == 0) return RoleBlacklistRemoveResult.Ok;
+        
+        var guildIdStr = guildId.ToString();
+        var nowValue = now.GetValueOrDefault(DateTime.UtcNow);
+        var roleIdStrs = roleIds.Select(e => e.ToString()).ToArray();
+        
+        var existing = await db.RolePreserveBlacklistedRoles
+            .Where(e => ((IEnumerable<string>)roleIdStrs).Contains(e.RoleId))
+            .Select(e => e.RoleId)
+            .ToArrayAsync();
+
+        var addRange = new List<RolePreserveBlacklistedRoleModel>();
+        var addedRoles = new HashSet<string>();
+        foreach (var roleId in roleIds.Select(e => e.ToString()))
+        {
+            if (existing.Contains(roleId)) continue;
+            if (addedRoles.Add(roleId))
+            {
+                addRange.Add(new RolePreserveBlacklistedRoleModel()
+                {
+                    GuildId = guildIdStr,
+                    RoleId = roleId,
+                    CreatedByUserId = doneByUser?.Id.ToString(),
+                    CreatedAt = nowValue
+                });
+            }
+        }
+
+        await db.AddRangeAsync(addRange);
+
+        await AuditAddRange(
+            db,
+            guildId,
+            roleIds,
+            RolePreserveAuditAction.BlacklistAdd,
+            doneByUser?.Id,
+            null,
+            now);
+        return RoleBlacklistRemoveResult.Ok;
+    }
+    public async Task<RoleBlacklistRemoveResult> RoleBlacklistRemoveRange(
+        XeniaDbContext db,
+        ulong guildId,
+        ulong[] roleIds,
+        IUser? doneByUser = null,
+        DateTime? now = null)
+    {
+        roleIds = [.. roleIds.Distinct().Where(e => e > 0)];
+
+        if (roleIds.Length == 0) return RoleBlacklistRemoveResult.Ok;
+        
+        var roleIdStrs = roleIds.Select(e => e.ToString()).ToArray();
+        object[] existing = await db.RolePreserveBlacklistedRoles
+            .Where(e => ((IEnumerable<string>)roleIdStrs).Contains(e.RoleId))
+            .ToArrayAsync();
+        
+        if (existing.Length == 0) return RoleBlacklistRemoveResult.NotFound;
+        
+        db.RemoveRange(existing);
+
+        await AuditAddRange(
+            db,
+            guildId,
+            roleIds,
+            RolePreserveAuditAction.BlacklistRemove,
+            doneByUser?.Id,
+            null,
+            now);
+
+        return RoleBlacklistRemoveResult.Ok;
+    }
+
+    private async Task<RolePreserveAuditModel?> AuditAddRange(
+        XeniaDbContext db,
+        ulong guildId,
+        ulong[] roleIds,
+        RolePreserveAuditAction action,
+        ulong? userId,
+        ulong? targetUserId,
+        DateTime? now = null,
+        Dictionary<ulong, (RolePreserveAuditAppliedRoleAction AppliedAction, string? ExceptionText)>? appliedRolesDict = null)
+    {
+        roleIds = [.. roleIds.Distinct().Where(e => e > 0)];
+        if ((action == RolePreserveAuditAction.AppliedRoles ||
+             action == RolePreserveAuditAction.BlacklistAdd ||
+             action == RolePreserveAuditAction.BlacklistRemove)
+            && roleIds.Length == 0) return null;
+
+        var nowValue = now.GetValueOrDefault(DateTime.UtcNow);
+        var model = new RolePreserveAuditModel
+        {
+            GuildId = guildId.ToString(),
+            Action = action,
+            UserId = userId?.ToString(),
+            TargetUserId = targetUserId?.ToString(),
+            RecordCreatedAt = nowValue
+        };
+        if (action == RolePreserveAuditAction.AppliedRoles)
+        {
+            foreach (var roleId in roleIds)
+            {
+                var item = new RolePreserveAuditAppliedRoleModel
+                {
+                    RolePreserveAuditId = model.Id,
+                    RoleId = roleId.ToString(),
+                };
+                if (appliedRolesDict?.TryGetValue(roleId, out var rs) == true)
+                {
+                    item.Action = rs.AppliedAction;
+                    item.ExceptionText = rs.ExceptionText;
+                }
+                model.AppliedRoles.Add(item);
+            }
+        }
+        else if (roleIds.Length == 1)
+        {
+            model.TargetRoleId = roleIds[0].ToString();
+        }
+        else if (roleIds.Length > 1)
+        {
+            model.ReferencedRoles.AddRange(roleIds
+                .Distinct()
+                .Select(e => new RolePreserveAuditReferencedRoleModel
+                {
+                    RolePreserveAuditId = model.Id,
+                    RoleId = e.ToString(),
+                }));
+        }
+
+        await db.AddAsync(model);
+        return model;
     }
 
     public enum RoleBlacklistRemoveResult

--- a/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
+++ b/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
@@ -107,12 +107,16 @@ public class RolePreserveGuildRepository
             .ToListAsync();
     }
 
-    public async Task RoleBlacklistAdd(
+    public async Task<RoleBlacklistAddResult> RoleBlacklistAdd(
         XeniaDbContext db,
         IGuild guild,
         IRole role,
         IGuildUser? doneByUser = null)
     {
+        if (guild.Id != role.Guild.Id)
+        {
+            return RoleBlacklistAddResult.GuildMismatch;
+        }
         var guildIdStr = guild.Id.ToString();
         var roleIdStr = role.Id.ToString();
         if (await db.RolePreserveGuilds.FindAsync(guildIdStr) == null)
@@ -127,7 +131,7 @@ public class RolePreserveGuildRepository
         // already exists
         if (await db.RolePreserveBlacklistedRoles.FindAsync(guildIdStr, roleIdStr) != null)
         {
-            return;
+            return RoleBlacklistAddResult.AlreadyExists;
         }
 
         await db.RolePreserveBlacklistedRoles.AddAsync(new RolePreserveBlacklistedRoleModel()
@@ -136,9 +140,17 @@ public class RolePreserveGuildRepository
             RoleId = roleIdStr,
             CreatedByUserId = doneByUser?.Id.ToString()
         });
+        return RoleBlacklistAddResult.Ok;
     }
 
-    public async Task RoleBlacklistRemove(
+    public enum RoleBlacklistAddResult
+    {
+        Ok,
+        AlreadyExists,
+        GuildMismatch
+    }
+
+    public async Task<RoleBlacklistRemoveResult> RoleBlacklistRemove(
         XeniaDbContext db,
         ulong guildId,
         ulong roleId)
@@ -146,10 +158,17 @@ public class RolePreserveGuildRepository
         var guildIdStr = guildId.ToString();
         var roleIdStr = roleId.ToString();
         var target = await db.RolePreserveBlacklistedRoles.FindAsync(guildIdStr, roleIdStr);
-        if (target != null)
-        {
-            db.Remove(target);
-        }
+        if (target == null) return RoleBlacklistRemoveResult.NotFound;
+        
+        db.Remove(target);
+        return RoleBlacklistRemoveResult.Ok;
+
+    }
+
+    public enum RoleBlacklistRemoveResult
+    {
+        Ok,
+        NotFound
     }
 
     public Task EnableAsync(XeniaDbContext db, ulong guildId)

--- a/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
+++ b/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Discord;
+using Microsoft.EntityFrameworkCore;
 using NLog;
 using XeniaDiscord.Data.Models.RolePreserve;
 
@@ -81,6 +82,73 @@ public class RolePreserveGuildRepository
                 Enabled = enable
             });
             _log.Trace($"Created Record (GuildId={guildIdStr}, Enabled={enable}");
+        }
+    }
+
+    public async Task<List<RolePreserveBlacklistedRoleModel>> GetBlacklistedRoles(
+        XeniaDbContext db)
+    {
+        return await db.RolePreserveBlacklistedRoles
+            .AsNoTracking()
+            .OrderBy(e => e.GuildId)
+            .ThenBy(e => e.RoleId)
+            .ToListAsync();
+    }
+
+    public async Task<List<RolePreserveBlacklistedRoleModel>> GetBlacklistRolesForGuild(
+        XeniaDbContext db,
+        ulong guildId)
+    {
+        var guildIdStr = guildId.ToString();
+        return await db.RolePreserveBlacklistedRoles
+            .AsNoTracking()
+            .Where(e => e.GuildId == guildIdStr)
+            .OrderBy(e => e.RoleId)
+            .ToListAsync();
+    }
+
+    public async Task RoleBlacklistAdd(
+        XeniaDbContext db,
+        IGuild guild,
+        IRole role,
+        IGuildUser? doneByUser = null)
+    {
+        var guildIdStr = guild.Id.ToString();
+        var roleIdStr = role.Id.ToString();
+        if (await db.RolePreserveGuilds.FindAsync(guildIdStr) == null)
+        {
+            await db.RolePreserveGuilds.AddAsync(new RolePreserveGuildModel
+            {
+                GuildId = guildIdStr,
+                Enabled = false
+            });
+        }
+
+        // already exists
+        if (await db.RolePreserveBlacklistedRoles.FindAsync(guildIdStr, roleIdStr) != null)
+        {
+            return;
+        }
+
+        await db.RolePreserveBlacklistedRoles.AddAsync(new RolePreserveBlacklistedRoleModel()
+        {
+            GuildId = guildIdStr,
+            RoleId = roleIdStr,
+            CreatedByUserId = doneByUser?.Id.ToString()
+        });
+    }
+
+    public async Task RoleBlacklistRemove(
+        XeniaDbContext db,
+        ulong guildId,
+        ulong roleId)
+    {
+        var guildIdStr = guildId.ToString();
+        var roleIdStr = roleId.ToString();
+        var target = await db.RolePreserveBlacklistedRoles.FindAsync(guildIdStr, roleIdStr);
+        if (target != null)
+        {
+            db.Remove(target);
         }
     }
 

--- a/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
+++ b/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
@@ -102,6 +102,10 @@ public class RolePreserveGuildRepository
             .ToListAsync();
     }
 
+    public Task<List<RolePreserveBlacklistedRoleModel>> GetBlacklistRolesForGuild(
+        XeniaDbContext db,
+        IGuild guild)
+        => GetBlacklistRolesForGuild(db, guild.Id);
     public async Task<List<RolePreserveBlacklistedRoleModel>> GetBlacklistRolesForGuild(
         XeniaDbContext db,
         ulong guildId)
@@ -165,11 +169,18 @@ public class RolePreserveGuildRepository
         GuildMismatch
     }
 
+    public Task<RoleBlacklistRemoveResult> RoleBlacklistRemove(
+        XeniaDbContext db,
+        IGuild guild,
+        ulong roleId,
+        IUser? doneByUser = null)
+        => RoleBlacklistRemove(db, guild.Id, roleId, doneByUser);
+
     public async Task<RoleBlacklistRemoveResult> RoleBlacklistRemove(
         XeniaDbContext db,
         ulong guildId,
         ulong roleId,
-        IGuildUser? doneByUser = null)
+        IUser? doneByUser = null)
     {
         var guildIdStr = guildId.ToString();
         var roleIdStr = roleId.ToString();
@@ -248,6 +259,8 @@ public class RolePreserveGuildRepository
         if (roleIds.Length == 0) return RoleBlacklistRemoveResult.Ok;
         
         var roleIdStrs = roleIds.Select(e => e.ToString()).ToArray();
+        
+        // "object[]" is done to keep "db.RemoveRange" happy
         object[] existing = await db.RolePreserveBlacklistedRoles
             .Where(e => ((IEnumerable<string>)roleIdStrs).Contains(e.RoleId))
             .ToArrayAsync();

--- a/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
+++ b/XeniaDiscord.Data/Repositories/RolePreserveGuildRepository.cs
@@ -63,7 +63,7 @@ public class RolePreserveGuildRepository
         }
     }
 
-    public async Task EnableAsync(XeniaDbContext db, ulong guildId, bool enable)
+    public async Task EnableAsync(XeniaDbContext db, ulong guildId, bool enable, IUser? doneByUser = null)
     {
         var guildIdStr = guildId.ToString();
         if (await db.RolePreserveGuilds.AnyAsync(e => e.GuildId == guildIdStr))
@@ -83,6 +83,13 @@ public class RolePreserveGuildRepository
             });
             _log.Trace($"Created Record (GuildId={guildIdStr}, Enabled={enable}");
         }
+        var userIdStr = doneByUser?.Id.ToString();
+        await db.RolePreserveAudit.AddAsync(new RolePreserveAuditModel()
+        {
+            GuildId = guildIdStr,
+            Action = enable ? RolePreserveAuditAction.Enable : RolePreserveAuditAction.Disable,
+            UserId = userIdStr
+        });
     }
 
     public async Task<List<RolePreserveBlacklistedRoleModel>> GetBlacklistedRoles(
@@ -134,11 +141,19 @@ public class RolePreserveGuildRepository
             return RoleBlacklistAddResult.AlreadyExists;
         }
 
+        var userIdStr = doneByUser?.Id.ToString();
         await db.RolePreserveBlacklistedRoles.AddAsync(new RolePreserveBlacklistedRoleModel()
         {
             GuildId = guildIdStr,
             RoleId = roleIdStr,
-            CreatedByUserId = doneByUser?.Id.ToString()
+            CreatedByUserId = userIdStr
+        });
+        await db.RolePreserveAudit.AddAsync(new RolePreserveAuditModel()
+        {
+            GuildId = guildIdStr,
+            Action = RolePreserveAuditAction.BlacklistAdd,
+            UserId = userIdStr,
+            TargetRoleId = roleIdStr
         });
         return RoleBlacklistAddResult.Ok;
     }
@@ -153,14 +168,22 @@ public class RolePreserveGuildRepository
     public async Task<RoleBlacklistRemoveResult> RoleBlacklistRemove(
         XeniaDbContext db,
         ulong guildId,
-        ulong roleId)
+        ulong roleId,
+        IGuildUser? doneByUser = null)
     {
         var guildIdStr = guildId.ToString();
         var roleIdStr = roleId.ToString();
         var target = await db.RolePreserveBlacklistedRoles.FindAsync(guildIdStr, roleIdStr);
         if (target == null) return RoleBlacklistRemoveResult.NotFound;
-        
+        var userIdStr = doneByUser?.Id.ToString();
         db.Remove(target);
+        await db.RolePreserveAudit.AddAsync(new RolePreserveAuditModel()
+        {
+            GuildId = guildIdStr,
+            Action = RolePreserveAuditAction.BlacklistRemove,
+            UserId = userIdStr,
+            TargetRoleId = roleIdStr
+        });
         return RoleBlacklistRemoveResult.Ok;
 
     }

--- a/XeniaDiscord.Data/Repositories/RolePreserveUserRepository.cs
+++ b/XeniaDiscord.Data/Repositories/RolePreserveUserRepository.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Discord;
+using Microsoft.EntityFrameworkCore;
 using NLog;
 using XeniaDiscord.Data.Models.RolePreserve;
 using XeniaDiscord.Data.Models.Snapshot;
@@ -8,7 +9,21 @@ namespace XeniaDiscord.Data.Repositories;
 public class RolePreserveUserRepository
 {
     private readonly Logger _log = LogManager.GetCurrentClassLogger();
-    
+
+    #region GetAsync
+    public Task<RolePreserveUserModel?> GetAsync(
+        XeniaDbContext db,
+        IGuildUser member,
+        QueryOptions? options = null)
+        => GetAsync(db, member.GuildId, member.Id, options);
+
+    public Task<RolePreserveUserModel?> GetAsync(
+        XeniaDbContext db,
+        IGuild guild,
+        IUser user,
+        QueryOptions? options = null)
+        => GetAsync(db, guild.Id, user.Id, options);
+
     public async Task<RolePreserveUserModel?> GetAsync(
         XeniaDbContext db,
         ulong guildId,
@@ -21,6 +36,7 @@ public class RolePreserveUserRepository
             .AsNoTracking()
             .FirstOrDefaultAsync(e => e.GuildId == guildIdStr && e.UserId == userIdStr);
     }
+    #endregion
 
     public async Task InsertOrUpdate(
         XeniaDbContext db,
@@ -77,7 +93,7 @@ public class RolePreserveUserRepository
 
         await db.RolePreserveUserRoles
             .AsNoTracking()
-            .Where(e => e.GuildId == guildIdStr && e.UserId == userIdStr && delete.Contains(e.RoleId))
+            .Where(e => e.GuildId == guildIdStr && e.UserId == userIdStr && ((IEnumerable<string>)delete).Contains(e.RoleId))
             .ExecuteDeleteAsync();
         await db.RolePreserveUserRoles.AddRangeAsync(
             add.Select(roleIdStr => new RolePreserveUserRoleModel

--- a/XeniaDiscord.Data/Repositories/ServerLogRepository.cs
+++ b/XeniaDiscord.Data/Repositories/ServerLogRepository.cs
@@ -510,6 +510,7 @@ public class ServerLogRepository
         }
         if (options.IgnoreDisabledGuilds)
         {
+            if (!options.IncludeServerLogGuild) q = q.Include(e => e.ServerLogGuild);
             q = q.Where(e => e.ServerLogGuild.Enabled);
         }
         return q.AsNoTracking();

--- a/XeniaDiscord.Data/Repositories/ServerLogRepository.cs
+++ b/XeniaDiscord.Data/Repositories/ServerLogRepository.cs
@@ -24,11 +24,16 @@ public class ServerLogRepository
         _discordClient = services.GetRequiredService<DiscordSocketClient>();
     }
 
+    public Task<bool> IsEnabled(IGuild guild)
+        => IsEnabled(guild.Id);
     public async Task<bool> IsEnabled(ulong guildId)
     {
         await using var db = _db.CreateSession();
         return await IsEnabled(db, guildId);
     }
+
+    public Task<bool> IsEnabled(XeniaDbContext db, IGuild guild)
+        => IsEnabled(db, guild.Id);
     public async Task<bool> IsEnabled(XeniaDbContext db, ulong guildId)
     {
         var guildIdStr = guildId.ToString();
@@ -37,11 +42,21 @@ public class ServerLogRepository
         return model?.Enabled != false;
     }
 
+    public Task<ServerLogGuildModel?> GetGuild(
+        IGuild guild,
+        GuildQueryOptions? options = null)
+        => GetGuild(guild.Id, options);
     public async Task<ServerLogGuildModel?> GetGuild(ulong guildId, GuildQueryOptions? options = null)
     {
         await using var db = _db.CreateSession();
         return await GetGuild(db, guildId, options);
     }
+
+    public Task<ServerLogGuildModel?> GetGuild(
+        XeniaDbContext db,
+        IGuild guild,
+        GuildQueryOptions? options = null)
+        => GetGuild(db, guild.Id, options);
     public async Task<ServerLogGuildModel?> GetGuild(
         XeniaDbContext db,
         ulong guildId,
@@ -63,6 +78,11 @@ public class ServerLogRepository
             .FirstOrDefaultAsync();
     }
 
+    public Task<IReadOnlyCollection<ServerLogChannelModel>> GetChannelsForGuild(
+        XeniaDbContext db,
+        IGuild guild,
+        ChannelQueryOptions? options = null)
+        => GetChannelsForGuild(db, guild.Id, options);
     public async Task<IReadOnlyCollection<ServerLogChannelModel>> GetChannelsForGuild(
         XeniaDbContext db,
         ulong guildId,
@@ -75,6 +95,12 @@ public class ServerLogRepository
         return await Apply(query, options)
             .ToListAsync();
     }
+
+    public Task<IReadOnlyCollection<ServerLogChannelModel>> GetChannelsForGuild(
+        IGuild guild,
+        ulong channelId,
+        ChannelQueryOptions? options = null)
+        => GetChannelsForGuild(guild.Id, channelId, options);
     public async Task<IReadOnlyCollection<ServerLogChannelModel>> GetChannelsForGuild(
         ulong guildId,
         ulong channelId,
@@ -83,6 +109,13 @@ public class ServerLogRepository
         await using var db = _db.CreateSession();
         return await GetChannelsForGuild(db, guildId, channelId, options);
     }
+
+    public Task<IReadOnlyCollection<ServerLogChannelModel>> GetChannelsForGuild(
+        XeniaDbContext db,
+        IGuild guild,
+        ulong channelId,
+        ChannelQueryOptions? options = null)
+        => GetChannelsForGuild(db, guild.Id, channelId, options);
     public async Task<IReadOnlyCollection<ServerLogChannelModel>> GetChannelsForGuild(
         XeniaDbContext db,
         ulong guildId,
@@ -97,6 +130,7 @@ public class ServerLogRepository
     }
     public async Task<IReadOnlyCollection<ServerLogChannelModel>> GetChannelsForGuild(ulong guildId, ServerLogEvent[] events, ChannelQueryOptions? options = null)
     {
+        if (events.Length == 0) return [];
         await using var db = _db.CreateSession();
         return await GetChannelsForGuild(db, guildId, events, options);
     }
@@ -106,6 +140,7 @@ public class ServerLogRepository
         ServerLogEvent[] events,
         ChannelQueryOptions? options = null)
     {
+        if (events.Length == 0) return [];
         var guildIdStr = guildId.ToString();
         var eventsSet = events.ToHashSet();
         var query = db.ServerLogChannels

--- a/XeniaDiscord.Data/Services/DatabaseMigrationService.cs
+++ b/XeniaDiscord.Data/Services/DatabaseMigrationService.cs
@@ -15,7 +15,7 @@ public class DatabaseMigrationService : BaseService
         _err = services.GetRequiredService<ErrorReportService>();
     }
 
-    private bool hasInitialized = false;
+    private bool _hasInitialized = false;
 
     /// <inheritdoc/>
     /// <remarks>
@@ -24,7 +24,7 @@ public class DatabaseMigrationService : BaseService
     /// </remarks>
     public override async Task InitializeAsync()
     {
-        if (hasInitialized) return;
+        if (_hasInitialized) return;
 
         new Thread(() =>
         {
@@ -38,14 +38,14 @@ public class DatabaseMigrationService : BaseService
             }
             finally
             {
-                hasInitialized = true;
+                _hasInitialized = true;
             }
         })
         {
             Name = $"Xenia.{nameof(DatabaseMigrationService)}.{nameof(InitializeAsync)}"
         }.Start();
 
-        while (!hasInitialized) await Task.Delay(500);
+        while (!_hasInitialized) await Task.Delay(500);
     }
 
     private async Task InitializeThread()
@@ -58,7 +58,7 @@ public class DatabaseMigrationService : BaseService
         if (migrationsArray.Length < 1)
         {
             _log.Info("No pending migrations");
-            hasInitialized = true;
+            _hasInitialized = true;
             return;
         }
 
@@ -69,11 +69,11 @@ public class DatabaseMigrationService : BaseService
         {
             await db.Database.MigrateAsync();
             await db.SaveChangesAsync();
-            hasInitialized = true;
+            _hasInitialized = true;
         }
         catch (Exception ex)
         {
-            hasInitialized = true;
+            _hasInitialized = true;
             var msg = $"Failed to apply {migrationCount} migration(s)";
             _log.Error(ex, msg);
             await _err.Submit(new ErrorReportBuilder()

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
 using XeniaDiscord.Data.Extensions;
 using XeniaDiscord.Data.Models;
 using XeniaDiscord.Data.Models.BanSync;
@@ -11,6 +12,7 @@ using XeniaDiscord.Data.Models.Snapshot;
 
 namespace XeniaDiscord.Data;
 
+[UsedImplicitly]
 public class XeniaDbContext : DbContext
 {
     private readonly DbContextOptions<XeniaDbContext> _ops;

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -36,6 +36,7 @@ public class XeniaDbContext : DbContext
     public DbSet<GuildSnapshotModel> GuildSnapshots { get; set; }
     public DbSet<GuildRoleSnapshotModel> GuildRoleSnapshots { get; set; }
     public DbSet<GuildRolePermissionSnapshotModel> GuildRolePermissionSnapshots { get; set; }
+    public DbSet<GuildRoleColorSnapshotModel> GuildRoleColorSnapshots { get; set; }
 
     public DbSet<GuildSnapshotEventModel> GuildSnapshotEvent { get; set; }
 
@@ -129,6 +130,10 @@ public class XeniaDbContext : DbContext
             b.HasMany(e => e.Permissions)
              .WithOne()
              .HasForeignKey(e => e.GuildRoleSnapshotId);
+            b.HasOne(e => e.RoleColors)
+                .WithOne()
+                .HasForeignKey<GuildRoleColorSnapshotModel>(e => e.GuildRoleSnapshotId)
+                .OnDelete(DeleteBehavior.SetNull);
         });
         builder.Entity<GuildRolePermissionSnapshotModel>(b =>
         {
@@ -141,6 +146,11 @@ public class XeniaDbContext : DbContext
                 e.GuildId,
                 e.RoleId
             }).IsDescending();
+        });
+        builder.Entity<GuildRoleColorSnapshotModel>(b =>
+        {
+            b.ToTable(GuildRoleColorSnapshotModel.TableName)
+                .HasKey(e => e.GuildRoleSnapshotId);
         });
         builder.Entity<GuildMemberSnapshotModel>(b =>
         {

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -65,6 +65,7 @@ public class XeniaDbContext : DbContext
     public DbSet<RolePreserveUserModel> RolePreserveUsers { get; set; }
     public DbSet<RolePreserveUserRoleModel> RolePreserveUserRoles { get; set; }
     public DbSet<RolePreserveBlacklistedRoleModel> RolePreserveBlacklistedRoles { get; set; }
+    public DbSet<RolePreserveAuditModel> RolePreserveAudit { get; set; }
     #endregion
     
     public DbSet<GuildApprovalModel> GuildApprovals { get; set; }
@@ -401,6 +402,24 @@ public class XeniaDbContext : DbContext
                     e.GuildId,
                     e.RoleId
                 });
+        });
+        builder.Entity<RolePreserveAuditModel>(b =>
+        {
+            b.ToTable(RolePreserveAuditModel.TableName)
+                .HasKey(e => e.Id);
+            b.HasIndex(e => new
+            {
+                e.RecordCreatedAt,
+                e.GuildId
+            });
+            b.HasIndex(e => new
+            {
+                e.RecordCreatedAt,
+                e.GuildId,
+                e.UserId,
+                e.TargetUserId,
+                e.TargetRoleId
+            });
         });
         #endregion
         

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -64,6 +64,7 @@ public class XeniaDbContext : DbContext
     public DbSet<RolePreserveGuildModel> RolePreserveGuilds { get; set; }
     public DbSet<RolePreserveUserModel> RolePreserveUsers { get; set; }
     public DbSet<RolePreserveUserRoleModel> RolePreserveUserRoles { get; set; }
+    public DbSet<RolePreserveBlacklistedRoleModel> RolePreserveBlacklistedRoles { get; set; }
     #endregion
     
     public DbSet<GuildApprovalModel> GuildApprovals { get; set; }
@@ -368,6 +369,11 @@ public class XeniaDbContext : DbContext
                 .WithOne(e => e.RolePreserveGuild)
                 .HasForeignKey(e => e.GuildId)
                 .IsRequired();
+
+            b.HasMany(e => e.BlacklistedRoles)
+                .WithOne()
+                .HasForeignKey(e => e.GuildId)
+                .IsRequired();
         });
         builder.Entity<RolePreserveUserModel>(b =>
         {
@@ -386,6 +392,15 @@ public class XeniaDbContext : DbContext
                 e.UserId,
                 e.RoleId
             });
+        });
+        builder.Entity<RolePreserveBlacklistedRoleModel>(b =>
+        {
+            b.ToTable(RolePreserveBlacklistedRoleModel.TableName)
+                .HasKey(e => new
+                {
+                    e.GuildId,
+                    e.RoleId
+                });
         });
         #endregion
         

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -466,11 +466,23 @@ public class XeniaDbContext : DbContext
         {
             b.ToTable(RolePreserveAuditAppliedRoleModel.TableName)
                 .HasKey(e => new { e.RolePreserveAuditId, e.RoleId });
+            
+            b.HasOne(e => e.Role)
+                .WithMany()
+                .HasForeignKey(e => e.RoleId)
+                .OnDelete(DeleteBehavior.NoAction)
+                .IsRequired(false);
         });
         builder.Entity<RolePreserveAuditReferencedRoleModel>(b =>
         {
             b.ToTable(RolePreserveAuditReferencedRoleModel.TableName)
                 .HasKey(e => new { e.RolePreserveAuditId, e.RoleId });
+
+            b.HasOne(e => e.Role)
+                .WithMany()
+                .HasForeignKey(e => e.RoleId)
+                .OnDelete(DeleteBehavior.NoAction)
+                .IsRequired(false);
         });
         #endregion
         

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -258,6 +258,7 @@ public class XeniaDbContext : DbContext
             b.ToTable(GuildRoleCacheModel.TableName)
                 .HasKey(e => e.RoleId);
             b.HasIndex(e => e.GuildId);
+            b.HasIndex(e => new { e.GuildId, e.Position }).IsDescending(false);
             b.HasOne(e => e.Snapshot)
                 .WithMany()
                 .HasForeignKey(e => e.SnapshotId)

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -258,7 +258,7 @@ public class XeniaDbContext : DbContext
             b.ToTable(GuildRoleCacheModel.TableName)
                 .HasKey(e => e.RoleId);
             b.HasIndex(e => e.GuildId);
-            b.HasIndex(e => new { e.GuildId, e.Position }).IsDescending(false);
+            b.HasIndex(e => e.Position);
             b.HasOne(e => e.Snapshot)
                 .WithMany()
                 .HasForeignKey(e => e.SnapshotId)

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -45,6 +45,7 @@ public class XeniaDbContext : DbContext
     public DbSet<GuildChannelCacheModel> GuildChannelCache { get; set; }
     public DbSet<GuildMemberCacheModel> GuildMemberCache { get; set; }
     public DbSet<GuildCacheModel> GuildCache { get; set; }
+    public DbSet<GuildRoleCacheModel> GuildRoleCache { get; set; }
     public DbSet<UserCacheModel> UserCache { get; set; }
     public DbSet<AuditLogBanCacheModel> AuditLogBanEntryCache { get; set; }
     #endregion
@@ -66,6 +67,7 @@ public class XeniaDbContext : DbContext
     public DbSet<RolePreserveUserRoleModel> RolePreserveUserRoles { get; set; }
     public DbSet<RolePreserveBlacklistedRoleModel> RolePreserveBlacklistedRoles { get; set; }
     public DbSet<RolePreserveAuditModel> RolePreserveAudit { get; set; }
+    public DbSet<RolePreserveAuditAppliedRoleModel> RolePreserveAuditAppliedRoles { get; set; }
     #endregion
     
     public DbSet<GuildApprovalModel> GuildApprovals { get; set; }
@@ -251,6 +253,16 @@ public class XeniaDbContext : DbContext
             .HasForeignKey(e => e.GuildId)
             .IsRequired();
         });
+        builder.Entity<GuildRoleCacheModel>(b =>
+        {
+            b.ToTable(GuildRoleCacheModel.TableName)
+                .HasKey(e => e.RoleId);
+            b.HasIndex(e => e.GuildId);
+            b.HasOne(e => e.Snapshot)
+                .WithMany()
+                .HasForeignKey(e => e.SnapshotId)
+                .IsRequired();
+        });
         builder.Entity<GuildChannelCacheModel>(b =>
         {
             b.ToTable(GuildChannelCacheModel.TableName)
@@ -362,6 +374,8 @@ public class XeniaDbContext : DbContext
         #endregion
 
         #region Role Preserve
+        builder.HasPostgresEnum<RolePreserveAuditAction>();
+        builder.HasPostgresEnum<RolePreserveAuditAppliedRoleAction>();
         builder.Entity<RolePreserveGuildModel>(b =>
         {
             b.ToTable(RolePreserveGuildModel.TableName).HasKey(e => e.GuildId);
@@ -425,6 +439,15 @@ public class XeniaDbContext : DbContext
                 e.TargetUserId,
                 e.TargetRoleId
             });
+            b.HasMany(e => e.AppliedRoles)
+                .WithOne()
+                .HasForeignKey(e => e.RolePreserveAuditId)
+                .IsRequired();
+        });
+        builder.Entity<RolePreserveAuditAppliedRoleModel>(b =>
+        {
+            b.ToTable(RolePreserveAuditAppliedRoleModel.TableName)
+                .HasKey(e => new { e.RolePreserveAuditId, e.RoleId });
         });
         #endregion
         

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -71,8 +71,9 @@ public class XeniaDbContext : DbContext
     public DbSet<RolePreserveBlacklistedRoleModel> RolePreserveBlacklistedRoles { get; set; }
     public DbSet<RolePreserveAuditModel> RolePreserveAudit { get; set; }
     public DbSet<RolePreserveAuditAppliedRoleModel> RolePreserveAuditAppliedRoles { get; set; }
+    public DbSet<RolePreserveAuditReferencedRoleModel> RolePreserveAuditReferencedRoles { get; set; }
     #endregion
-    
+
     public DbSet<GuildApprovalModel> GuildApprovals { get; set; }
     public DbSet<GuildApprovalLogEventModel> GuildApprovalLogEvents { get; set; }
 
@@ -456,10 +457,19 @@ public class XeniaDbContext : DbContext
                 .WithOne()
                 .HasForeignKey(e => e.RolePreserveAuditId)
                 .IsRequired();
+            b.HasMany(e => e.ReferencedRoles)
+                .WithOne()
+                .HasForeignKey(e => e.RolePreserveAuditId)
+                .IsRequired();
         });
         builder.Entity<RolePreserveAuditAppliedRoleModel>(b =>
         {
             b.ToTable(RolePreserveAuditAppliedRoleModel.TableName)
+                .HasKey(e => new { e.RolePreserveAuditId, e.RoleId });
+        });
+        builder.Entity<RolePreserveAuditReferencedRoleModel>(b =>
+        {
+            b.ToTable(RolePreserveAuditReferencedRoleModel.TableName)
                 .HasKey(e => new { e.RolePreserveAuditId, e.RoleId });
         });
         #endregion

--- a/XeniaDiscord.Data/XeniaDbContext.cs
+++ b/XeniaDiscord.Data/XeniaDbContext.cs
@@ -375,24 +375,30 @@ public class XeniaDbContext : DbContext
                 .WithOne()
                 .HasForeignKey(e => e.GuildId)
                 .IsRequired();
+            
+            b.HasMany(e => e.AuditEntries)
+                .WithOne()
+                .HasForeignKey(e => e.GuildId)
+                .IsRequired();
         });
         builder.Entity<RolePreserveUserModel>(b =>
         {
             b.ToTable(RolePreserveUserModel.TableName).HasKey(e => new { e.GuildId, e.UserId });
 
             b.HasMany(e => e.Roles)
-             .WithOne()
-             .HasForeignKey(e => new { e.GuildId, e.UserId })
-             .IsRequired();
+                .WithOne()
+                .HasForeignKey(e => new { e.GuildId, e.UserId })
+                .IsRequired();
         });
         builder.Entity<RolePreserveUserRoleModel>(b =>
         {
-            b.ToTable(RolePreserveUserRoleModel.TableName).HasKey(e => new
-            {
-                e.GuildId,
-                e.UserId,
-                e.RoleId
-            });
+            b.ToTable(RolePreserveUserRoleModel.TableName)
+                .HasKey(e => new
+                {
+                    e.GuildId,
+                    e.UserId,
+                    e.RoleId
+                });
         });
         builder.Entity<RolePreserveBlacklistedRoleModel>(b =>
         {
@@ -405,8 +411,7 @@ public class XeniaDbContext : DbContext
         });
         builder.Entity<RolePreserveAuditModel>(b =>
         {
-            b.ToTable(RolePreserveAuditModel.TableName)
-                .HasKey(e => e.Id);
+            b.ToTable(RolePreserveAuditModel.TableName).HasKey(e => e.Id);
             b.HasIndex(e => new
             {
                 e.RecordCreatedAt,
@@ -467,12 +472,13 @@ public class XeniaDbContext : DbContext
         });
         #endregion
         
-        builder.HasDbFunction(typeof(XeniaDbContext).GetMethod(nameof(spBanSyncGetMutualRecordsForGuild), [typeof(string)]))
+        builder.HasDbFunction(typeof(XeniaDbContext).GetMethod(nameof(spBanSyncGetMutualRecordsForGuild), [typeof(string)])!)
             .HasName("spBanSyncGetMutualRecordsForGuild");
-        builder.HasDbFunction(typeof(XeniaDbContext).GetMethod(nameof(spBanSyncGetMutualRecordsForGuild_Paginate), [typeof(string), typeof(int), typeof(int)]))
+        builder.HasDbFunction(typeof(XeniaDbContext).GetMethod(nameof(spBanSyncGetMutualRecordsForGuild_Paginate), [typeof(string), typeof(int), typeof(int)])!)
             .HasName("spBanSyncGetMutualRecordsForGuild_Paginate");
     }
 
+    // ReSharper disable InconsistentNaming
     public IQueryable<BanSyncRecordModel> spBanSyncGetMutualRecordsForGuild(
         string guildId)
         => FromExpression(() => spBanSyncGetMutualRecordsForGuild(guildId));
@@ -481,4 +487,5 @@ public class XeniaDbContext : DbContext
         int page,
         int pageSize = 50)
         => FromExpression(() => spBanSyncGetMutualRecordsForGuild_Paginate(guildId, page, pageSize));
+    // ReSharper restore InconsistentNaming
 }

--- a/XeniaDiscord.Data/XeniaDiscord.Data.csproj
+++ b/XeniaDiscord.Data/XeniaDiscord.Data.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NLog" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="NLog" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/XeniaDiscord.Data/XeniaDiscord.Data.csproj
+++ b/XeniaDiscord.Data/XeniaDiscord.Data.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="NLog" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>

--- a/XeniaDiscord.Data/XeniaDiscordData.cs
+++ b/XeniaDiscord.Data/XeniaDiscordData.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using XeniaBot.Shared;
 using XeniaDiscord.Data.Repositories;
 using XeniaDiscord.Data.Services;
+#pragma warning disable S1186
+#pragma warning disable IDE0130
 
 namespace XeniaDiscord;
 
@@ -22,6 +23,7 @@ public static class XeniaDiscordData
 
         RegisterRepositories(services, includeAsSingleton);
     }
+
     public static void RegisterRepositories(
         IServiceCollection services,
         bool includeAsSingleton = false)

--- a/XeniaDiscord.Interactions.DataMigration/XeniaDiscord.Interactions.DataMigration.csproj
+++ b/XeniaDiscord.Interactions.DataMigration/XeniaDiscord.Interactions.DataMigration.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/XeniaDiscord.Interactions.DataMigration/XeniaDiscordInteractionsDataMigration.cs
+++ b/XeniaDiscord.Interactions.DataMigration/XeniaDiscordInteractionsDataMigration.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using XeniaBot.Shared.Helpers;
 using XeniaDiscord.Interactions.DataMigration.Modules;
+#pragma warning disable S1186
+#pragma warning disable IDE0130
 
 namespace XeniaDiscord;
 
@@ -10,6 +12,7 @@ public static class XeniaDiscordInteractionsDataMigration
     public static void RegisterServices(IServiceCollection services)
     {
     }
+    
     public static async Task<ModuleInfo[]> RegisterDeveloperModules(InteractionService interactions, IServiceProvider services)
     {
         var transaction = SentryHelper.CreateTransaction();

--- a/XeniaDiscord.Interactions/ModuleHelper.cs
+++ b/XeniaDiscord.Interactions/ModuleHelper.cs
@@ -6,9 +6,8 @@ namespace XeniaDiscord.Interactions;
 
 public static class ModuleHelper
 {
-
     /// <summary>
-    /// Callback for <see cref="PerformTransaction(Func{XeniaDbContext, Task{bool}})"/>
+    /// Callback for <see cref="PerformTransaction(IServiceProvider, PerformTransactionCallback)"/>
     /// </summary>
     /// <param name="db"></param>
     /// <returns>
@@ -16,6 +15,7 @@ public static class ModuleHelper
     /// Otherwise, it will rollback the transaction.
     /// </returns>
     public delegate Task<bool> PerformTransactionCallback(XeniaDbContext db);
+    
     public static async Task<TimeSpan> PerformTransaction(IServiceProvider services, PerformTransactionCallback callback)
     {
         var sw = new Stopwatch();

--- a/XeniaDiscord.Interactions/Modules/Admin/AdmDataModule.cs
+++ b/XeniaDiscord.Interactions/Modules/Admin/AdmDataModule.cs
@@ -190,7 +190,7 @@ public partial class AdmDataModule : InteractionModuleBase
         await DeferAsync();
         try
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             var elapsed = await ModuleHelper.PerformTransaction(_services, async db =>
             {
                 foreach (var guild in _client.Guilds)

--- a/XeniaDiscord.Interactions/Modules/Admin/AdmDataModule.cs
+++ b/XeniaDiscord.Interactions/Modules/Admin/AdmDataModule.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
 using System.Text;
@@ -16,6 +17,7 @@ namespace XeniaDiscord.Interactions.Modules.Admin;
 [DeveloperModule]
 [CommandContextType(InteractionContextType.Guild)]
 [RequireDeveloper]
+[UsedImplicitly]
 public partial class AdmDataModule : InteractionModuleBase
 {
     private readonly ConfigData _config;

--- a/XeniaDiscord.Interactions/Modules/Admin/AdmDataModule.cs
+++ b/XeniaDiscord.Interactions/Modules/Admin/AdmDataModule.cs
@@ -1,5 +1,4 @@
-﻿
-using Discord;
+﻿using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;

--- a/XeniaDiscord.Interactions/Modules/Admin/AdmRolePreserveModule.cs
+++ b/XeniaDiscord.Interactions/Modules/Admin/AdmRolePreserveModule.cs
@@ -1,5 +1,6 @@
 ﻿using Discord;
 using Discord.Interactions;
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
 using System.Diagnostics;
@@ -13,6 +14,7 @@ namespace XeniaDiscord.Interactions.Modules.Admin;
 [Group("adm-rp", "Admin: Role Preserve")]
 [CommandContextType(InteractionContextType.Guild)]
 [RequireDeveloper]
+[UsedImplicitly]
 public class AdmRolePreserveModule : InteractionModuleBase
 {
     private readonly Logger _log = LogManager.GetCurrentClassLogger();

--- a/XeniaDiscord.Interactions/Modules/Admin/DeveloperModule.CheckGuildConfig.cs
+++ b/XeniaDiscord.Interactions/Modules/Admin/DeveloperModule.CheckGuildConfig.cs
@@ -1,11 +1,13 @@
 ﻿using Discord;
 using Discord.Interactions;
+using JetBrains.Annotations;
 using XeniaDiscord.Data;
 
 namespace XeniaDiscord.Interactions.Modules;
 
 partial class DeveloperModule
 {
+    [UsedImplicitly]
     [SlashCommand("chk-guild-cfg", "Validate Guild Config")]
     public async Task ValidateGuildConfig(
         string guildId,
@@ -54,8 +56,8 @@ partial class DeveloperModule
         };
 
 
-        var logchannelId = guildConfig.GetLogChannelId();
-        if (!logchannelId.HasValue)
+        var logChannelId = guildConfig.GetLogChannelId();
+        if (!logChannelId.HasValue)
         {
             embed.WithDescription("Log Channel Id not configured.");
             await FollowupWithFilesAsync(files, embeds: [embed.Build()]);
@@ -64,7 +66,7 @@ partial class DeveloperModule
 
         var validatePermissions = await ValidatePermissions(
             guildId,
-            logchannelId.Value,
+            logChannelId.Value,
             [
                 ChannelPermission.ViewChannel,
                 ChannelPermission.ReadMessageHistory,
@@ -86,10 +88,10 @@ partial class DeveloperModule
             ]);
         if (validatePermissions.IsFailure)
         {
-            embed.WithDescription(validatePermissions.Error.Item1);
-            if (validatePermissions.Error.Item2 != null)
+            embed.WithDescription(validatePermissions.Error.Message);
+            if (validatePermissions.Error.Exception != null)
             {
-                files.Add(CreateStringAttachment("exception.txt", validatePermissions.Error.Item2.ToString()));
+                files.Add(CreateStringAttachment("exception.txt", validatePermissions.Error.Exception.ToString()));
             }
             await FollowupWithFilesAsync(files, embeds: [embed.Build()]);
             return;

--- a/XeniaDiscord.Interactions/Modules/Admin/DeveloperModule.ValidatePermissions.cs
+++ b/XeniaDiscord.Interactions/Modules/Admin/DeveloperModule.ValidatePermissions.cs
@@ -2,12 +2,13 @@
 using Discord;
 using Discord.WebSocket;
 using System.Collections.Frozen;
+using XeniaBot.Shared.Helpers;
 
 namespace XeniaDiscord.Interactions.Modules;
 
 partial class DeveloperModule
 {
-    private async Task<Result<ValidateChannelPermissionsResult, (string, Exception?)>> ValidatePermissions(
+    private async Task<Result<ValidateChannelPermissionsResult, ValidatePermissionsError>> ValidatePermissions(
         ulong guildId,
         ulong channelId,
         ChannelPermission[] expected,
@@ -18,39 +19,39 @@ partial class DeveloperModule
         SocketGuildUser? member = null;
         try
         {
-            guild = _client.GetGuild(guildId);
+            guild = ExceptionHelper.RetryOnTimedOut(() => _client.GetGuild(guildId));
             if (guild == null)
             {
-                return Result.Failure<ValidateChannelPermissionsResult, (string, Exception?)>(($"Guild not found: `{guildId}`", null));
+                return new ValidatePermissionsError($"Guild not found: `{guildId}`", null);
             }
         }
         catch (Exception ex)
         {
-            return Result.Failure<ValidateChannelPermissionsResult, (string, Exception?)>(($"Failed to get Guild: `{guildId}`", ex));
+            return new ValidatePermissionsError($"Failed to get Guild: `{guildId}`", ex);
         }
         try
         {
-            channel = guild.GetChannel(channelId);
+            channel = ExceptionHelper.RetryOnTimedOut(() => guild.GetChannel(channelId));
             if (channel == null)
             {
-                return Result.Failure<ValidateChannelPermissionsResult, (string, Exception?)>(($"Channel `{channelId}` not found in Guild `{guildId}`", null));
+                return new ValidatePermissionsError($"Channel `{channelId}` not found in Guild `{guildId}`", null);
             }
         }
         catch (Exception ex)
         {
-            return Result.Failure<ValidateChannelPermissionsResult, (string, Exception?)>(($"Failed to get Channel `{channelId}` Guild `{guildId}`", ex));
+            return new ValidatePermissionsError($"Failed to get Channel `{channelId}` Guild `{guildId}`", ex);
         }
         try
         {
-            member = guild.GetUser(_client.CurrentUser.Id);
+            member = ExceptionHelper.RetryOnTimedOut(() => guild.GetUser(_client.CurrentUser.Id));
             if (member == null)
             {
-                return Result.Failure<ValidateChannelPermissionsResult, (string, Exception?)>(($"Member `{_client.CurrentUser.Id}` (me) not found in Guild `{guildId}`", null));
+                return new ValidatePermissionsError($"Member `{_client.CurrentUser.Id}` (me) not found in Guild `{guildId}`", null);
             }
         }
         catch (Exception ex)
         {
-            return Result.Failure<ValidateChannelPermissionsResult, (string, Exception?)>(($"Failed to get own user in Guild `{guildId}`", ex));
+            return new ValidatePermissionsError($"Failed to get own user in Guild `{guildId}`", ex);
         }
 
         var channelPermissions = member.GetPermissions(channel);
@@ -69,43 +70,50 @@ partial class DeveloperModule
         };
     }
 
+    internal sealed record ValidatePermissionsError(string Message, Exception? Exception);
+    
     internal class ValidateChannelPermissionsResult(
         IEnumerable<ChannelPermission> permissions)
     {
         public IReadOnlySet<ChannelPermission> Missing { get; } = permissions.ToFrozenSet();
         public IReadOnlySet<GuildPermission> GuildMissing { get; init; } = Array.Empty<GuildPermission>().ToFrozenSet();
 
+        private const string TextNothing = "No issues found.";
+        private const string EmoteAlert = "❗";
+        private const string EmoteOk = "✔️";
+        public string GetMissingText()
+        {
+            if (Missing.Count == 0) return TextNothing;
+            return string.Join("\n",
+                $"Missing {Missing.Count} permission(s)",
+                "```",
+                string.Join("\n", Missing.Select(e => e.ToString())),
+                "```");
+        }
+
+        public string GetGuildMissingText()
+        {
+            if (GuildMissing.Count == 0) return TextNothing;
+            return string.Join("\n",
+                $"Missing {GuildMissing.Count} permission(s)",
+                "```",
+                string.Join("\n", GuildMissing.Select(e => e.ToString())),
+                "```");
+        }
+        
         public void AddEmbedFields(EmbedBuilder embed)
         {
-            const string nothing = "No issues found.";
-            const string alert = "❗";
-            const string ok = "✔️";
-            if (Missing.Count < 1)
-            {
-                embed.AddField($"{ok} Channel", nothing);
-            }
-            else
-            {
-                embed.AddField($"{alert} Channel",
-                    string.Join("\n",
-                    $"Missing {Missing.Count} permission(s)",
-                    "```",
-                    string.Join("\n", Missing.Select(e => e.ToString())),
-                    "```"));
-            }
-            if (GuildMissing.Count < 1)
-            {
-                embed.AddField($"{ok} Guild", nothing);
-            }
-            else
-            {
-                embed.AddField($"{alert} Guild",
-                    string.Join("\n",
-                    $"Missing {GuildMissing.Count} permission(s)",
-                    "```",
-                    string.Join("\n", GuildMissing.Select(e => e.ToString())),
-                    "```"));
-            }
+            var channelText = GetMissingText();
+            var channelTitle = Missing.Count == 0
+                ? $"{EmoteOk} Channel"
+                : $"{EmoteAlert} Channel";
+            embed.AddField(channelTitle, channelText);
+
+            var guildText = GetGuildMissingText();
+            var guildTitle = GuildMissing.Count == 0
+                ? $"{EmoteOk} Guild"
+                : $"{EmoteAlert} Guild";
+            embed.AddField(guildTitle, guildText);
 
             var color = GuildMissing.Count == 0 && Missing.Count == 0
                 ? Color.Green

--- a/XeniaDiscord.Interactions/Modules/Admin/DeveloperModule.cs
+++ b/XeniaDiscord.Interactions/Modules/Admin/DeveloperModule.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Services;
@@ -12,6 +13,7 @@ namespace XeniaDiscord.Interactions.Modules;
 [DeveloperModule]
 [CommandContextType(InteractionContextType.Guild)]
 [RequireDeveloper]
+[UsedImplicitly]
 public partial class DeveloperModule : InteractionModuleBase
 {
     private readonly DiscordSocketClient _client;

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalAdminModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalAdminModule.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using NLog;
 using System.Collections.Frozen;
 using System.Text;
+using JetBrains.Annotations;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Helpers;
 using XeniaBot.Shared.Services;
@@ -16,6 +17,7 @@ using SetupGreeterModal = XeniaDiscord.Interactions.Modules.GuildApprovalModalMo
 
 namespace XeniaDiscord.Interactions.Modules;
 
+[UsedImplicitly]
 [Group("approval-admin", "Configure: Approval")]
 [CommandContextType(InteractionContextType.Guild)]
 public class GuildApprovalAdminModule : InteractionModuleBase
@@ -32,7 +34,8 @@ public class GuildApprovalAdminModule : InteractionModuleBase
         _service = (scope?.ServiceProvider ?? services).GetRequiredService<GuildApprovalService>();
         _repo = (scope?.ServiceProvider ?? services).GetRequiredService<GuildApprovalRepository>();
     }
-    
+
+    [UsedImplicitly]
     [SlashCommand("enable", "Enable Approval module")]
     [RequireUserPermission(GuildPermission.ManageRoles)]
     [RegisterDBLCommand]
@@ -103,6 +106,7 @@ public class GuildApprovalAdminModule : InteractionModuleBase
         }
     }
 
+    [UsedImplicitly]
     [SlashCommand("set-approved-role", "Set role to be given to approved users")]
     [RequireUserPermission(GuildPermission.ManageRoles)]
     [RequireBotPermission(GuildPermission.ManageRoles)]
@@ -186,7 +190,8 @@ public class GuildApprovalAdminModule : InteractionModuleBase
                 .Build());
         }
     }
-    
+
+    [UsedImplicitly]
     [SlashCommand("set-channel", "Set log channel for user approvals")]
     [RequireUserPermission(GuildPermission.ManageChannels)]
     [RegisterDBLCommand]
@@ -216,7 +221,8 @@ public class GuildApprovalAdminModule : InteractionModuleBase
         }
         throw new NotImplementedException();
     }
-    
+
+    [UsedImplicitly]
     [SlashCommand("set-greeter-channel", "Set channel to send message for greeting user (post-approval)")]
     [RequireUserPermission(GuildPermission.ManageChannels)]
     [RegisterDBLCommand]
@@ -246,6 +252,7 @@ public class GuildApprovalAdminModule : InteractionModuleBase
         }
     }
 
+    [UsedImplicitly]
     [SlashCommand("get-greeter-msg", "Get the message used for greeting users (post-approval)")]
     [RequireUserPermission(GuildPermission.ManageChannels)]
     public async Task GetGreeterMessage()
@@ -304,7 +311,7 @@ public class GuildApprovalAdminModule : InteractionModuleBase
         }
     }
 
-
+    [UsedImplicitly]
     [SlashCommand("setup-greeter", "Setup post-approval greeter for user approvals", runMode: RunMode.Async)]
     [RequireUserPermission(GuildPermission.ManageChannels)]
     [RegisterDBLCommand]

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalModalModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalModalModule.cs
@@ -1,5 +1,6 @@
 using Discord;
 using Discord.Interactions;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
@@ -10,6 +11,7 @@ using XeniaDiscord.Data.Repositories;
 
 namespace XeniaDiscord.Interactions.Modules;
 
+[UsedImplicitly]
 [CommandContextType(InteractionContextType.Guild)]
 public class GuildApprovalModalModule : InteractionModuleBase
 {
@@ -25,6 +27,7 @@ public class GuildApprovalModalModule : InteractionModuleBase
         _validation = services.GetRequiredService<ValidationService>();
         _repo = (scope?.ServiceProvider ?? services).GetRequiredService<GuildApprovalRepository>();
     }
+
     private async Task HandleSetupGreeterModalInternal(SetupGreeterModal modal)
     {
         var errors = new List<string>();
@@ -113,7 +116,8 @@ public class GuildApprovalModalModule : InteractionModuleBase
                 .AddSerializedAttachment("guildApprovalModel.json", model));
         }
     }
-    
+
+    [UsedImplicitly]
     [ModalInteraction("guild-approval-setup-greeter", runMode: RunMode.Async)]
     public async Task HandleSetupGreeterModal(SetupGreeterModal modal)
     {

--- a/XeniaDiscord.Interactions/Modules/GuildApprovalModule.cs
+++ b/XeniaDiscord.Interactions/Modules/GuildApprovalModule.cs
@@ -1,5 +1,6 @@
 using Discord;
 using Discord.Interactions;
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Services;
@@ -7,6 +8,7 @@ using XeniaDiscord.Common.Services;
 
 namespace XeniaDiscord.Interactions.Modules;
 
+[UsedImplicitly]
 [CommandContextType(InteractionContextType.Guild)]
 public class GuildApprovalModule : InteractionModuleBase
 {
@@ -18,6 +20,7 @@ public class GuildApprovalModule : InteractionModuleBase
         _service = services.GetRequiredService<GuildApprovalService>();
     }
 
+    [UsedImplicitly]
     [SlashCommand("approve", "Guild Approvals: Approve a user")]
     [RequireUserPermission(GuildPermission.ManageRoles)]
     [RequireBotPermission(GuildPermission.ManageRoles)]

--- a/XeniaDiscord.Interactions/Modules/ServerLogModule.cs
+++ b/XeniaDiscord.Interactions/Modules/ServerLogModule.cs
@@ -17,11 +17,13 @@ public class ServerLogModule : InteractionModuleBase
 {
     private readonly ErrorReportService _err;
     private readonly ServerLogRepository _repo;
+    private readonly ConfigData _config;
 
     public ServerLogModule(IServiceProvider services)
     {
         _err = services.GetRequiredService<ErrorReportService>();
         _repo = services.GetRequiredService<ServerLogRepository>();
+        _config = services.GetRequiredService<ConfigData>();
     }
 
     [UsedImplicitly]
@@ -65,9 +67,12 @@ public class ServerLogModule : InteractionModuleBase
         try
         {
             await _repo.Enable(Context.Guild.Id);
+            var txt = "Server logging has been enabled. It's a good idea to [read the guide](https://xenia.kate.pet/guide/about_moderation) if you haven't already.";
+            if (_config.HasDashboard)
+                txt += $"\n\n-# [You can also configure server logging in the dashboard]({_config.DashboardUrl}/Server/{Context.Guild.Id}/Moderation)";
             await FollowupAsync(embed: new EmbedBuilder()
                 .WithTitle("Server Log - Enable")
-                .WithDescription("Server logging has been enabled. Make sure that you setup your log events [via the dashboard](), or with the `/log` commands.")
+                .WithDescription(txt)
                 .WithColor(Color.Blue)
                 .WithCurrentTimestamp()
                 .Build());

--- a/XeniaDiscord.Interactions/Modules/ServerLogModule.cs
+++ b/XeniaDiscord.Interactions/Modules/ServerLogModule.cs
@@ -1,5 +1,6 @@
 using Discord;
 using Discord.Interactions;
+using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using XeniaBot.Shared;
 using XeniaBot.Shared.Services;
@@ -8,6 +9,7 @@ using XeniaDiscord.Data.Repositories;
 
 namespace XeniaDiscord.Interactions.Modules;
 
+[UsedImplicitly]
 [Group("log", "Configure Server Event Logging")]
 [RequireUserPermission(GuildPermission.ManageGuild)]
 [CommandContextType(InteractionContextType.Guild)]
@@ -22,6 +24,7 @@ public class ServerLogModule : InteractionModuleBase
         _repo = services.GetRequiredService<ServerLogRepository>();
     }
 
+    [UsedImplicitly]
     [SlashCommand("reset", "Reset server log configuration")]
     [RegisterDBLCommand]
     public async Task Reset()
@@ -53,6 +56,7 @@ public class ServerLogModule : InteractionModuleBase
     }
 
     #region Enable/Disable
+    [UsedImplicitly]
     [SlashCommand("enable", "Enable server logging")]
     [RegisterDBLCommand]
     public async Task Enable()
@@ -82,6 +86,7 @@ public class ServerLogModule : InteractionModuleBase
         }
     }
 
+    [UsedImplicitly]
     [SlashCommand("disable", "Disable server logging")]
     [RegisterDBLCommand]
     public async Task Disable()
@@ -113,6 +118,7 @@ public class ServerLogModule : InteractionModuleBase
     }
     #endregion
 
+    [UsedImplicitly]
     [SlashCommand("reset-channel", "Remove all events from a channel")]
     [RegisterDBLCommand]
     public async Task ResetChannel(
@@ -145,6 +151,7 @@ public class ServerLogModule : InteractionModuleBase
         }
     }
 
+    [UsedImplicitly]
     [SlashCommand("add-event", "Add an event to a channel")]
     [RegisterDBLCommand]
     public async Task AddChannelEvent(
@@ -215,6 +222,7 @@ public class ServerLogModule : InteractionModuleBase
         }
     }
 
+    [UsedImplicitly]
     [SlashCommand("get-channel-events", "See events being sent to a channel")]
     [RegisterDBLCommand]
     public async Task GetEventsByChannel(
@@ -256,6 +264,7 @@ public class ServerLogModule : InteractionModuleBase
         }
     }
 
+    [UsedImplicitly]
     [SlashCommand("get-channels", "See channels that use an event")]
     [RegisterDBLCommand]
     public async Task GetChannelsByEvent(ServerLogEvent @event)

--- a/XeniaDiscord.Interactions/XeniaDiscord.Interactions.csproj
+++ b/XeniaDiscord.Interactions/XeniaDiscord.Interactions.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/XeniaDiscord.Interactions/XeniaDiscordInteractions.cs
+++ b/XeniaDiscord.Interactions/XeniaDiscordInteractions.cs
@@ -16,6 +16,7 @@ public static class XeniaDiscordInteractions
             typeof(GuildApprovalModule),
             typeof(GuildApprovalModalModule),
             typeof(GuildApprovalAdminModule),
+            typeof(ServerLogModule)
         };
         await Task.WhenAll(types.Select(type => interactions.AddModuleAsync(type, services)));
         transaction.Finish();
@@ -29,8 +30,7 @@ public static class XeniaDiscordInteractions
             typeof(AdmRolePreserveModule),
 
             typeof(AdmDataModule),
-            typeof(DeveloperModule),
-            typeof(ServerLogModule)
+            typeof(DeveloperModule)
         };
         var result = await Task.WhenAll(types.Select(type => interactions.AddModuleAsync(type, services)));
         transaction.Finish();

--- a/XeniaDiscord.Interactions/XeniaDiscordInteractions.cs
+++ b/XeniaDiscord.Interactions/XeniaDiscordInteractions.cs
@@ -2,6 +2,7 @@
 using XeniaBot.Shared.Helpers;
 using XeniaDiscord.Interactions.Modules;
 using XeniaDiscord.Interactions.Modules.Admin;
+#pragma warning disable IDE0130
 
 namespace XeniaDiscord;
 
@@ -19,6 +20,7 @@ public static class XeniaDiscordInteractions
         await Task.WhenAll(types.Select(type => interactions.AddModuleAsync(type, services)));
         transaction.Finish();
     }
+
     public static async Task<ModuleInfo[]> RegisterDeveloperModules(InteractionService interactions, IServiceProvider services)
     {
         var transaction = SentryHelper.CreateTransaction();

--- a/XeniaDiscord.UnitTest/DiscordPermissionHelperTests.cs
+++ b/XeniaDiscord.UnitTest/DiscordPermissionHelperTests.cs
@@ -1,0 +1,14 @@
+﻿namespace XeniaDiscord.UnitTest;
+public class DiscordPermissionHelperTests
+{
+    [Test]
+    public void CalculateGuild()
+    {
+        // TODO implement tests for DiscordPermissionHelper
+        // specifically for CalculateGuild(IReadOnlyCollection<IRole>, GuildPermissions)
+        // Use the Moq library to create mocks for IRole, IGuildRoleChannel, and other Discord related stuff.
+        // https://stackoverflow.com/a/67308655
+        // https://github.com/devlooped/moq
+        Assert.Pass();
+    }
+}

--- a/XeniaDiscord.UnitTest/XeniaDiscord.UnitTest.csproj
+++ b/XeniaDiscord.UnitTest/XeniaDiscord.UnitTest.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\XeniaDiscord.Common\XeniaDiscord.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
New feature for Role Preservation to ignore/blacklist roles from being given to users when they re-join. Useful if you have a server that required users to raise a ticket to be let in, and have a manual approval process.

DB Layer and Application Commands are complete. Just finishing up the UI for the settings (which is currently being rewritten)

I've also added an auditing feature to Role Preservation, so it's audited if anything went wrong with granting a users roles back, and what roles were granted back. This auditing also includes when a staff/mod updates the Role Preservation configuration.

Tasks:
-  [x] Add database models
-  [x] Add GuildRoleCache to database (just points to latest snapshot w/ basic info like name)
-  [x] Add logic removing blacklisted roles in the db when the role is deleted
-  [x] Add slash commands for viewing configuration
-  [x] Add slash commands for add/remove roles from blacklist
-  [x] Add web panel UI for viewing blacklisted roles (incl partial refactor of web ui for moderation)
-  [ ] Add web panel UI for adding blacklisted roles (will be done in a later release maybe)
-  [x] Add logging feature for role preserve